### PR TITLE
Allow function handlers to dynamically overwrite the status code

### DIFF
--- a/addon/controllers/front.js
+++ b/addon/controllers/front.js
@@ -26,6 +26,7 @@ export default {
     var data = this[controller][handlerMethod](handler, db, request, code);
 
     if (data) {
+      code = request.status !== 0 && request.status !== code ? request.status : code;
       return [code, {"Content-Type": "application/json"}, data];
     } else {
       return [code, {}, undefined];

--- a/tests/acceptance/controllers/get-controller-test.js
+++ b/tests/acceptance/controllers/get-controller-test.js
@@ -24,7 +24,7 @@ module('mirage:frontController GET', {
 // TODO: AMS-type response dependency, includes key
 // TODO: Extract to single class for data, handle response code/app elsewhere
 test("string shorthand works", function() {
-  var result = controller.handle('get', 'contacts', db);
+  var result = controller.handle('get', 'contacts', db, {});
 
   deepEqual(result[2], {contacts: contacts});
 });
@@ -39,7 +39,7 @@ test("string shorthand with id works", function() {
 
 // e.g. this.stub('get', '/', ['contacts', 'addresses']);
 test("array shorthand works", function() {
-  var result = controller.handle('get', ['contacts', 'addresses'], db);
+  var result = controller.handle('get', ['contacts', 'addresses'], db, {});
 
   deepEqual(result[2], {contacts: contacts, addresses: addresses});
 });


### PR DESCRIPTION
I was trying to implement a `post` handler that validated the record and returned errors. Unfortunatly the status code was only overwritable statically by providing it as a third argument.
This way a function handler can look like this:

```
this.post('users', function(db, request) {
  var postedUser = JSON.parse(request.requestBody);
  if (postedUser.name === "") {
    request.status = 422;
    return { name: "can't be blank" };
  }
  // ... otherwise normal handling
});
```

Not sure if this is too dirty.