### PR TITLE
[WFA] More clever ID parseInt

### DIFF
--- a/addon/db.js
+++ b/addon/db.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+var allDigitsRegex = /^\d+$/;
+
 /*
   An identity map.
 */
@@ -74,7 +76,9 @@ export default function() {
 
   this._find = function(collection, id) {
     // If parses, coerce to integer
-    id = parseInt(id, 10) || id;
+    if (typeof id === "string" && allDigitsRegex.test(id)) {
+      id = parseInt(id, 10);
+    }
 
     return this[collection].filter(function(obj) {
       return obj.id === id;

--- a/addon/shorthands/utils.js
+++ b/addon/shorthands/utils.js
@@ -1,5 +1,7 @@
 import { singularize } from '../utils/inflector';
 
+var allDigitsRegex = /^\d+$/;
+
 export default {
 
   getIdForRequest: function(request) {
@@ -7,8 +9,10 @@ export default {
 
     if (request && request.params && request.params.id) {
       id = request.params.id;
-      // If the id is not a number, return the string. Otherwise, parse it as an integer
-      id = isNaN(id) ? id : parseInt(id, 10);
+      // If parses, coerce to integer
+      if (typeof id === "string" && allDigitsRegex.test(id)) {
+        id = parseInt(request.params.id, 10);
+      }
     }
 
     return id;

--- a/tests/unit/db-test.js
+++ b/tests/unit/db-test.js
@@ -132,6 +132,16 @@ test('returns a record that matches a string id', function(assert) {
   assert.deepEqual(contact, {id: 'abc', name: 'Ganon'});
 });
 
+test('returns a record whose id is a string that start with numbers', function(assert) {
+  db.contacts.insert({
+    id: '123-456',
+    name: 'Epona'
+  });
+
+  var contact = db.contacts.find('123-456');
+  assert.deepEqual(contact, {id: '123-456', name: 'Epona'});
+});
+
 
 module('mirage:db#where', {
   beforeEach: function() {


### PR DESCRIPTION
Mirage was parsing ids like "123-456" like "123". That is not correct.
Now only tries to parse the ID as an integer if its a String that looks like an Interger.