### PR TITLE
Add tmp directory to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 bower_components/
 tests/
+tmp/
 
 .bowerrc
 .editorconfig


### PR DESCRIPTION
The Size of this addon on npm registry is pretty big (~188MB) because of packaged `tmp` folder.