### PR TITLE
Rename `extend` to `utilsExtend`

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -1,5 +1,5 @@
 import { pluralize } from '../utils/inflector';
-import extend from '../utils/extend';
+import utilsExtend from '../utils/extend';
 
 /*
   The Model class. Notes:
@@ -197,6 +197,6 @@ class Model {
   }
 }
 
-Model.extend = extend;
+Model.extend = utilsExtend;
 
 export default Model;

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -1,6 +1,6 @@
 /* global _ */
 import Model from './orm/model';
-import extend from './utils/extend';
+import utilsExtend from './utils/extend';
 
 class Serializer {
 
@@ -49,6 +49,6 @@ Serializer.prototype.relationships = [];
 Serializer.prototype.root = true;
 Serializer.prototype.embed = false;
 
-Serializer.extend = extend;
+Serializer.extend = utilsExtend;
 
 export default Serializer;


### PR DESCRIPTION
Running a project's CI with `phantomjs@~1.9.0` raises the following
error:

```
Exception while running qunit-bdd `before` hook:
`undefined` is not a function
  (evaluating `extend['default'].bind(Model, null)`)
```

`extend` seems to be a pre-existing variable (and will probably be a
keyword in future browsers). Therefore `extend['default']` is
`undefined`.

To work around this, export the `utils/extend` to a different name.