### PR TITLE
Include `es5-shim` for PhantomJS/IE8

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -33,6 +33,7 @@ module.exports = {
     });
 
     return this.addBowerPackagesToProject([
+      {name: 'es5-shim', target: '~4.1.11'},
       {name: 'pretender', target: '~0.9.0'},
       {name: 'lodash', target: '~3.7.0'},
       {name: 'Faker', target: '~3.0.0'}

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
+    "es5-shim": "~4.1.11",
     "qunit": "~1.18.0",
     "pretender": "~0.9.0",
     "lodash": "~3.7.0",

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ module.exports = {
       });
       app.import(app.bowerDirectory + '/lodash/lodash.js');
       app.import(app.bowerDirectory + '/Faker/build/build/faker.js');
+      if (app.env === 'test') {
+        app.import(app.bowerDirectory + '/es5-shim/es5-shim.js');
+      }
     }
   },
 


### PR DESCRIPTION
Versions of `phantomjs` < `2.0.0` [don't include
Function.prototype.bind][bind].

To deal with this, the library could include `es5-shim` in test
environments.

Related to [#262].

[#262]: https://github.com/samselikoff/ember-cli-mirage/pull/262 
[bind]: https://github.com/ember-cli/ember-cli/issues/2634#issuecomment-65326419