### PR TITLE
[WFA] Fix update for records with string ids.

### DIFF
--- a/addon/db.js
+++ b/addon/db.js
@@ -106,7 +106,7 @@ export default function() {
         });
       });
 
-    } else if (typeof target === 'number') {
+    } else if (typeof target === 'number' || typeof target === 'string') {
       var id = target;
       var record = this._find(collection, id);
 

--- a/addon/db.js
+++ b/addon/db.js
@@ -132,11 +132,10 @@ export default function() {
     if (typeof target === 'undefined') {
       this[collection] = [];
 
-    } else if (typeof target === 'number') {
+    } else if (typeof target === 'number' || typeof target === 'string') {
       var record = this._find(collection, target);
       var index = this[collection].indexOf(record);
       this[collection].splice(index, 1);
-
     } else if (typeof target === 'object') {
       var records = this._where(collection, target);
       records.forEach(function(record) {

--- a/tests/unit/db-test.js
+++ b/tests/unit/db-test.js
@@ -205,6 +205,15 @@ test('it can update a record by id', function(assert) {
   assert.deepEqual(ganon, {id: 3, name: 'Ganondorf', evil: false});
 });
 
+test('it can update a record by id when the id is a string', function(assert) {
+  db.contacts.insert({id: '123-abc', name: 'Epona', evil: true});
+  db.contacts.update('123-abc', { name: 'Epona', evil: false });
+
+  var epona = db.contacts.find('123-abc');
+
+  assert.deepEqual(epona, {id: '123-abc', name: 'Epona', evil: false});
+});
+
 test('it can update records by query', function(assert) {
   db.contacts.update({evil: false}, {name: 'Sam'});
 

--- a/tests/unit/db-test.js
+++ b/tests/unit/db-test.js
@@ -255,6 +255,17 @@ test('it can remove a single record', function(assert) {
   ]);
 });
 
+test('it can remove a single record then the id is a string', function(assert) {
+  db.contacts.insert({id: '123-abc', name: 'Epona', evil: true});
+  db.contacts.remove('123-abc');
+
+  assert.deepEqual(db.contacts, [
+    {id: 1, name: 'Link', evil: false},
+    {id: 2, name: 'Zelda', evil: false},
+    {id: 3, name: 'Ganon', evil: true},
+  ]);
+});
+
 test('it can remove multiple records by query', function(assert) {
   db.contacts.remove({evil: false});
 


### PR DESCRIPTION
I found that `db.contacts.update('123-abc', { name: 'new-name' })` didn't work.

Now it does :)