### PR TITLE
Ensure consuming apps depend on pretender 0.9

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -19,7 +19,7 @@ module.exports = {
     });
 
     return this.addBowerPackagesToProject([
-      {name: 'pretender', target: '~0.7.0'},
+      {name: 'pretender', target: '~0.9.0'},
       {name: 'lodash', target: '~3.7.0'},
       {name: 'Faker', target: '~3.0.0'}
     ]);


### PR DESCRIPTION
We changed it in `package.json` but not here.