### PR TITLE
Fix WHERE db method example

### DIFF
--- a/docs/v0.1.x/database.md
+++ b/docs/v0.1.x/database.md
@@ -64,7 +64,7 @@ Returns an array of models from *collection* that match the key-value pairs in t
   Given users = [{id: 1, name: 'Link'}, {id: 2, name: 'Zelda'}]
 */
 
-db.users.where({name: 'Zelda'}); // [{id: 2, name: 'Link'}]
+db.users.where({name: 'Zelda'}); // [{id: 2, name: 'Zelda'}]
 ```
 
 <a name="update" href="#update">#</a> db.collection.<b>update</b>(<i>attrs</i>) or db.collection.<b>update</b>(<i>target</i>, <i>attrs</i>)


### PR DESCRIPTION
The db.users.where clause was not returning an existing user in the db according to the 'Givens'. We want the documentation to match the 'Given' users for a clear example.