### PR TITLE
[FEATURE] `DbCollection#firstOrCreate`

### DIFF
--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -76,6 +76,20 @@ class DbCollection {
     return records.map( r => stringify(r) );
   }
 
+  firstOrCreate(query, attributesForNew={}) {
+    let queryResult = this.where(query);
+    let record = queryResult[0];
+
+    if (record) {
+      return record;
+    } else {
+      let mergedAttributes = _.assign(attributesForNew, query);
+      let createdRecord = this.insert(mergedAttributes);
+
+      return createdRecord;
+    }
+  }
+
   update(target, attrs) {
     let records;
 

--- a/addon/db.js
+++ b/addon/db.js
@@ -27,7 +27,7 @@ class Db {
         get() {
           var recordsCopy = newCollection.all();
 
-          ['insert', 'find', 'where', 'update', 'remove']
+          ['insert', 'find', 'where', 'update', 'remove', 'firstOrCreate']
             .forEach(function(method) {
               recordsCopy[method] = newCollection[method].bind(newCollection);
             });

--- a/tests/unit/db-test.js
+++ b/tests/unit/db-test.js
@@ -442,3 +442,40 @@ test('it can add a record after removing all records', function(assert) {
     {id: 1, name: 'Foo'}
   ]);
 });
+
+module('Unit | Db #firstOrCreate', {
+  beforeEach() {
+    db = new Db();
+    db.createCollection('contacts');
+    db.contacts.insert([
+      {id: 1, name: 'Link', evil: false},
+      {id: 2, name: 'Zelda', evil: false},
+      {id: 3, name: 'Ganon', evil: true},
+    ]);
+  },
+
+  afterEach() {
+    db.emptyData();
+  }
+});
+
+test('it can find the first record available from the query', function(assert) {
+  let record = db.contacts.firstOrCreate({ name: 'Link' });
+
+  assert.deepEqual(record, { id: 1, name: 'Link', evil: false });
+});
+
+test('it creates a new record from query + attrs if none found', function(assert) {
+  let record = db.contacts.firstOrCreate({ name: 'Mario' }, { evil: false });
+
+  assert.equal(record.name, 'Mario');
+  assert.equal(record.evil, false);
+  assert.ok(record.id);
+});
+
+test('does not require attrs', function(assert) {
+  let record = db.contacts.firstOrCreate({ name: 'Luigi' });
+
+  assert.equal(record.name, 'Luigi');
+  assert.ok(record.id);
+});


### PR DESCRIPTION
A common pattern I was seeing in our Mirage config was the need to
either find the first record matching a certain query, or to create it.
This change introduce `DbCollection#firstOrCreate`. It returns the first
record that matches a query, or creates it if need be.