### PR TITLE
Allow to modify the server timing in runtime.

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -25,14 +25,13 @@ export default function(options) {
 
   this.loadConfig = function(config) {
     config.call(this);
+    this.timing = environment === 'test' ? 0 : (this.timing || 0);
   };
 
   this.stub = function(verb, path, handler, code) {
     var _this = this;
     var interceptor = this.interceptor;
-    var timing = environment === 'test' ? 0 : this.timing;
     path = path[0] === '/' ? path.slice(1) : path;
-
     interceptor[verb].call(interceptor, this.namespace + '/' + path, function(request) {
 
       var response = frontController.handle(verb, handler, _this.store, request, code);
@@ -43,7 +42,7 @@ export default function(options) {
       }
 
       return response;
-    }, timing);
+    }, function() { return _this.timing; });
   };
 
   this.get = function(path, handler, code) {

--- a/tests/acceptance/timing-test.js
+++ b/tests/acceptance/timing-test.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+
+var App;
+var contact;
+var appStore;
+
+module('Acceptance: Timing', {
+  setup: function() {
+    App = startApp();
+    appStore = App.__container__.lookup('store:main');
+    contact = server.create('contact');
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+
+test('delays the response the configured time', function(assert) {
+  var done = assert.async();
+  var startTime = +new Date();
+  server.timing = 600;
+  appStore.findAll('contact').then(function(contacts) {
+    assert.equal(contacts.get('length'), 1);
+    var endTime = +new Date();
+    assert.ok(endTime - startTime >= 600, 'response has beed delayed 600ms');
+    done();
+  });
+});
+
+test('by default the response is not delayed', function(assert) {
+  var done = assert.async();
+  var startTime = +new Date();
+  appStore.findAll('contact').then(function(contacts) {
+    assert.equal(contacts.get('length'), 1);
+    var endTime = +new Date();
+    assert.ok(endTime - startTime < 150, 'server responds right away');
+    done();
+  });
+});

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -15,6 +15,24 @@ test('it cannot be instantiated without an environment', function() {
   });
 });
 
+module('mirage:server#loadConfig');
+
+test('forces timing to 0 in test environment', function() {
+  var server = new Server({environment: 'test'});
+  server.loadConfig(function() {
+    this.timing = 50;
+  });
+  equal(server.timing, 0);
+});
+
+test("doesn't modify user's timing config in other environments", function() {
+  var server = new Server({environment: 'blah'});
+  server.loadConfig(function() {
+    this.timing = 50;
+  });
+  equal(server.timing, 50);
+});
+
 module('mirage:server#store');
 
 test('its store is isolated across instances', function() {


### PR DESCRIPTION
Motivation:

I have some acceptance tests where I want to tests that if the server
take too long to respond, a message of "Loading more data" is displayed.
Making the interceptor respond without delay in tests is a reasonable
default but for my use case made some things untestable.

What I wanted was to allow in specific tests to set `server.timing = 1000`
and then restore the old value. Example:

```js
module('Acceptance: Slow Filtering', {
  beforeEach: function() {
   server.timing = 1000;
    application = startApp();
    server.createList('posts', 21);
  },

  afterEach: function() {
    server.timing = 0;
    Ember.run(application, 'destroy');
  }
});

test('when the server takes too much to respond a loading message is displayed', function(assert) {
   // Some test
});
```




That was not possible because the route handlers were
registered with the timing at the moment when the configuration is
loaded, by passint that number directly:

```js
  this.stub = function(verb, path, handler, code) {
    var timing = environment === 'test' ? 0 : this.timing;
    /* some code */
    interceptor[verb].call(interceptor, this.namespace + '/' + path, function(request) {
     /* route handling */
    }, timing});
  };
```

It turns out that Pretender is impressively good designed and the
`async` parameter can also be a function that returns the number of
milliseconds.

Thanks to that, the changes are minimal. The only tricky part was how
to test that. I created an acceptance test for that because I cound't
figure out how to test that in isolation.

Check it and tell me what you think and if you want me to document this a little bit in the readme or the wiki.