### PR TITLE
Move babel into dependencies so it can be used.

### DIFF
--- a/addon/controller.js
+++ b/addon/controller.js
@@ -2,12 +2,8 @@ import Ember from 'ember';
 import shorthandHandlers from 'ember-cli-mirage/shorthands/index';
 import Response from './response';
 
-var isArray = Ember.isArray;
-var isBlank = Ember.isBlank;
-var typeOf  = Ember.typeOf;
-var keys    = Ember.keys;
-
-var defaultCodes = {
+const { isArray, isBlank, typeOf, keys } = Ember;
+const defaultCodes = {
   get: 200,
   put: 204,
   post: 201,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "chai": "2.0.0",
     "ember-cli": "0.2.0",
     "ember-cli-app-version": "0.3.2",
-    "ember-cli-babel": "^4.0.0",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-htmlbars": "0.7.4",
@@ -54,6 +53,7 @@
   },
   "dependencies": {
     "broccoli-funnel": "^0.2.3",
-    "broccoli-merge-trees": "^0.2.1"
+    "broccoli-merge-trees": "^0.2.1",
+    "ember-cli-babel": "^4.0.0"
   }
 }


### PR DESCRIPTION
Opening to run tests on Travis with a 4.x.x version of babel. Other code from #133.