### PR TITLE
Warn that passthrough only works with jQuery > 2.x

### DIFF
--- a/docs/v0.0.27/server-configuration.md
+++ b/docs/v0.0.27/server-configuration.md
@@ -50,6 +50,8 @@ export default function() {
 
 Refer to [pretender's docs](https://github.com/trek/pretender#mutating-the-body) if you want to change this or any other options on your pretender instance.
 
+Be aware that the `passthrough`-option wil currently only work with jQuery versions >= 2.x. See this [issue](https://github.com/pretenderjs/pretender/issues/85) for details.
+
 ## Environment options
 
 <a name="enabled" href="#enabled">#</a> ENV['ember-cli-mirage'].<b>enabled</b>

--- a/docs/v0.0.28/server-configuration.md
+++ b/docs/v0.0.28/server-configuration.md
@@ -50,6 +50,8 @@ export default function() {
 
 Refer to [pretender's docs](https://github.com/trek/pretender#mutating-the-body) if you want to change this or any other options on your pretender instance.
 
+Be aware that the `passthrough`-option wil currently only work with jQuery versions >= 2.x. See this [issue](https://github.com/pretenderjs/pretender/issues/85) for details.
+
 ## Environment options
 
 <a name="enabled" href="#enabled">#</a> ENV['ember-cli-mirage'].<b>enabled</b>

--- a/docs/v0.0.29/server-configuration.md
+++ b/docs/v0.0.29/server-configuration.md
@@ -52,6 +52,8 @@ export default function() {
 
 Refer to [pretender's docs](https://github.com/trek/pretender#mutating-the-body) if you want to change this or any other options on your pretender instance.
 
+Be aware that the `passthrough`-option wil currently only work with jQuery versions >= 2.x. See this [issue](https://github.com/pretenderjs/pretender/issues/85) for details.
+
 ## Environment options
 
 <a name="enabled" href="#enabled">#</a> ENV['ember-cli-mirage'].<b>enabled</b>

--- a/docs/v0.1.x/server-configuration.md
+++ b/docs/v0.1.x/server-configuration.md
@@ -69,6 +69,8 @@ export default function() {
 
 Refer to [pretender's docs](https://github.com/trek/pretender#mutating-the-body) if you want to change this or any other options on your pretender instance.
 
+Be aware that the `passthrough`-option wil currently only work with jQuery versions >= 2.x. See this [issue](https://github.com/pretenderjs/pretender/issues/85) for details.
+
 <a name="testConfig" href="#testConfig">#</a> **testConfig**
 
 Export a named `testConfig` function to define routes that only apply in your test environment:


### PR DESCRIPTION
This took me some time to figure out and find in the issues. I suppose this is something that a lot of people need (passthrough option) and might run into.