### PR TITLE
Install ember-inflector from NPM

### DIFF
--- a/addon/utils/inflector.js
+++ b/addon/utils/inflector.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
+export { singularize, pluralize } from 'ember-inflector';
 
-export var singularize = Ember.String.singularize;
-export var pluralize = Ember.String.pluralize;
 export var capitalize = Ember.String.capitalize;

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1",
     "pretender": "~0.9.0",
-    "ember-inflector": "~1.3.1",
     "lodash": "~3.7.0",
     "Faker": "~3.0.0"
   }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ module.exports = {
         type: 'vendor',
         exports: { 'pretender': ['default'] }
       });
-      app.import(app.bowerDirectory + '/ember-inflector/ember-inflector.js');
       app.import(app.bowerDirectory + '/lodash/lodash.js');
       app.import(app.bowerDirectory + '/Faker/build/build/faker.js');
     }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "broccoli-funnel": "^0.2.3",
     "broccoli-merge-trees": "^0.2.1",
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-inflector": "^1.9.0"
   }
 }


### PR DESCRIPTION
- Also updates ember-inflector from version 1.3.1 to 1.9.0
- Prevents installing `ember-cli-mirage` from breaking the build with the latest Ember canary (the reference to `Ember.Handlebars` in the old version of `ember-inflector` was messing with things)

Closes #221 