### PR TITLE
Fix removing all records then adding new ones

### DIFF
--- a/addon/db.js
+++ b/addon/db.js
@@ -132,7 +132,7 @@ export default function() {
     var _this = this;
 
     if (typeof target === 'undefined') {
-      this[collection] = [];
+      this[collection].length = 0;
 
     } else if (typeof target === 'number' || typeof target === 'string') {
       var record = this._find(collection, target);

--- a/tests/unit/db-test.js
+++ b/tests/unit/db-test.js
@@ -280,3 +280,13 @@ test('it can remove multiple records by query', function(assert) {
     {id: 3, name: 'Ganon', evil: true},
   ]);
 });
+
+test('it can add a record after removing all records', function(assert) {
+  db.contacts.remove();
+  db.contacts.insert({name: 'Foo'});
+
+  assert.equal(db.contacts.length, 1);
+  assert.deepEqual(db.contacts, [
+    {id: 1, name: 'Foo'}
+  ]);
+});


### PR DESCRIPTION
Fixed issue where removing all records from the collection would not allow you to add new ones afterwards.

The collection would no longer have the methods on it anymore because it was just set back to an empty array. By calling `createCollection` again it clears the collection's array and also adds the methods back on it as well.

@samselikoff What do you think?