### PR TITLE
Add ember 1.13.2 scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-1.13.2
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -18,6 +19,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -5,6 +5,13 @@ module.exports = {
       dependencies: { }
     },
     {
+      name: 'ember-1.13.2',
+      dependencies: {
+        'ember': '1.13.2',
+        'ember-data': '1.13.2'
+      }
+    },
+    {
       name: 'ember-release',
       dependencies: {
         'ember': 'components/ember#release'

--- a/tests/dummy/app/routes/contacts.js
+++ b/tests/dummy/app/routes/contacts.js
@@ -4,7 +4,9 @@ export default Ember.Route.extend({
 
   model() {
     return this.store.find('contact').then(null, (reason) => {
-      this.set('error', reason.responseJSON.errors[0]);
+      var errorMsg = reason.responseJSON ? reason.responseJSON.errors[0] :
+                                           reason.errors[0];
+      this.set('error', errorMsg);
     });
   },
 


### PR DESCRIPTION
I was trying to track down the build failures for #175 and I discovered that on master the "ember-beta" scenario is also failing. It appears to be failing because in that scenario ember-data attempts to read off `indexOf` from `Ember.EnumerableUtils.indexOf`, which no longer exists in ember beta.

This makes a few changes:

  * adds the ember 1.13.2 scenario which also uses ember-data 1.13.2
  * I had to make a small change to the dummy app contacts route error
    handler to account for a difference in the way ember-data 1.13.2
    handles exposes errors (it no longer passes through the jqXHR)
  * Change travis.yml to allow the ember-beta scenario to fail. It is failing anyway because `ember#beta` now points at ember 2.0, whereas when v0.1.4 of mirage was released beta was pointing at 1.13, and that's not incompatible with ember-data.

When I have a chance (in a couple days) I'm going to look at this again and see if I can make it pass w/ ember beta as well. It should be able to do so, it's just a discrepancy between the versions used in the 'ember-beta' scenario. I tried with both ember and ember-data pointing at 'beta' but that didn't work either. The fixes to ember-data's fixture adapter (removing use of `Ember.EnumerableUtils` and `Ember.ArrayPolyFills`) doesn't seem to be on beta yet.