### PR TITLE
Update config.js examples with new db API

### DIFF
--- a/blueprints/ember-cli-mirage/files/app/mirage/config.js
+++ b/blueprints/ember-cli-mirage/files/app/mirage/config.js
@@ -52,18 +52,17 @@ export default function() {
   /*
     Function fallback. Manipulate data in the db via
 
-      - db.find(key, id)
-      - db.findAll(key)
-      - db.findQuery(key, query)
-      - db.push(key, data)
-      - db.remove(key, id)
-      - db.removeQuery(key, query)
+      - db.{collection} // returns all the data defined in /app/mirage/fixtures/{collection}.js
+      - db.{collection}.find(id)
+      - db.{collection}.where(query)
+      - db.{collection}.update(target, attrs)
+      - db.{collection}.remove(target)
 
     // Example: return a single object with related models
     this.get('/contacts/:id', function(db, request) {
       var contactId = +request.params.id;
-      var contact = db.find('contact', contactId);
-      var addresses = db.findAll('address')
+      var contact = db.contacts.find(contactId);
+      var addresses = db.addresses
         .filterBy('contact_id', contactId);
 
       return {


### PR DESCRIPTION
I noticed the config.js was using an old version of the db API, updated the syntax/methods to reflect the new one.

I'm not sure if {collection} is the best way to express what's happening, but I think between the comment on line 55 and the example function the intent should be clear.