### PR TITLE
WIP Queuing events

### DIFF
--- a/addon/event-queue.js
+++ b/addon/event-queue.js
@@ -1,0 +1,36 @@
+/*
+  A manager for events to be processed
+*/
+
+export default function() {
+  this.events = [];
+  this.factories = {};
+
+  this.loadFactories = function(factories) {
+    this.factories = factories;
+  };
+
+  this.addEvent = function(name, params) {
+    var factory = this.factories[name];
+
+    if(!factory) {
+      throw 'No event factory defined for ' + name + '.';
+    }
+
+    this.events.push({
+      name: name,
+      params: params,
+      factory: factory
+    });
+  };
+
+  this.nextEvent = function() {
+    return this.events[this.events.length - 1];
+  };
+
+  this.length = function() {
+    return this.events.length;
+  };
+
+  return this;
+}

--- a/addon/server.js
+++ b/addon/server.js
@@ -172,5 +172,15 @@ export default function(options) {
   */
   this._eventQueue = new EventQueue();
 
+  this.enqueueEvent = function(eventName, params) {
+    this._eventQueue.addEvent(eventName, params);
+  };
+
+  this.enqueueEvents = function(eventName, n, params) {
+    for(var i = 0; i < n; i ++) {
+      this._eventQueue.addEvent(eventName, params);
+    }
+  };
+
   return this;
 }

--- a/addon/server.js
+++ b/addon/server.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { pluralize } from './utils/inflector';
+import EventQueue from './event-queue';
 import Pretender from 'pretender';
 import Db from './db';
 import controller from './controller';
@@ -120,6 +121,12 @@ export default function(options) {
     // Store a reference to the factories
     this._factoryMap = factoryMap;
 
+    // Extract the event factories
+    if (factoryMap['events']) {
+      this._eventQueue.loadFactories(factoryMap['events']);
+      delete this._factoryMap['events'];
+    }
+
     // Create a collection for each factory
     Ember.keys(factoryMap).forEach(function(type) {
       _this.db.createCollection(pluralize(type));
@@ -159,6 +166,11 @@ export default function(options) {
   this.shutdown = function(){
     this.pretender.shutdown();
   };
+
+  /*
+    Event queue
+  */
+  this._eventQueue = new EventQueue();
 
   return this;
 }

--- a/tests/unit/event-queue-test.js
+++ b/tests/unit/event-queue-test.js
@@ -1,0 +1,38 @@
+import EventQueue from 'ember-cli-mirage/event-queue';
+import {module, test} from 'qunit';
+import Factory from 'ember-cli-mirage/factory';
+
+var eventQueue;
+
+module('mirage:event-queue');
+
+test('it can be instantiated', function(assert) {
+  var eventQueue = new EventQueue();
+  assert.ok(eventQueue);
+});
+
+module('mirage:eventQueue#addEvent', {
+  beforeEach: function() {
+    eventQueue = new EventQueue();
+  }
+});
+
+test('it can queue an event', function(assert) {
+  var fileAddFactory = Factory.extend({ name: 'ben.jpg' });
+  eventQueue.loadFactories({ 'file-add': fileAddFactory });
+  assert.equal(eventQueue.length(), 0);
+
+  eventQueue.addEvent('file-add', { name: 'ben2.jpg' });
+  assert.equal(eventQueue.length(), 1);
+
+  var event = eventQueue.nextEvent();
+  assert.equal(event.name, 'file-add');
+  assert.deepEqual(event.params, { name: 'ben2.jpg' });
+  assert.equal(event.factory, fileAddFactory);
+});
+
+test('it will not queue an event without a factory', function(assert) {
+  assert.throws(function() {
+    eventQueue.addEvent('file-add', { name: 'ben2.jpg' });
+  });
+});

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -217,3 +217,31 @@ test('loadFactories does not save event factories to server', function(assert) {
 
   assert.equal(server._factoryMap['events'], null);
 });
+
+module('mirage:server#enqueueEvent', {
+  beforeEach: function() {
+    server = new Server({environment: 'test'});
+
+    server.loadFactories({
+      events: {
+        'file-add': Factory.extend({fileName: 'ben.jpg'})
+      }
+    });
+  }
+});
+
+test('enqueueEvent queues an event', function(assert) {
+  assert.equal(server._eventQueue.length(), 0);
+  server.enqueueEvent('file-add', { fileName: 'sam.jpg' });
+  assert.equal(server._eventQueue.length(), 1);
+  assert.equal(server._eventQueue.nextEvent().name, 'file-add');
+  assert.equal(server._eventQueue.nextEvent().params.fileName, 'sam.jpg');
+});
+
+test('enqueueEvents queues many events', function(assert) {
+  assert.equal(server._eventQueue.length(), 0);
+  server.enqueueEvents('file-add', 10, { fileName: 'sam.jpg' });
+  assert.equal(server._eventQueue.length(), 10);
+  assert.equal(server._eventQueue.nextEvent().name, 'file-add');
+  assert.equal(server._eventQueue.nextEvent().params.fileName, 'sam.jpg');
+});

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -203,3 +203,17 @@ test('createList respects attr overrides', function(assert) {
   assert.deepEqual(links[0], {id: 3, name: 'Link'});
   assert.deepEqual(links[1], {id: 4, name: 'Link'});
 });
+
+module('mirage:server#loadFactories', {
+  beforeEach: function() {
+    server = new Server({environment: 'test'});
+  }
+});
+
+test('loadFactories does not save event factories to server', function(assert) {
+  server.loadFactories({
+    events: {}
+  });
+
+  assert.equal(server._factoryMap['events'], null);
+});


### PR DESCRIPTION
Add an interface to mock event data from servers.

Hit list:

 - [x] Ability to register an 'event' factory
 - [x] Interface on `server` to queue events with factories
 - [ ] Interface on `server` to queue events with generic string data
 - [ ] Interface to register a mock event server with an adapter for mock-socket
 - [ ] Logic to process events queue with delay

Bonus:

 - [ ] Also write an event server adapter for mock-firebase

Out of scope:

 + Handling multiple mock event servers