### PR TITLE
Shorthand method with id return 404 when record is missing

### DIFF
--- a/addon/shorthands/get.js
+++ b/addon/shorthands/get.js
@@ -1,3 +1,4 @@
+import Response from '../response';
 import { singularize, pluralize } from '../utils/inflector';
 import utils from './utils';
 
@@ -16,6 +17,7 @@ export default {
     var collection = pluralize(string);
     var id = utils.getIdForRequest(request);
     var data = {};
+    var record;
     options = options || {};
 
     if (!db[collection]) {
@@ -23,7 +25,11 @@ export default {
     }
 
     if (id) {
-      data[key] = db[collection].find(id);
+      record = db[collection].find(id);
+      if (!record) {
+        return new Response(404, {}, {});
+      }
+      data[key] = record;
     } else if (options.coalesce && request.queryParams && request.queryParams.ids) {
       data[key] = db[collection].find(request.queryParams.ids);
     } else {
@@ -102,6 +108,7 @@ export default {
     var type = utils.getTypeFromUrl(url, id);
     var collection = pluralize(type);
     var data = {};
+    var record;
     options = options || {};
 
     if (!db[collection]) {
@@ -109,6 +116,10 @@ export default {
     }
 
     if (id) {
+      record = db[collection].find(id);
+      if (!record) {
+        return new Response(404, {}, {});
+      }
       data[type] = db[collection].find(id);
     } else if (options.coalesce && request.queryParams && request.queryParams.ids) {
       data[collection] = db[collection].find(request.queryParams.ids);

--- a/tests/unit/shorthands/get-test.js
+++ b/tests/unit/shorthands/get-test.js
@@ -31,6 +31,9 @@ test("string shorthand with id works", function(assert) {
   var result = get.string('contact', db, {params: {id: 1}});
 
   assert.deepEqual(result, {contact: contacts[0]});
+
+  var result404 = get.undefined(undefined, db, {url: '/contacts/1', params: {id: 999}});
+  assert.equal(result404.toArray()[0], 404, 'Status is Not Found');
 });
 
 // e.g. this.stub('get', '/contacts?ids=1,3', 'contact');
@@ -75,6 +78,9 @@ test("undefined shorthand with id works", function(assert) {
   var result = get.undefined(undefined, db, {url: '/contacts/1', params: {id: 1}});
 
   assert.deepEqual(result, {contact: contacts[0]});
+
+  var result404 = get.undefined(undefined, db, {url: '/contacts/1', params: {id: 999}});
+  assert.equal(result404.toArray()[0], 404, 'Status is Not Found');
 });
 
 // e.g. this.stub('get', '/contacts/:id');


### PR DESCRIPTION
p.e: `/users/999` now returns `new Mirage.Response(404, {}, {})` when
the user with that id is not in the database