### PR TITLE
Updated faker method for 0.1.6

### DIFF
--- a/addon/faker.js
+++ b/addon/faker.js
@@ -3,7 +3,7 @@ var list = {
     var items = arguments.length > 0 ? arguments : [];
 
     return function () {
-      return faker.random.arrayElement(items);
+      return faker.random.array_element(items);
     };
   },
 


### PR DESCRIPTION
Resolves ```faker.random.arrayElement is not a function``` error after upgrading from 0.1.5 and using Faker 2.12.1