### PR TITLE
Coalesce find requests in get shorthand handlers

### DIFF
--- a/addon/controller.js
+++ b/addon/controller.js
@@ -16,10 +16,10 @@ var defaultCodes = {
 
 export default {
 
-  handle: function(verb, handler, db, request, customizedCode) {
+  handle: function(verb, handler, db, request, customizedCode, options) {
     var code, isEmptyObject;
     var handlerMethod = this._lookupHandlerMethod(verb, handler);
-    var response = handlerMethod(handler, db, request);
+    var response = handlerMethod(handler, db, request, options);
 
     if (response instanceof Response) {
       return response.toArray();

--- a/tests/acceptance/friends-test.js
+++ b/tests/acceptance/friends-test.js
@@ -5,7 +5,7 @@ import startApp from '../helpers/start-app';
 var App;
 var friends;
 
-module('Acceptance: Contacts', {
+module('Acceptance: Friends', {
   beforeEach: function() {
     App = startApp();
   },
@@ -30,5 +30,23 @@ test("I can view the friends", function(assert) {
     assert.ok( find('p:first').text().match(friend.age) );
     assert.ok( find('p:last').text().match('Tommy') );
     assert.ok( find('p:last').text().match(10) );
+  });
+});
+
+test("I can view the selected friends", function(assert) {
+  var friend1 = server.create('friend', { name: 'Jane', age: 30 });
+  var friend2 = server.create('friend', { name: 'Tommy', age: 10});
+  var friend3 = server.create('friend', { name: 'Bob', age: 28 });
+
+  visit('/close-friends');
+
+  andThen(function() {
+    assert.equal(currentRouteName(), 'close-friends');
+    assert.equal( find('p').length, 2 );
+
+    assert.ok( find('p:first').text().match('Jane') );
+    assert.ok( find('p:first').text().match(30) );
+    assert.ok( find('p:last').text().match('Bob') );
+    assert.ok( find('p:last').text().match(28) );
   });
 });

--- a/tests/dummy/app/mirage/config.js
+++ b/tests/dummy/app/mirage/config.js
@@ -10,7 +10,7 @@ export default function() {
   this.del('/contacts/:id');
 
   // Friends
-  this.get('/friends');
+  this.get('/friends', { coalesce: true });
 
   // Pets
   this.get('/pets', function(db) {

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('edit', {path: '/:contact_id/edit'});
 
   this.route('friends');
+  this.route('close-friends');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/close-friends.js
+++ b/tests/dummy/app/routes/close-friends.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+  model: function() {
+    var store = this.store;
+    return store.find('friend', { ids: [1, 3] }).then(function() {
+      // I request 2 friends and then return all friends to be sure no other friend
+      // was loaded into the store.
+      return store.all('friend');
+    });
+  }
+
+});

--- a/tests/dummy/app/templates/close-friends.hbs
+++ b/tests/dummy/app/templates/close-friends.hbs
@@ -1,0 +1,3 @@
+{{#each friend in model}}
+  <p>{{friend.name}} is your {{friend.age}}-year-old friend.</p>
+{{/each}}

--- a/tests/unit/shorthands/get-test.js
+++ b/tests/unit/shorthands/get-test.js
@@ -3,7 +3,11 @@ import Db from 'ember-cli-mirage/db';
 
 import {module, test} from 'qunit';
 
-var contacts = [{id: 1, name: 'Link', address_ids: [1]}, {id: 2, name: 'Zelda', address_ids: [2]}];
+var contacts = [
+  {id: 1, name: 'Link', address_ids: [1]},
+  {id: 2, name: 'Zelda', address_ids: [2]},
+  {id: 3, name: 'Epona', address_ids: []}
+];
 var addresses = [{id: 1, name: '123 Hyrule Way', contact_id: 1}, {id: 2, name: '456 Hyrule Way', contact_id: 2}];
 var db;
 module('mirage:shorthands#get', {
@@ -27,6 +31,14 @@ test("string shorthand with id works", function(assert) {
   var result = get.string('contact', db, {params: {id: 1}});
 
   assert.deepEqual(result, {contact: contacts[0]});
+});
+
+// e.g. this.stub('get', '/contacts?ids=1,3', 'contact');
+test("string shorthand works with coalesce options", function(assert) {
+  var reqWithManyIds = { queryParams: { ids: [1, 3] } };
+  var result = get.string('contacts', db, reqWithManyIds, { coalesce: true });
+
+  assert.deepEqual(result, { contacts: [ contacts[0], contacts[2] ]});
 });
 
 // e.g. this.stub('get', '/', ['contacts', 'addresses']);
@@ -70,4 +82,12 @@ test("undefined shorthand with id works when query params are present", function
   var result = get.undefined(undefined, db, {url: '/contacts/1?foo=true', params: {id: 1}});
 
   assert.deepEqual(result, {contact: contacts[0]});
+});
+
+// e.g. this.stub('get', '/contacts/:id');
+test("undefined shorthand with ids in the query params and coalesced enabled works", function(assert) {
+  var request = { url: '/contacts?ids=1,2,3', queryParams: { ids: [1,3] } };
+  var result = get.undefined(undefined, db, request, { coalesce: true });
+
+  assert.deepEqual(result, { contacts: [ contacts[0], contacts[2] ]});
 });


### PR DESCRIPTION
Now shorthand methods can receive a POJO with options, ignored by all
shorthands except of the `get` one.

The `get` handler supports the `coalesce` option, which defaults to
false. When enabled that option will make the shorthand method look for
an `ids` attribute on the queryParams, and will return with a collection
containing only the models with those ids.

Examples:

```js
this.get("/contacts", { coalesce: true }); // "/contacts?ids=1,3]"
this.get("/friends", "users", { coalesce: true }) // "/friends?ids=2,4"
```