### PR TITLE
Adds support for FQDN in route configuration 

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -18,6 +18,7 @@ export default class Server {
     this.environment = options.environment;
     this.timing = 400;
     this.namespace = '';
+    this.urlPrefix = '';
 
     this._setupStubAliases();
 
@@ -69,7 +70,7 @@ export default class Server {
     var _this = this;
     path = path[0] === '/' ? path.slice(1) : path;
 
-    this.interceptor[verb].call(this.interceptor, this.namespace + '/' + path, function(request) {
+    this.interceptor[verb].call(this.interceptor, this._getFullPath(path), function(request) {
       var response = controller.handle(verb, handler, (_this.schema || _this.db), request, code, options);
       var shouldLog = typeof _this.logging !== 'undefined' ? _this.logging : (_this.environment !== 'test');
 
@@ -166,6 +167,38 @@ export default class Server {
       ary.splice(argsInitialLength, 0, undefined);
     }
     return ary;
+  }
+
+  /*
+    Builds a full path for Pretender to monitor based on the `path` and
+    configured options (`urlPrefix` and `namespace`).
+  */
+  _getFullPath(path) {
+    var fullPath = '',
+        urlPrefix = this.urlPrefix ? this.urlPrefix.trim() : '',
+        namespace = this.namespace ? this.namespace.trim() : '';
+
+    // check to see if path is a FQDN. if so, ignore any urlPrefix/namespace that was set
+    if (/^https?:\/\//.test(path)) {
+      fullPath += path;
+    } else {
+
+      // otherwise, if there is a urlPrefix, use that as the beginning of the path
+      if (!!urlPrefix.length) {
+        fullPath += urlPrefix[urlPrefix.length - 1] === '/' ? urlPrefix : urlPrefix + '/';
+      }
+
+      // if a namespace has been configured, add it before the path
+      if (!!namespace.length) {
+        fullPath += namespace ? namespace + '/' : namespace;
+      }
+
+      // finally add the configured path
+      fullPath += path;
+    }
+
+    console.log(fullPath);
+    return fullPath;
   }
 
 }

--- a/blueprints/ember-cli-mirage/files/app/mirage/config.js
+++ b/blueprints/ember-cli-mirage/files/app/mirage/config.js
@@ -7,6 +7,7 @@ export default function() {
 
     Note: these only affect routes defined *after* them!
   */
+  // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
   // this.namespace = '';    // make this `api`, for example, if your API is namespaced
   // this.timing = 400;      // delay for each request, automatically set to 0 during testing
 

--- a/tests/integration/server-config-test.js
+++ b/tests/integration/server-config-test.js
@@ -34,3 +34,87 @@ test("namespace can be configured", function(assert) {
     done();
   });
 });
+
+test("urlPrefix can be configured", function(assert) {
+  assert.expect(1);
+  var done = assert.async();
+  var server = this.server;
+
+  var contacts = [
+    {id: 1, name: 'Link'},
+    {id: 2, name: 'Zelda'},
+  ];
+  server.db.loadData({
+    contacts: contacts
+  });
+  server.urlPrefix = 'http://localhost:3000';
+  server.get('/contacts');
+
+  $.getJSON('http://localhost:3000/contacts', function(data) {
+    assert.deepEqual(data, { contacts: contacts });
+    done();
+  });
+});
+
+test("urlPrefix and namespace can be configured simultaneously", function(assert) {
+  assert.expect(1);
+  var done = assert.async();
+  var server = this.server;
+
+  var contacts = [
+    {id: 1, name: 'Link'},
+    {id: 2, name: 'Zelda'},
+  ];
+  server.db.loadData({
+    contacts: contacts
+  });
+  server.urlPrefix = 'http://localhost:3000';
+  server.namespace = 'api';
+  server.get('/contacts');
+
+  $.getJSON('http://localhost:3000/api/contacts', function(data) {
+    assert.deepEqual(data, { contacts: contacts });
+    done();
+  });
+});
+
+test("fully qualified domain names can be used in configuration", function(assert) {
+  assert.expect(1);
+  var done = assert.async();
+  var server = this.server;
+
+  var contacts = [
+    {id: 1, name: 'Link'},
+    {id: 2, name: 'Zelda'},
+  ];
+  server.db.loadData({
+    contacts: contacts
+  });
+  server.get('http://example.org/api/contacts', 'contacts');
+
+  $.getJSON('http://example.org/api/contacts', function(data) {
+    assert.deepEqual(data, { contacts: contacts });
+    done();
+  });
+});
+
+test("urlPrefix/namespace are ignored when fully qualified domain names are used in configuration", function(assert) {
+  assert.expect(1);
+  var done = assert.async();
+  var server = this.server;
+
+  var contacts = [
+    {id: 1, name: 'Link'},
+    {id: 2, name: 'Zelda'},
+  ];
+  server.db.loadData({
+    contacts: contacts
+  });
+  this.urlPrefix = 'https://example.net';
+  server.get('http://example.org/api/contacts', 'contacts');
+
+  $.getJSON('http://example.org/api/contacts', function(data) {
+    assert.deepEqual(data, { contacts: contacts });
+    done();
+  });
+});


### PR DESCRIPTION
With Pretender v0.9.0 now supporting fully-qualified URLs, this update adds the ability to use FQDNs in your route configurations. It also adds a new `urlPrefix` parameter that allows you to configure Mirage to prepend a FQDN to all of your route configurations automatically.