### PR TITLE
Add npm unrelated folders to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,7 @@
+.sass-cache/
+_site/
 bower_components/
+jekyll-tmp/
 tests/
 tmp/
 


### PR DESCRIPTION
Add .sass-cache, _site and jekyll-tmp folders to .npmignore as their size is ~ 120MiB