### PR TITLE
Enable only when visiting tests page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Are you tired of
 - Wiring up tests for each of your apps manually, from scratch?
 - Changing lots of files/tests when your API changes?
 
-Ember CLI Mirage may be for you! It lets you create a client-side server using [Pretender](https://github.com/trek/pretender) to help you develop and test your app. By default, it only runs if you're not in production and if you're not proxying to an explicit API server via `ember serve --proxy`.
+Ember CLI Mirage may be for you! It lets you create a client-side
+server using [Pretender](https://github.com/trek/pretender) to help
+you develop and test your app. By default, it only runs if you're not
+in production and if you're in the tests page: `/tests`.
 
 ## Installation
 

--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -9,7 +9,8 @@ export default {
   initialize: function(container, application) {
     var config = ENV['ember-cli-mirage'];
     var env = ENV.environment;
-    var usingInDev = env === 'development' && !config.usingProxy;
+    var isForTests =  window.location.pathname.match('^/tests');
+    var usingInDev = env === 'development' && isForTests;
     var usingInTest = env === 'test';
     var shouldUseServer = usingInDev || usingInTest || config.force;
 


### PR DESCRIPTION
We can't rely always on `--proxy` being set since we can also specify
multiple proxies doing `ember g proxy`.

With this we can use both proxy and mirage without having any
problems, additionally if we want all the request to be handle by
mirage we can just use `config.force`.