### PR TITLE
Update Pretender version to ~0.10.1

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -33,7 +33,7 @@ module.exports = {
     });
 
     return this.addBowerPackagesToProject([
-      {name: 'pretender', target: '~0.9.0'},
+      {name: 'pretender', target: '~0.10.1'},
       {name: 'lodash', target: '~3.7.0'},
       {name: 'Faker', target: '~3.0.0'}
     ]);


### PR DESCRIPTION
Changes from version 0.9 include better synchronous xhr support, some fixes for content-type header and event firing on `passthrough`'d requests, better error messages.

See the changes from Pretender 0.10.0 -> 0.10.1 [here](https://github.com/pretenderjs/pretender/blob/master/CHANGELOG.md).