### PR TITLE
Avoid deprecation warning in Ember.js 2.1

### DIFF
--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -11,7 +11,11 @@ function hasModulesOfType(modulesMap, type) {
 
 export default {
   name: 'ember-cli-mirage',
-  initialize: function(container, application) {
+  initialize: function(application) {
+    if (arguments.length > 1) { // Ember < 2.1
+      var container = arguments[0],
+          application = arguments[1];
+    }
     var env = ENV.environment;
 
     if (_shouldUseMirage(env, ENV['ember-cli-mirage'])) {


### PR DESCRIPTION
Ember 2.1 introduces the following deprecation message:

https://github.com/emberjs/ember.js/blob/master/packages/ember-application/lib/system/application.js#L607

This avoids that message in a backward compatible manner.