### PR TITLE
Where coherces query parameters to strings

### DIFF
--- a/addon/db.js
+++ b/addon/db.js
@@ -92,7 +92,7 @@ export default function() {
 
     Object.keys(query).forEach(function(queryKey) {
       records = records.filter(function(record) {
-        return record[queryKey] === query[queryKey];
+        return String(record[queryKey]) === String(query[queryKey]);
       });
     });
 

--- a/tests/unit/db-test.js
+++ b/tests/unit/db-test.js
@@ -155,9 +155,9 @@ module('mirage:db#where', {
     db = new Db();
     db.createCollection('contacts');
     db.contacts.insert([
-      {name: 'Link', evil: false},
-      {name: 'Zelda', evil: false},
-      {name: 'Ganon', evil: true}
+      { name: 'Link',  evil: false, age: 17 },
+      { name: 'Zelda', evil: false, age: 17 },
+      { name: 'Ganon', evil: true,  age: 45 }
     ]);
   },
   afterEach: function() {
@@ -169,7 +169,15 @@ test('returns an array of records that match the query', function(assert) {
   var result = db.contacts.where({evil: true});
 
   assert.deepEqual(result, [
-    {id: 3, name: 'Ganon', evil: true}
+    {id: 3, name: 'Ganon', evil: true, age: 45}
+  ]);
+});
+
+test('it coerces query params to strings', function(assert) {
+  var result = db.contacts.where({age: "45"});
+
+  assert.deepEqual(result, [
+    {id: 3, name: 'Ganon', evil: true, age: 45}
   ]);
 });
 


### PR DESCRIPTION
Having this records in the db:
```js
[
 { id: 1, name: 'Bob', teacher_id: 123},
 { id: 2, name: 'Jane', teacher_id: 234}
]
```
performing a query like `/students?teacher_id=123` would return no
result because queryParameters in the requests are always treated as
strings, and `db.students.where({teacher_id: req.queryParams.teacher_id})`
will compare using `===`.

Now `where` coherces both operands to string before comparing them,
returning the expected student.

This also makes true === "true" and such, but that is very unlikely to cause
any problem.