### PR TITLE
[WFA] Change status 204 to 200 when response is present

### DIFF
--- a/addon/controller.js
+++ b/addon/controller.js
@@ -2,12 +2,12 @@ import Ember from 'ember';
 import shorthandHandlers from 'ember-cli-mirage/shorthands/index';
 import Response from './response';
 
-const isArray = Ember.isArray;
-const isBlank = Ember.isBlank;
-const typeOf  = Ember.typeOf;
-const keys    = Ember.keys;
+var isArray = Ember.isArray;
+var isBlank = Ember.isBlank;
+var typeOf  = Ember.typeOf;
+var keys    = Ember.keys;
 
-const defaultCodes = {
+var defaultCodes = {
   put: 204,
   post: 201,
   delete: 204

--- a/tests/acceptance/custom-handlers-test.js
+++ b/tests/acceptance/custom-handlers-test.js
@@ -1,0 +1,70 @@
+import Ember from 'ember';
+import {module, test} from 'qunit';
+import startApp from '../helpers/start-app';
+
+var App, appStore, rex, toby, sam, andy;
+
+module('Acceptance: Custom handlers', {
+  beforeEach: function() {
+    App = startApp();
+    appStore = App.__container__.lookup('store:main');
+    rex  = server.create('pet', { name: 'Rex',  alive: true  });
+    toby = server.create('pet', { name: 'Toby', alive: false });
+    sam  = server.create('pet', { name: 'Sam',  alive: false });
+    andy = server.create('pet', { name: 'Andy', alive: true  });
+  },
+  afterEach: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test("You can customize the response by passing a handler function that returns the desired body", function(assert) {
+  var done = assert.async();
+  appStore.find('pet').then(function(pets) {
+    assert.deepEqual(pets.mapBy('name'), ['Rex', 'Andy']);
+  }).finally(done);
+});
+
+test("You can customize the response code of a custom handler passing the code as 3rd argument", function(assert) {
+  var done = assert.async();
+  var request = Ember.$.ajax({
+    url: '/pets/' + rex.id,
+    method: 'delete'
+  });
+
+  request.then(function(response, statusText, jqXHR) {
+    assert.equal(jqXHR.status, 200, 'The status code is 200 instead od 204');
+    done();
+  });
+});
+
+test("You can can programatically returns a taylored response by returning a Mirage.Response", function(assert) {
+  var done = assert.async();
+  var request = Ember.$.ajax({
+    url: '/pets',
+    method: 'post',
+    data: JSON.stringify({ pet: { alive: true } })
+  });
+
+  request.then(function() { /* noop */ }, function(response) {
+    assert.equal(response.status, 422, 'The status code is 422');
+    assert.equal(response.responseText, '{"errors":{"name":["can\'t be blank"]}}', 'The response body is correct');
+    assert.equal(response.getResponseHeader('some'), 'header', 'The response contains the custom header');
+    done();
+  });
+});
+
+test("returning a non-blank response from a custom handler whose default status is 204 changes the status to 200", function(assert) {
+  var done = assert.async();
+  var request = Ember.$.ajax({
+    url: '/pets/' + rex.id,
+    method: 'put',
+    data: JSON.stringify({ pet: { id: rex.id, name: 'The Rex', alive: true } })
+  });
+
+  request.then(function(response, statusText, jqXHR) {
+    assert.equal(jqXHR.status, 200, 'The status code is 200 instead od 204');
+    assert.deepEqual(response, { id: 1, name: "The Rex", alive: true }, 'The response is correct');
+    done();
+  });
+});

--- a/tests/dummy/app/mirage/config.js
+++ b/tests/dummy/app/mirage/config.js
@@ -1,3 +1,6 @@
+import Mirage from 'ember-cli-mirage';
+import Ember from 'ember';
+
 export default function() {
   // Contacts
   this.get('/contacts');
@@ -8,4 +11,27 @@ export default function() {
 
   // Friends
   this.get('/friends');
+
+  // Pets
+  this.get('/pets', function(db) {
+    return { pets: db.pets.filter(pet => pet.alive) };
+  });
+
+  this.post('/pets', function(db, req) {
+    let pet = JSON.parse(req.requestBody).pet;
+    if (Ember.isBlank(pet.name)) {
+      let body = { errors: { name: ["can't be blank"] } };
+      return new Mirage.Response(422, { some: 'header' }, body);
+    } else {
+      return { pet: db.pets.insert(pet) };
+    }
+  });
+
+  this.put('/pets/:id', function(db, req) {
+    let pet = JSON.parse(req.requestBody).pet;
+    db.pets.update(pet.id, pet);
+    return pet;
+  });
+
+  this.delete('/pets/:id', function(db, req) { }, 200);
 }

--- a/tests/dummy/app/mirage/factories/pet.js
+++ b/tests/dummy/app/mirage/factories/pet.js
@@ -1,0 +1,11 @@
+import Mirage from 'ember-cli-mirage';
+
+const names = ['Rex', 'Toby', 'Sam', 'Andy', 'Lassie', 'Annibal', 'Spark'];
+
+export default Mirage.Factory.extend({
+  alive: true,
+
+  name: function(i) {
+    return names[i%names.length];
+  },
+});

--- a/tests/dummy/app/mirage/factories/pet.js
+++ b/tests/dummy/app/mirage/factories/pet.js
@@ -1,6 +1,6 @@
 import Mirage from 'ember-cli-mirage';
 
-const names = ['Rex', 'Toby', 'Sam', 'Andy', 'Lassie', 'Annibal', 'Spark'];
+var names = ['Rex', 'Toby', 'Sam', 'Andy', 'Lassie', 'Annibal', 'Spark'];
 
 export default Mirage.Factory.extend({
   alive: true,

--- a/tests/dummy/app/models/pet.js
+++ b/tests/dummy/app/models/pet.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  alive: DS.attr('boolean')
+});

--- a/tests/unit/controller-test.js
+++ b/tests/unit/controller-test.js
@@ -75,9 +75,41 @@ test('its default response is 201 if the verb is post', function(assert) {
   assert.equal(response[0], 204);
 });
 
-test('its default response is 204 if the verb is delete', function(assert) {
+test('its default response is 204 if the verb is delete and the response is empty', function(assert) {
   var response = controller.handle('delete', {});
   assert.equal(response[0], 204);
+});
+
+test('its default response is 200 if the verb is delete and the response is not empty and no specific code passed', function(assert) {
+  var response = controller.handle('delete', function() {
+    return { text: 'thanks' };
+  });
+  assert.equal(response[0], 200, 'Returning a non-empty object changes the default code to 200');
+
+  var response2 = controller.handle('delete', function() {
+    return [];
+  });
+  assert.equal(response2[0], 200, 'An empty array IS NOT an empty response');
+
+  var response3 = controller.handle('delete', function() {
+    return;
+  });
+  assert.equal(response3[0], 204, 'undefined is considered an empty response');
+
+  var response4 = controller.handle('delete', function() {
+    return '';
+  });
+  assert.equal(response4[0], 204, 'An empty string is considered and empty response');
+
+  var response5 = controller.handle('delete', function() {
+    return;
+  }, 204);
+  assert.equal(response4[0], 204, 'If the response code is forced, that takes precedence');
+
+  var response6 = controller.handle('delete', function() {
+    return {};
+  }, 204);
+  assert.equal(response6[0], 204, 'An empty object is considered and empty response');
 });
 
 // TODO: Use spies to ensure get#shorthand is called with appropriate args

--- a/tests/unit/controller-test.js
+++ b/tests/unit/controller-test.js
@@ -33,9 +33,41 @@ test("function handler works with custom response", function(assert) {
   assert.deepEqual(response, [201, {some: 'header'}, {some: 'data'}]);
 });
 
-test('its default response is 204 if the verb is put', function(assert) {
+test('its default response is 204 if the verb is put and the response is empty', function(assert) {
   var response = controller.handle('put', {});
   assert.equal(response[0], 204);
+});
+
+test('its default response is 200 if the verb is put and the response is not empty and no specific code passed', function(assert) {
+  var response = controller.handle('put', function() {
+    return { text: 'thanks' };
+  });
+  assert.equal(response[0], 200, 'Returning a non-empty object changes the default code to 200');
+
+  var response2 = controller.handle('put', function() {
+    return [];
+  });
+  assert.equal(response2[0], 200, 'An empty array IS NOT an empty response');
+
+  var response3 = controller.handle('put', function() {
+    return;
+  });
+  assert.equal(response3[0], 204, 'undefined is considered an empty response');
+
+  var response4 = controller.handle('put', function() {
+    return '';
+  });
+  assert.equal(response4[0], 204, 'An empty string is considered and empty response');
+
+  var response5 = controller.handle('put', function() {
+    return;
+  }, 204);
+  assert.equal(response4[0], 204, 'If the response code is forced, that takes precedence');
+
+  var response6 = controller.handle('put', function() {
+    return {};
+  }, 204);
+  assert.equal(response6[0], 204, 'An empty object is considered and empty response');
 });
 
 test('its default response is 201 if the verb is post', function(assert) {


### PR DESCRIPTION
When a custom handler of an action that by default returns a 204 status
generates a non-blank response, a status 200 is used instead. 

Also added high-level acceptance tests for custom handlers