### PR TITLE
Add ability to have per environment configs.

### DIFF
--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -1,5 +1,5 @@
 import ENV from '../config/environment';
-import userConfig from '../mirage/config';
+import baseConfig, { testConfig } from '../mirage/config';
 import Server from 'ember-cli-mirage/server';
 import readFixtures from 'ember-cli-mirage/utils/read-fixtures';
 import readFactories from 'ember-cli-mirage/utils/read-factories';
@@ -16,7 +16,11 @@ export default {
         environment: env
       });
 
-      server.loadConfig(userConfig);
+      server.loadConfig(baseConfig);
+
+      if (env === 'test') {
+        server.loadConfig(testConfig);
+      }
 
       if (env === 'test' && factoryMap) {
         server.loadFactories(factoryMap);
@@ -33,7 +37,7 @@ function _shouldUseMirage(env, addonConfig) {
   var defaultEnabled = _defaultEnabled(env, addonConfig);
 
   return userDeclaredEnabled ? addonConfig.enabled : defaultEnabled;
-};
+}
 
 /*
   Returns a boolean specifying the default behavior for whether

--- a/tests/acceptance/friends-test.js
+++ b/tests/acceptance/friends-test.js
@@ -50,3 +50,14 @@ test("I can view the selected friends", function(assert) {
     assert.ok( find('p:last').text().match(28) );
   });
 });
+
+test("I can view a friend that was configured only for test mode", function(assert) {
+  var friend = server.create('friend', { name: 'The Dude' });
+
+  visit('/friends/' + friend.id);
+
+  andThen(function() {
+    assert.equal(currentRouteName(), 'friend');
+    assert.ok( find('h2.friend-name').text().match('The Dude') );
+  });
+});

--- a/tests/dummy/app/mirage/config.js
+++ b/tests/dummy/app/mirage/config.js
@@ -34,4 +34,9 @@ export default function() {
   });
 
   this.delete('/pets/:id', function(db, req) { }, 200);
+
+}
+
+export function testConfig() {
+  this.get('/friends/:id');
 }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('edit', {path: '/:contact_id/edit'});
 
   this.route('friends');
+  this.route('friend', { path: '/friends/:friend_id'});
   this.route('close-friends');
 });
 

--- a/tests/dummy/app/templates/friend.hbs
+++ b/tests/dummy/app/templates/friend.hbs
@@ -1,0 +1,1 @@
+<h2 class="friend-name">{{model.name}}</h2>


### PR DESCRIPTION
First, here's the use case this is solving. The app is already existing and is set up with `--proxy`, so mirage needs to be explicitly enabled.

Workflow:
1. Create fixtures/factories for new feature development.
2. Stop using the fixtures in development when the API is ready, but keep using the factories in tests. This assumes a passthrough fallback is in place, either manually or from #134 so mirage doesn't complain about the route not being defined.

I can't think of a way to do this without requiring an update of some sort to consuming apps, and the approach here seems the least invasive. I can do this manually by adding `if (environment === 'test')` around test only routes, but it's messy. I also need to do this across at least 3 apps, and assume some others might be in a similar boat.

I added an integration test for this functionality because it's the only way I could think of to test that the initializer has actually been called.

Thoughts on the approach? Anything I'm missing?