### PR TITLE
Update base controller id coercion

### DIFF
--- a/addon/controllers/base.js
+++ b/addon/controllers/base.js
@@ -25,8 +25,8 @@ export default Ember.Object.extend({
 
     if (request && request.params && request.params.id) {
       id = request.params.id;
-      // If parses, coerce to integer
-      id = parseInt(id, 10) || id;
+      // If the id is not a number, return the string. Otherwise, parse it as an integer
+      id = isNaN(id) ? id : parseInt(id, 10);
     }
 
     return id;

--- a/tests/unit/base-controller-test.js
+++ b/tests/unit/base-controller-test.js
@@ -1,0 +1,31 @@
+import baseController from 'ember-cli-mirage/controllers/base';
+
+import {module, test} from 'qunit';
+
+var controller, request;
+module('mirage:base-controller#_getIdForRequest', {
+  beforeEach: function() {
+    controller = new baseController();
+    request = { params: {id: ''} };
+  }
+});
+
+test('it returns a number if it\'s a number', function(assert) {
+  request.params.id = 2;
+  assert.equal(controller._getIdForRequest(request), 2, 'it returns a number');
+});
+
+test('it returns a number if it\'s a string represented number', function(assert) {
+  request.params.id = "2";
+  assert.equal(controller._getIdForRequest(request), 2, 'it returns a number');
+});
+
+test('it returns a string it\'s a dasherized number', function(assert) {
+  request.params.id = "2-1";
+  assert.equal(controller._getIdForRequest(request), "2-1", 'it returns a number');
+});
+
+test('it returns a string if it\'s a string', function(assert) {
+  request.params.id = "someID";
+  assert.equal(controller._getIdForRequest(request), "someID", 'it returns a number');
+});


### PR DESCRIPTION
I have a model that has an id with dashes in it. When trying to model this in mirage, I noticed that it grabbed the id with just the first number.

I added a couple of tests for my edge case (where `2-1` was the id which resolved to `2`)

I'd love to see this merged, but if there's something that I'm overlooking, just let me know!