### PR TITLE
[Feature] reference dynamic attributes from dynamic attributes.

### DIFF
--- a/addon/factory.js
+++ b/addon/factory.js
@@ -1,32 +1,48 @@
+import _keys from 'lodash/object/keys';
 import _assign from 'lodash/object/assign';
 import _isArray from 'lodash/lang/isArray';
 import _isFunction from 'lodash/lang/isFunction';
-import _isPlainObject from 'lodash/lang/isPlainObject';
 import _mapValues from 'lodash/object/mapValues';
+import referenceSort from './utils/reference-sort';
+import _isPlainObject from 'lodash/lang/isPlainObject';
 
 var Factory = function() {
   this.build = function(sequence) {
+    const object = {};
     const topLevelAttrs = this.attrs || {};
-    let buildAttrs;
-    let buildSingleValue;
+    const keys = sortAttrs(topLevelAttrs, sequence);
 
-    buildAttrs = function(attrs) {
-      return _mapValues(attrs, buildSingleValue);
-    };
+    keys.forEach(function(key) {
 
-    buildSingleValue = function(value) {
-      if (_isArray(value)) {
-        return value.map(buildSingleValue);
-      } else if (_isPlainObject(value)) {
-        return buildAttrs(value);
-      } else if (_isFunction(value)) {
-        return value.call(topLevelAttrs, sequence);
+      let buildAttrs;
+      let buildSingleValue;
+
+      buildAttrs = function(attrs) {
+        return _mapValues(attrs, buildSingleValue);
+      };
+
+      buildSingleValue = (value) => {
+        if (_isArray(value)) {
+          return value.map(buildSingleValue);
+        } else if (_isPlainObject(value)) {
+          return buildAttrs(value);
+        } else if (_isFunction(value)) {
+          return value.call(topLevelAttrs, sequence);
+        } else {
+          return value;
+        }
+      };
+
+      const value = topLevelAttrs[key];
+      if (_isFunction(value)) {
+        object[key] = value.call(object, sequence);
       } else {
-        return value;
+        object[key] = buildSingleValue(value);
       }
-    };
 
-    return buildAttrs(topLevelAttrs);
+    });
+
+    return object;
   };
 };
 
@@ -47,5 +63,35 @@ Factory.extend = function(attrs) {
 
   return Subclass;
 };
+
+function sortAttrs(attrs, sequence) {
+  var Temp = function() {};
+  var obj = new Temp();
+  var refs = [];
+  var property;
+
+  _keys(attrs).forEach(function(key) {
+    Object.defineProperty(obj.constructor.prototype, key, {
+        get: function () {
+          refs.push([property, key]);
+        },
+        enumerable: false,
+        configurable: true
+    });
+  });
+
+  _keys(attrs).forEach(function(key) {
+    var value = attrs[key];
+    property = key;
+
+    if (typeof value === 'function') {
+      value.call(obj, sequence);
+    }
+
+    refs.push([key]);
+  });
+
+  return referenceSort(refs);
+}
 
 export default Factory;

--- a/addon/utils/reference-sort.js
+++ b/addon/utils/reference-sort.js
@@ -1,0 +1,49 @@
+import _uniq from 'lodash/array/uniq';
+import _flatten from 'lodash/array/flatten';
+
+export default function(edges) {
+  var nodes = _uniq(_flatten(edges));
+  var cursor = nodes.length;
+  var sorted = new Array(cursor);
+  var visited = {};
+  var i = cursor;
+
+  var visit = function(node, i, predecessors) {
+
+    if(predecessors.indexOf(node) >= 0) {
+      throw new Error('Cyclic dependency in properties ' + JSON.stringify(predecessors));
+    }
+
+    if (visited[i]) {
+      return;
+    } else {
+      visited[i] = true;
+    }
+
+    var outgoing = edges.filter(function(edge){
+      return edge && edge[0] === node;
+    });
+
+    if (i = outgoing.length) {
+      var preds = predecessors.concat(node);
+      do {
+        var pair = outgoing[--i];
+        var child = pair[1];
+        if (child) {
+          visit(child, nodes.indexOf(child), preds);
+        }
+      } while (i);
+    }
+
+    sorted[--cursor] = node;
+  };
+
+  while (i--) {
+    if (!visited[i]) {
+      visit(nodes[i], i, []);
+    }
+  }
+
+  return sorted.reverse();
+
+}

--- a/tests/unit/factory-test.js
+++ b/tests/unit/factory-test.js
@@ -171,6 +171,6 @@ test('throws meaningfull exception on circular reference', function(assert) {
   assert.throws(function() {
     b.build(1);
   }, function(e) {
-    return e.toString() === 'Error: Cyclic dependency in properties ["bar","foo"]';
+    return e.toString() === 'Error: Cyclic dependency in properties ["foo","bar"]';
   });
 });

--- a/tests/unit/factory-test.js
+++ b/tests/unit/factory-test.js
@@ -104,3 +104,73 @@ test('it can reuse dynamic properties', function(assert) {
   assert.deepEqual(baz1, {foo: 5, bar: 10});
   assert.deepEqual(baz2, {foo: 10, bar: 20});
 });
+
+test('it can reference properties out of order', function(assert) {
+  var BazFactory = Mirage.Factory.extend({
+    bar: function() {
+      return this.foo + 2;
+    },
+
+    baz: 6,
+
+    foo: function(i) {
+      return this.baz * i;
+    }
+  });
+
+  var b = new BazFactory();
+  var baz1 = b.build(1);
+  var baz2 = b.build(2);
+
+  assert.deepEqual(baz1, {baz: 6, foo: 6, bar: 8});
+  assert.deepEqual(baz2, {baz: 6, foo: 12, bar: 14});
+});
+
+test('it can reference properties on complex object', function(assert) {
+  var AbcFactory = Mirage.Factory.extend({
+    a: function(i) {
+      return this.b + i;
+    },
+    b: function() {
+      return this.c + 1;
+    },
+    c: function() {
+      return this.f + 1;
+    },
+    d: function(i) {
+      return this.e + i;
+    },
+    e: function() {
+      return this.c + 1;
+    },
+    f: 1,
+    g: 2,
+    h: 3,
+  });
+
+  var b = new AbcFactory();
+  var abc1 = b.build(1);
+  var abc2 = b.build(2);
+
+  assert.deepEqual(abc1, {a: 4, b: 3, c: 2, d: 4, e: 3, f: 1, g: 2, h: 3});
+  assert.deepEqual(abc2, {a: 5, b: 3, c: 2, d: 5, e: 3, f: 1, g: 2, h: 3});
+});
+
+test('throws meaningfull exception on circular reference', function(assert) {
+  var BazFactory = Mirage.Factory.extend({
+    bar: function() {
+      return this.foo;
+    },
+
+    foo: function(i) {
+      return this.bar;
+    }
+  });
+
+  var b = new BazFactory();
+  assert.throws(function() {
+    b.build(1);
+  }, function(e) {
+    return e.toString() === 'Error: Cyclic dependency in properties ["bar","foo"]';
+  });
+});

--- a/tests/unit/factory-test.js
+++ b/tests/unit/factory-test.js
@@ -70,3 +70,37 @@ test('it can use sequences', function(assert) {
   assert.deepEqual(post1, {likes: 5});
   assert.deepEqual(post2, {likes: 10});
 });
+
+test('it can reuse static properties', function(assert) {
+  var BazFactory = Mirage.Factory.extend({
+    foo: 5,
+    bar: function(i) {
+      return this.foo * i;
+    }
+  });
+
+  var b = new BazFactory();
+  var baz1 = b.build(1);
+  var baz2 = b.build(2);
+
+  assert.deepEqual(baz1, {foo: 5, bar: 5});
+  assert.deepEqual(baz2, {foo: 5, bar: 10});
+});
+
+test('it can reuse dynamic properties', function(assert) {
+  var BazFactory = Mirage.Factory.extend({
+    foo: function(i) {
+      return 5*i;
+    },
+    bar: function() {
+      return this.foo * 2;
+    }
+  });
+
+  var b = new BazFactory();
+  var baz1 = b.build(1);
+  var baz2 = b.build(2);
+
+  assert.deepEqual(baz1, {foo: 5, bar: 10});
+  assert.deepEqual(baz2, {foo: 10, bar: 20});
+});

--- a/tests/unit/factory-test.js
+++ b/tests/unit/factory-test.js
@@ -126,6 +126,50 @@ test('it can reference properties out of order', function(assert) {
   assert.deepEqual(baz2, {baz: 6, foo: 12, bar: 14});
 });
 
+test('it can reference multiple properties in any order', function(assert) {
+  var FooFactory = Mirage.Factory.extend({
+    foo: function() {
+      return this.bar + this.baz;
+    },
+
+    bar: 6,
+
+    baz: 10
+  });
+
+  var BarFactory = Mirage.Factory.extend({
+    bar: 6,
+
+    foo: function() {
+      return this.bar + this.baz;
+    },
+
+    baz: 10
+  });
+
+  var BazFactory = Mirage.Factory.extend({
+    bar: 6,
+
+    baz: 10,
+
+    foo: function() {
+      return this.bar + this.baz;
+    }
+  });
+
+  var Foo = new FooFactory();
+  var Bar = new BarFactory();
+  var Baz = new BazFactory();
+
+  var foo = Foo.build(1);
+  var bar = Bar.build(1);
+  var baz = Baz.build(1);
+
+  assert.deepEqual(foo, {foo: 16, bar: 6, baz: 10});
+  assert.deepEqual(bar, {foo: 16, bar: 6, baz: 10});
+  assert.deepEqual(baz, {foo: 16, bar: 6, baz: 10});
+});
+
 test('it can reference properties on complex object', function(assert) {
   var AbcFactory = Mirage.Factory.extend({
     a: function(i) {

--- a/tests/unit/reference-sort-test.js
+++ b/tests/unit/reference-sort-test.js
@@ -1,0 +1,38 @@
+import referenceSort from 'ember-cli-mirage/utils/reference-sort';
+import {module, test} from 'qunit';
+
+module('mirage:reference-sort');
+
+test('it sorts property references', function(assert) {
+  var sorted = referenceSort([
+    ['propB', 'propC'],
+    ['propC', 'propA'],
+    ['propA'],
+    ['propD']
+  ]);
+
+  assert.deepEqual(sorted, ['propB', 'propC', 'propA', 'propD']);
+});
+
+test('it throws on circular dependency', function(assert) {
+  assert.throws(function () {
+    referenceSort([
+      ['propA', 'propB'],
+      ['propB', 'propA'],
+    ]);
+  }, function(e) {
+    return e.toString() === 'Error: Cyclic dependency in properties ["propB","propA"]';
+  });
+
+});
+
+test('it works with no references', function(assert) {
+  var sorted = referenceSort([
+    ['propA'],
+    ['propB'],
+    ['propC'],
+    ['propD']
+  ]);
+
+  assert.deepEqual(sorted, ['propA', 'propB', 'propC', 'propD']);
+});

--- a/tests/unit/reference-sort-test.js
+++ b/tests/unit/reference-sort-test.js
@@ -5,13 +5,13 @@ module('mirage:reference-sort');
 
 test('it sorts property references', function(assert) {
   var sorted = referenceSort([
+    ['propA'],
     ['propB', 'propC'],
     ['propC', 'propA'],
-    ['propA'],
     ['propD']
   ]);
 
-  assert.deepEqual(sorted, ['propB', 'propC', 'propA', 'propD']);
+  assert.deepEqual(sorted, ['propD', 'propA', 'propC', 'propB']);
 });
 
 test('it throws on circular dependency', function(assert) {
@@ -34,5 +34,5 @@ test('it works with no references', function(assert) {
     ['propD']
   ]);
 
-  assert.deepEqual(sorted, ['propA', 'propB', 'propC', 'propD']);
+  assert.deepEqual(sorted, ['propD', 'propC', 'propB', 'propA']);
 });


### PR DESCRIPTION
This PR lets you reference dynamic attributes from different dynamic attributes.


Currently you are able to reference static attributes from dynamic ones like so:
```js
// mirage/factories/user.js
import Mirage from 'ember-cli-mirage';

export default Mirage.Factory.extend({
  age: 18,
  is_admin: function(i) {
    return this.age > 30;
  }
});
```

but I also want to be able to reference dynamic attributes from dynamic attributes like so:
```js
// mirage/factories/user.js
import Mirage from 'ember-cli-mirage';

export default Mirage.Factory.extend({
  year_of_birth() {
    return faker.random.number({ min: 1900, max: 2000 });
  },
  year_of_death() {
    return faker.random.number({ min: this.year_of_birth, max: this.year_of_birth + 90 });
  }
});
```

That is now possible. I also made sure it does not matter in what order you specify the properties, so it also works for:
```js
// mirage/factories/contact.js
import Mirage from 'ember-cli-mirage';

export default Mirage.Factory.extend({
  year_of_death() { // I reference a property that is not yet set up, but don't worry, it'll still work!
    return faker.random.number({ min: this.year_of_birth, max: this.year_of_birth + 90 });
  },
  year_of_birth() {
    return faker.random.number({ min: 1900, max: 2000 });
  }
});
```

What *(obviously)* does not work is referencing `propA` from `propB` and `propB` from `propA`. If the user tries to attempt such a mad thing, he will get a nice and helpful. `Cyclic dependency in properties ["propA", "propB"]'` error thrown.

I also wanted to update the docs but they don't seem to be open source, is this correct?