### PR TITLE
Add es5 polyfill requirement to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Ember CLI Mirage may be for you! It lets you create a client-side server using [
 ```sh
 ember install ember-cli-mirage  # install:addon for Ember CLI < 0.2.3
 ```
+### Requirements
+
+If you are using a version of PhantomJS before 2.0, ensure you have [ember-cli-es5-shim](https://github.com/pixelhandler/ember-cli-es5-shim) installed in your app because Mirage uses `.bind`.
 
 ## Updating
 


### PR DESCRIPTION
This adds a sub-section to the Installation section that lets users
know that they need to add ember-cli-es5-shim to their project
if they are using PhantomJS < 2.0 because of the use of 
`.bind` in Mirage.

The credit for this really goes to @samselikoff for helping me
with this! 😁