### PR TITLE
Release window.server global on shutdown

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -123,6 +123,9 @@ export default class Server {
 
   shutdown() {
     this.pretender.shutdown();
+    if (this.environment === 'test') {
+      window.server = undefined;
+    }
   }
 
   _setupStubAliases() {


### PR DESCRIPTION
I keep my fight agains memory leaks. This one removes the server (and the internal pretender too) when the server is shut down.