### PR TITLE
Updates to use broccoli-merge-trees.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 var path = require('path');
+var mergeTrees = require('broccoli-merge-trees');
+var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-cli-mirage',

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
       return this._super.treeFor.apply(this, arguments);
     }
     this._requireBuildPackages();
-    return this.mergeTrees([]);
+    return mergeTrees([]);
   },
 
   postprocessTree: function(type, tree) {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
 
   _excludePretenderDir: function(tree) {
     var modulePrefix = this.app.project.config(this.app.env)['modulePrefix'];
-    return new this.Funnel(tree, {
+    return new Funnel(tree, {
       exclude: [new RegExp('^' + modulePrefix + '/mirage/')],
       description: 'Funnel: exclude mirage'
     });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "Sam Selikoff",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
+    "broccoli-funnel": "^0.2.3",
     "broccoli-merge-trees": "^0.2.1",
     "chai": "2.0.0",
     "ember-cli": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "Sam Selikoff",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
+    "broccoli-merge-trees": "^0.2.1",
     "chai": "2.0.0",
     "ember-cli": "0.2.0",
     "ember-cli-app-version": "0.3.2",


### PR DESCRIPTION
This switches to using broccoli-merge-trees directly instead of the deprecated `this.mergeTrees`. I also added broccoli-funnel.