### PR TITLE
Default mirage config was fail the tests

### DIFF
--- a/blueprints/ember-cli-mirage/files/app/mirage/factories/contact.js
+++ b/blueprints/ember-cli-mirage/files/app/mirage/factories/contact.js
@@ -3,7 +3,7 @@
 
   Create more files in this directory to define additional factories.
 */
-import Mirage, {faker} from 'ember-cli-mirage';
+import Mirage/*, {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
   // name: 'Pete',                         // strings

--- a/blueprints/ember-cli-mirage/files/app/mirage/scenarios/default.js
+++ b/blueprints/ember-cli-mirage/files/app/mirage/scenarios/default.js
@@ -1,4 +1,4 @@
-export default function(server) {
+export default function(/* server */) {
 
   // Seed your development database using your factories. This
   // data will not be loaded in your tests.


### PR DESCRIPTION
To reproduce:
```
ember new my-app 
cd my-app
ember install ember-cli-mirage
ember test
```

``` bash
JSHint - mirage/factories: mirage/factories/contact.js should pass jshint
    ✘ mirage/factories/contact.js should pass jshint.
    mirage/factories/contact.js: line 6, col 17, 'faker' is defined but never us
ed.
....

JSHint - mirage/scenarios: mirage/scenarios/default.js should pass jshint
    ✘ mirage/scenarios/default.js should pass jshint.
    mirage/scenarios/default.js: line 1, col 25, 'server' is defined but never u
sed.

```
