### PR TITLE
WIP intercept OPTIONS requests

### DIFF
--- a/addon/controller.js
+++ b/addon/controller.js
@@ -11,7 +11,8 @@ var defaultCodes = {
   get: 200,
   put: 204,
   post: 201,
-  'delete': 204
+  'delete': 204,
+  'options': 200
 };
 
 export default class Controller {

--- a/addon/server.js
+++ b/addon/server.js
@@ -69,7 +69,7 @@ export default class Server {
   stub(verb, path, handler, code, options) {
     var _this = this;
     path = path[0] === '/' ? path.slice(1) : path;
-
+    // debugger;
     this.interceptor[verb].call(this.interceptor, this._getFullPath(path), function(request) {
       var response = _this.controller.handle(verb, handler, (_this.schema || _this.db), request, code, options);
       var shouldLog = typeof _this.logging !== 'undefined' ? _this.logging : (_this.environment !== 'test');
@@ -142,7 +142,7 @@ export default class Server {
   _setupStubAliases() {
     var _this = this;
 
-    [['get'], ['post'], ['put'], ['delete', 'del'], ['patch']].forEach(function(names) {
+    [['get'], ['post'], ['put'], ['delete', 'del'], ['patch'], ['options']].forEach(function(names) {
       var verb = names[0];
       var alias = names[1];
 

--- a/tests/integration/http-verbs-test.js
+++ b/tests/integration/http-verbs-test.js
@@ -98,3 +98,20 @@ test('mirage responds to patch', function(assert) {
     done();
   });
 });
+
+test('mirage responds to options', function(assert) {
+  assert.expect(1);
+  var done = assert.async();
+
+  this.server.options('/contacts', function() {
+    return true;
+  });
+
+  $.ajax({
+    method: 'OPTIONS',
+    url: '/contacts'
+  }).done(function(res) {
+    assert.ok(res);
+    done();
+  });
+});


### PR DESCRIPTION
This could be pretty fringe, or even something I'm doing wrong on my app... I had the same problem before using Mirage, and had to add a hack route to fix it, which is a smell in itself. I don't have any other leads though, hence the hack. 

This is trying to fix the following error:

```
OPTIONS http://localhost:3000/me net::ERR_CONNECTION_REFUSED
```

For this stub:

```
this.get('/me', function(db, request) {
    let me = db.mes[0];

    return {
      data: {
        type: 'me',
        id: me.id,
        attributes: me
      }
    };
  });
```

On the backend, the current work around is:

```
match 'proposals/:id', to: 'proposals#index', via: [:options]
```

The code that triggers the calls to `/me` is the following custom (simple auth) session:

```
export default Session.extend({
  me: function() {
    var accessToken = this.get('secure.access_token');

    if (!Ember.isEmpty(accessToken)) {
      return PromiseObject.create({
        promise: this.container.lookup('service:me').find({}) //ember-jsonapi-resources, not ED
      });
    }
  }.property('secure.access_token')
});
```

In the patch submitted here, I'm stuck at [this.interceptor[verb]](https://github.com/samselikoff/ember-cli-mirage/compare/master...oliverbarnes:add-options-method?expand=1#diff-3da129bcd0b0367d1b65b28e9ecc34c9R73) coming through as undefined, though it seems like `this.interceptor['options']` should be set.

Please let me know if this doesn't make sense :)