### PR TITLE
Update factory blueprint to pass JSHint

### DIFF
--- a/blueprints/factory/files/app/mirage/factories/__name__.js
+++ b/blueprints/factory/files/app/mirage/factories/__name__.js
@@ -1,4 +1,4 @@
-import Mirage, {faker} from 'ember-cli-mirage';
+import Mirage/*, {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });


### PR DESCRIPTION
JSHint complains about unused {faker} import in default factory.