### PR TITLE
Use splice instead of insertAt

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -22,7 +22,7 @@ function extractStubArguments(/* path, handler, code, options */) {
     ary.push(options);
   }
   for(; i < 5 - ary.length; i++) {
-    ary.insertAt(argsInitialLength, undefined);
+    ary.splice(argsInitialLength, 0, undefined);
   }
   return ary;
 }


### PR DESCRIPTION
Replace `Array.insertAt` by `Array.splice`.

Note: this make it possible to use `ember-cli-mirage` for addons.