### PR TITLE
Fix bug with dasherized names

### DIFF
--- a/addon/controllers/post.js
+++ b/addon/controllers/post.js
@@ -1,4 +1,4 @@
-import { singularize, underscore } from '../utils/inflector';
+import { singularize } from '../utils/inflector';
 import BaseController from './base';
 
 /*
@@ -15,7 +15,6 @@ export default BaseController.extend({
   stringHandler: function(string, store, request) {
     var type = string;
     var postData = this._getJsonBodyForRequest(request);
-    // var attrs = postData[underscore(type)];
     var attrs = postData[type];
     var model = store.push(type, attrs);
 

--- a/addon/controllers/post.js
+++ b/addon/controllers/post.js
@@ -1,4 +1,4 @@
-import { singularize } from '../utils/inflector';
+import { singularize, underscore } from '../utils/inflector';
 import BaseController from './base';
 
 /*
@@ -15,7 +15,7 @@ export default BaseController.extend({
   stringHandler: function(string, store, request) {
     var type = string;
     var postData = this._getJsonBodyForRequest(request);
-    var attrs = postData[type];
+    var attrs = postData[underscore(type)];
     var model = store.push(type, attrs);
 
     var response = {};

--- a/addon/controllers/post.js
+++ b/addon/controllers/post.js
@@ -1,4 +1,4 @@
-import { singularize } from '../utils/inflector';
+import { singularize, underscore } from '../utils/inflector';
 import BaseController from './base';
 
 /*
@@ -15,6 +15,7 @@ export default BaseController.extend({
   stringHandler: function(string, store, request) {
     var type = string;
     var postData = this._getJsonBodyForRequest(request);
+    // var attrs = postData[underscore(type)];
     var attrs = postData[type];
     var model = store.push(type, attrs);
 

--- a/addon/store.js
+++ b/addon/store.js
@@ -1,4 +1,4 @@
-import { pluralize, underscore } from './utils/inflector';
+import { pluralize } from './utils/inflector';
 
 /*
   An identity map.
@@ -116,7 +116,7 @@ export default function() {
   };
 
   this._keyForType = function(type) {
-    return underscore(pluralize(type));
+    return pluralize(type);
   };
 
   this._findDataForType = function(type) {

--- a/addon/store.js
+++ b/addon/store.js
@@ -1,4 +1,4 @@
-import { pluralize } from './utils/inflector';
+import { pluralize, underscore } from './utils/inflector';
 
 /*
   An identity map.
@@ -116,7 +116,7 @@ export default function() {
   };
 
   this._keyForType = function(type) {
-    return pluralize(type);
+    return underscore(pluralize(type));
   };
 
   this._findDataForType = function(type) {

--- a/addon/utils/inflector.js
+++ b/addon/utils/inflector.js
@@ -2,3 +2,4 @@ import Ember from 'ember';
 
 export var singularize = Ember.String.singularize;
 export var pluralize = Ember.String.pluralize;
+export var underscore = Ember.String.underscore;

--- a/addon/utils/inflector.js
+++ b/addon/utils/inflector.js
@@ -2,4 +2,3 @@ import Ember from 'ember';
 
 export var singularize = Ember.String.singularize;
 export var pluralize = Ember.String.pluralize;
-export var underscore = Ember.String.underscore;

--- a/tests/acceptance/controllers/post-controller-test.js
+++ b/tests/acceptance/controllers/post-controller-test.js
@@ -34,12 +34,3 @@ test("undefined shorthand works", function() {
   equal(contactsInStore.length, 1);
   deepEqual(result[2], {contact: {id: 1, name: 'Ganon'}});
 });
-
-test("works with multi-word models using a underscored URL", function() {
-  var body = '{"staff_member":{"name":"Ganon"}}';
-  var result = controller.handle('post', undefined, store, {requestBody: body, url: '/staff_members'});
-
-  var staffMembersInStore = store.findAll('staff-member');
-  equal(staffMembersInStore.length, 1);
-  deepEqual(result[2], {staff_member: {id: 1, name: 'Ganon'}});
-});

--- a/tests/acceptance/controllers/post-controller-test.js
+++ b/tests/acceptance/controllers/post-controller-test.js
@@ -34,3 +34,12 @@ test("undefined shorthand works", function() {
   equal(contactsInStore.length, 1);
   deepEqual(result[2], {contact: {id: 1, name: 'Ganon'}});
 });
+
+test("works with multi-word models using a underscored URL", function() {
+  var body = '{"staff_member":{"name":"Ganon"}}';
+  var result = controller.handle('post', undefined, store, {requestBody: body, url: '/staff_members'});
+
+  var staffMembersInStore = store.findAll('staff-member');
+  equal(staffMembersInStore.length, 1);
+  deepEqual(result[2], {staff_member: {id: 1, name: 'Ganon'}});
+});

--- a/tests/acceptance/controllers/post-controller-test.js
+++ b/tests/acceptance/controllers/post-controller-test.js
@@ -34,3 +34,12 @@ test("undefined shorthand works", function() {
   equal(contactsInStore.length, 1);
   deepEqual(result[2], {contact: {id: 1, name: 'Ganon'}});
 });
+
+test("works with multi-word models using a underscored URL and a hypheneated model name", function() {
+  var body = '{"staff_member":{"name":"Ganon"}}';
+  var result = controller.handle('post', 'staff-member', store, {requestBody: body, url: '/staff_members'});
+
+  var staffMembersInStore = store.findAll('staff-member');
+  equal(staffMembersInStore.length, 1);
+  deepEqual(result[2], {'staff-member': {id: 1, name: 'Ganon'}});
+});

--- a/tests/dummy/app/models/staff-member.js
+++ b/tests/dummy/app/models/staff-member.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  age: DS.attr('number'),
+  email: DS.attr('string'),
+});

--- a/tests/dummy/app/pretender/config.js
+++ b/tests/dummy/app/pretender/config.js
@@ -8,4 +8,11 @@ export default function() {
 
   // Friends
   this.get('/friends');
+
+  // Staff members (multi-word models)
+  this.get('/staff_members', 'staff-members');
+  this.post('/staff_members', 'staff-member');
+  this.get('/staff_members/:id', 'staff-member');
+  this.del('/staff_members/:id', 'staff-member');
+  this.put('/staff_members/:id', 'staff-member');
 }

--- a/tests/dummy/app/pretender/data/staff-members.js
+++ b/tests/dummy/app/pretender/data/staff-members.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    id: 1,
+    name: 'Matt',
+    age: 30,
+    email: 'some@email.com'
+  },
+  {
+    id: 2,
+    name: 'James',
+    age: 80,
+    email: 'other@email.com'
+  }
+];

--- a/tests/factories/staff-member.js
+++ b/tests/factories/staff-member.js
@@ -1,0 +1,10 @@
+import EP from 'ember-pretenderify';
+
+export default EP.Factory.extend({
+  name: 'Pete',
+  age: 20,
+
+  email: function(i) {
+    return `staff-member${i}@test.com`;
+  }
+});


### PR DESCRIPTION
Long story short:
![no-idea](http://i.kinja-img.com/gawker-media/image/upload/s--gnSWo1nI--/japbcvpavbzau9dbuaxf.jpg)

This is an attempt to fix #39, because `POST` requests don't work with models whose name contains many words, p.e `StaffMember`.

Since the JSON in the body of post requests when using ActiveModel Serializer/Adapter uses underscored names, p.e `staff_members`, but the normalized names of the models in ember-cli use hyphens, ember-pretenderify never crashes then trying to add those record to the store.

The solution in this PR is to always undercore the string containing the normalized name of the model to match the root key of the json in the post request.
However, not everybody will AMS-like apis and I don't think this convention will be good for everybody, but I couldn't come up with a better solution.

