### PR TITLE
[WIP] Add sugar function to simulate uploads.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 npm-debug.log
 testem.log
 .floo
+.DS_Store

--- a/addon/server.js
+++ b/addon/server.js
@@ -122,6 +122,19 @@ export default function(options) {
     return list;
   };
 
+  this.simulateUpload = function(request, options) {
+    var interval = options.interval || (this.timing / 4);
+    var eventsCount = Math.floor(this.timing / interval);
+    var self = this;
+    /*jshint loopfunc:true */
+    for (var i = 0; i < eventsCount; i++) {
+      setTimeout(function() {
+        request.upload._progress(true, i * interval, self.timing);
+      }, i * interval);
+    }
+    /* loopfunc:false */
+  };
+
   // TODO: Better way to inject server
   if (environment === 'test') {
     window.server = this;

--- a/tests/acceptance/upload-test.js
+++ b/tests/acceptance/upload-test.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import {module, test} from 'qunit';
+import startApp from '../helpers/start-app';
+
+var App;
+var contact;
+var appStore;
+
+module('Acceptance: Uploads', {
+  beforeEach: function() {
+    App = startApp();
+    appStore = App.__container__.lookup('store:main');
+    server.timing = 400;
+  },
+  afterEach: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+
+test('mirage can stream upload events', function(assert) {
+  var done = assert.async();
+  var data = new window.FormData();
+  var xhr  = new window.XMLHttpRequest();
+  var progressEventCount = 0;
+  xhr.onload = function(event) {
+    var jsonResponse = JSON.parse(event.target.responseText);
+    assert.deepEqual(jsonResponse, { filename: "thriller.mp3" }, 'The response is still the same');
+    assert.equal(progressEventCount, 6, 'The upload event has been triggered 6 times before the completition');
+    done();
+  };
+  xhr.upload.onprogress = function(e) {
+    progressEventCount++;
+  };
+  xhr.open('POST', '/uploads', true);
+  xhr.send(data);
+});

--- a/tests/dummy/app/mirage/config.js
+++ b/tests/dummy/app/mirage/config.js
@@ -8,4 +8,10 @@ export default function() {
 
   // Friends
   this.get('/friends');
+
+  // Uploads
+  this.post('/uploads', (db, request) => {
+    this.simulateUpload(request, { interval: 60 });
+    return { filename: 'thriller.mp3' };
+  });
 }


### PR DESCRIPTION
This week I added to FakeXMLHttpRequest the ability of simulate XHR2 uploads and trigger progress events with the `_progress` function. While the feature is nice, is pretty low level and not particularly easy to use in the most common use case.

Example:

```js
  var xhr  = new XMLHttpRequest();
  xhr.open('POST', '/uploads', true);
  xhr.send(new FormData());
  xhr.upload._progress(true, 400, 3000); 
  // Fires a single progress event, with 400 of a total of 3000 completed (~13.33%).
```
For simulate a real progress you need to use something like `setInterval` to trigger different progress events at different moments of the request increasing the progress % on each one, and be sure of not fire another after the request has finished.

That's why I think having a more higher feature in mirage seemed a good idea to me. That is my proposed syntax. I also considered adding this into Pretender itself. Not sure where is the best place for this.

```js
export default function() {
  this.post('/uploads', (db, request) => {
    this.simulateUpload(request, { interval: 60 }); // Trigger a progress event each 60ms
    return { filename: 'thriller.mp3' };
  });
}
```
In this proposal you need to keep a reference to the server (`this`) using arrow functions or just storing a reference with a regular closure. The reason for this idea is because for simulate the upload it's necessary to know the length of the request, and that information already lives there. Not having to pass it makes the method signature simpler.

I am still not sure this is the best syntax for this feature.

As a bonus, here you can see a video of a file uploader component using mirage with this patch.

http://quick.as/jpw4i9rbr