### PR TITLE
Automatically add server to jshintrc files

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -8,6 +8,14 @@ module.exports = {
   },
 
   afterInstall: function() {
+    this.insertIntoFile('.jshintrc', '    "server",', {
+      after: '"predef": [\n'
+    });
+
+    this.insertIntoFile('tests/.jshintrc', '    "server",', {
+      after: '"predef": [\n'
+    });
+
     return this.addBowerPackagesToProject([
       {name: 'pretender', target: '~0.6.0'},
       {name: 'ember-inflector', target: '~1.3.1'},


### PR DESCRIPTION
Just added ember-cli-mirage to another project.

Too lazy to add `server` to my jshintrc, somehow not too lazy to put this together.