### PR TITLE
(Docs) Function declarations should not be followed by semi-colons

### DIFF
--- a/docs/v0.1.x/manually-starting-mirage.md
+++ b/docs/v0.1.x/manually-starting-mirage.md
@@ -13,7 +13,7 @@ import mirageInitializer from '../../initializers/ember-cli-mirage';
 
 export default function setupMirage(container) {
   mirageInitializer.initialize(container);
-};
+}
 ```
 
 Then, add the following to any test where you want Mirage to initialize:


### PR DESCRIPTION
This caused my jshint to warn me when I dropped it into my app.
The [spec](http://ecma262-5.com/ELS5_HTML.htm#Section_13) to back this up.