### PR TITLE
Handling urls types with slash before ?

### DIFF
--- a/addon/shorthands/utils.js
+++ b/addon/shorthands/utils.js
@@ -30,7 +30,8 @@ export default {
 
   getTypeFromUrl: function(url, hasId) {
     var urlNoId = hasId ? url.substr(0, url.lastIndexOf('/')) : url;
-    var urlNoIdNoQuery = urlNoId.split("?")[0];
+    var urlSplit = urlNoId.split("?");
+    var urlNoIdNoQuery = urlSplit[0].slice(-1) === '/' ? urlSplit[0].slice(0, -1) : urlSplit[0];
     var type = singularize(urlNoIdNoQuery.substr(urlNoIdNoQuery.lastIndexOf('/') + 1));
 
     return type;

--- a/tests/unit/shorthands/utils-test.js
+++ b/tests/unit/shorthands/utils-test.js
@@ -29,3 +29,11 @@ test('it returns a string if it\'s a string', function(assert) {
   request.params.id = "someID";
   assert.equal(utils.getIdForRequest(request), "someID", 'it returns a number');
 });
+
+test('url without id returns correct type', function (assert) {
+  var urlWithSlash = '/api/users/?test=true';
+  var urlWithoutSlash = '/api/users?test=true';
+  
+  assert.equal(utils.getTypeFromUrl(urlWithSlash), 'user', 'it returns a singular type');
+  assert.equal(utils.getTypeFromUrl(urlWithoutSlash), 'user', 'it returns a singular type');
+});


### PR DESCRIPTION
For example: '/api/properties/?ll=42.426894%2C-71.046524' 

That was not handled previously.