### PR TITLE
Depend on pretender 0.9

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1",
-    "pretender": "~0.7.0",
+    "pretender": "~0.9.0",
     "ember-inflector": "~1.3.1",
     "lodash": "~3.7.0",
     "Faker": "~3.0.0"


### PR DESCRIPTION
This should fix most of the memory leak happening in acceptance tests.
Tomorrow I'll perform some more checks to see if there is still
something leaking in my test suite, and is so apply some voodoo I've
learnt today.