### PR TITLE
Query params are accessed via request.queryParams

### DIFF
--- a/docs/latest/defining-routes.md
+++ b/docs/latest/defining-routes.md
@@ -74,7 +74,7 @@ this.get('/api/users/:id', function(db, request) {
 })
 ```
 
-Query params from the request can also be accessed via `request.params.[param]`.
+Query params from the request can also be accessed via `request.queryParams.[param]`.
 
 Data that's included in the message body of the request is accessible via `request.requestBody`. For example, if your app creates a user resource via a POST request that includes some JSON data, your route handler may look like this:
 

--- a/docs/v0.0.27/defining-routes.md
+++ b/docs/v0.0.27/defining-routes.md
@@ -74,7 +74,7 @@ this.get('/api/users/:id', function(db, request) {
 })
 ```
 
-Query params from the request can also be accessed via `request.params.[param]`.
+Query params from the request can also be accessed via `request.queryParams.[param]`.
 
 Data that's included in the message body of the request is accessible via `request.requestBody`. For example, if your app creates a user resource via a POST request that includes some JSON data, your route handler may look like this:
 

--- a/docs/v0.0.28/defining-routes.md
+++ b/docs/v0.0.28/defining-routes.md
@@ -74,7 +74,7 @@ this.get('/api/users/:id', function(db, request) {
 })
 ```
 
-Query params from the request can also be accessed via `request.params.[param]`.
+Query params from the request can also be accessed via `request.queryParams.[param]`.
 
 Data that's included in the message body of the request is accessible via `request.requestBody`. For example, if your app creates a user resource via a POST request that includes some JSON data, your route handler may look like this:
 

--- a/docs/v0.0.29/defining-routes.md
+++ b/docs/v0.0.29/defining-routes.md
@@ -74,7 +74,7 @@ this.get('/api/users/:id', function(db, request) {
 })
 ```
 
-Query params from the request can also be accessed via `request.params.[param]`.
+Query params from the request can also be accessed via `request.queryParams.[param]`.
 
 Data that's included in the message body of the request is accessible via `request.requestBody`. For example, if your app creates a user resource via a POST request that includes some JSON data, your route handler may look like this:
 


### PR DESCRIPTION
This caught me out earlier today. Just a typo, I think.

Thanks for this great project!