### PR TITLE
Shutdown the pretender server on destroyApp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+Update notes:
+  - We now use `destroyApp` test helper in Ember-CLI to shutdown the Mirage server
+  after each test to resolve a memory leak reported in #226. It's important to run
+  `ember g ember-cli-mirage` when upgrading to take advantage of this fix.
+
 Changes:
   - [BREAKING CHANGE] missing routes will now throw an Error instead of logging
     to the Logger's `error` channel.

--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -3,6 +3,9 @@
 'use strict';
 
 var path = require('path');
+var existsSync = require('exists-sync');
+var chalk = require('chalk');
+var EOL = require('os').EOL;
 
 module.exports = {
   normalizeEntityName: function() {
@@ -33,6 +36,23 @@ module.exports = {
     this.insertIntoFile('tests/.jshintrc', '    "server",', {
       after: '"predef": [\n'
     });
+
+    if (existsSync('tests/helpers/destroy-app.js')) {
+      this.insertIntoFile('tests/helpers/destroy-app.js', '  server.shutdown();', {
+        after: "Ember.run(application, 'destroy');\n"
+      });
+    } else {
+      this.ui.writeLine(
+        EOL +
+        chalk.yellow(
+          '******************************************************' + EOL +
+          'destroy-app.js helper is not present. Please read this' + EOL +
+          'https://gist.github.com/blimmer/35d3efbb64563029505a'   + EOL +
+          'to see how to fix the problem.'                         + EOL +
+          '******************************************************' + EOL
+        )
+      );
+    }
 
     return this.addPackagesToProject([
       { name: 'ember-lodash', target: '0.0.5' }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "broccoli-unwatched-tree": "^0.1.1",
     "ember-cli-babel": "^5.1.3",
     "ember-lodash": "0.0.6",
-    "ember-inflector": "^1.9.2"
+    "ember-inflector": "^1.9.2",
+    "chalk": "^1.1.1",
+    "exists-sync": "0.0.3"
   }
 }


### PR DESCRIPTION
Ember-CLI 1.13.9 and beyond will have a destroy-app helper that we can shutdown the server in.
This patch automatically inserts this behavior, or shows a message if the user doesn't have a destroy-app helper explaining how to fix the problem.
Fixes #226.