### PR TITLE
Feature: Extended factory type is parent type

### DIFF
--- a/addon/factory.js
+++ b/addon/factory.js
@@ -20,7 +20,6 @@ var Factory = function() {
 Factory.extend = function(attrs) {
   // Merge the new attributes with existing ones. If conflict, new ones win.
   var newAttrs = _.assign({}, this.attrs, attrs);
-
   var Subclass = function() {
     this.attrs = newAttrs;
     Factory.call(this);

--- a/addon/server.js
+++ b/addon/server.js
@@ -125,7 +125,7 @@ export default class Server {
 
   create(type, overrides, options) {
     var declaredType = type;
-    var options = options || {};
+    options = options || {};
 
     if (options['as']){
       type = options['as'];
@@ -146,7 +146,7 @@ export default class Server {
   }
 
   createList(type, amount, overrides, options) {
-    var options = options || {};
+    options = options || {};
     var list = [];
 
     for (var i = 0; i < amount; i++) {

--- a/addon/server.js
+++ b/addon/server.js
@@ -123,14 +123,21 @@ export default class Server {
     });
   }
 
-  create(type, overrides) {
+  create(type, overrides, options) {
+    var declaredType = type;
+    var options = options || {};
+
+    if (options['as']){
+      type = options['as'];
+    }
+
     var collection = pluralize(type);
     var currentRecords = this.db[collection];
     var sequence = currentRecords ? currentRecords.length: 0;
     if (!this._factoryMap || !this._factoryMap[type]) {
       throw "You're trying to create a " + type + ", but no factory for this type was found";
     }
-    var OriginalFactory = this._factoryMap[type];
+    var OriginalFactory = this._factoryMap[declaredType];
     var Factory = OriginalFactory.extend(overrides);
     var factory = new Factory();
 
@@ -138,11 +145,12 @@ export default class Server {
     return this.db[collection].insert(attrs);
   }
 
-  createList(type, amount, overrides) {
+  createList(type, amount, overrides, options) {
+    var options = options || {};
     var list = [];
 
     for (var i = 0; i < amount; i++) {
-      list.push(this.create(type, overrides));
+      list.push(this.create(type, overrides, options));
     }
 
     return list;

--- a/tests/dummy/app/mirage/factories/car.js
+++ b/tests/dummy/app/mirage/factories/car.js
@@ -1,0 +1,5 @@
+import Mirage from 'ember-cli-mirage';
+
+export default Mirage.Factory.extend({
+  color: 'Blue'
+});

--- a/tests/dummy/app/mirage/factories/dog.js
+++ b/tests/dummy/app/mirage/factories/dog.js
@@ -1,0 +1,6 @@
+import Mirage from 'ember-cli-mirage';
+import Pet from './pet';
+
+export default Pet.extend({
+  animal: 'Dog'
+});

--- a/tests/dummy/app/mirage/factories/dog.js
+++ b/tests/dummy/app/mirage/factories/dog.js
@@ -1,4 +1,3 @@
-import Mirage from 'ember-cli-mirage';
 import Pet from './pet';
 
 export default Pet.extend({

--- a/tests/dummy/app/mirage/scenarios/default.js
+++ b/tests/dummy/app/mirage/scenarios/default.js
@@ -9,6 +9,6 @@ export default function(server) {
   server.create('friend', {name: 'Joe', age: 10, is_young: true});
   server.create('friend', {name: 'Bob', age: 80, is_young: false});
 
-  server.createList('dog', 4, {}, { as: 'pet' })
-  server.create('dog', { name: 'Sauron' }, { as: 'pet' })
+  server.createList('dog', 4, {}, { as: 'pet' });
+  server.create('dog', { name: 'Sauron' }, { as: 'pet' });
 }

--- a/tests/dummy/app/mirage/scenarios/default.js
+++ b/tests/dummy/app/mirage/scenarios/default.js
@@ -8,4 +8,7 @@ export default function(server) {
 
   server.create('friend', {name: 'Joe', age: 10, is_young: true});
   server.create('friend', {name: 'Bob', age: 80, is_young: false});
+
+  server.createList('dog', 4, {}, { as: 'pet' })
+  server.create('dog', { name: 'Sauron' }, { as: 'pet' })
 }

--- a/tests/dummy/app/models/pet.js
+++ b/tests/dummy/app/models/pet.js
@@ -2,5 +2,6 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   name: DS.attr('string'),
-  alive: DS.attr('boolean')
+  alive: DS.attr('boolean'),
+  animal: DS.attr('string')
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function() {
   this.route('friends');
   this.route('friend', { path: '/friends/:friend_id'});
   this.route('close-friends');
+  this.route('pets');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/pets.js
+++ b/tests/dummy/app/routes/pets.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+  model() {
+    return this.store.findAll('pet');
+  },
+
+});

--- a/tests/dummy/app/templates/pets.hbs
+++ b/tests/dummy/app/templates/pets.hbs
@@ -1,0 +1,8 @@
+Pets:
+<hr/>
+{{#each model as |pet|}}
+  <div>
+    Name: {{pet.name}}, Animal: {{pet.animal}}
+  </div>
+  <br/>
+{{/each}}


### PR DESCRIPTION
To start, let me say that I'm a rails developer learning Ember and JS (also my first OS contribution attempt), so the code I've written could be terrible, please feel free to let me know :).

I wanted to be able to create extended factories which would still be saved in the DB as the parent type.  For example, if I'm on the '/pets' route, I'd like to be able to have factories 'cat' and 'dog' in order to make difference types of pets in my scenario, which would still end up in the 'pet' collection.

If this is a bad idea, cool, if its a good idea with bad implementation, cool, let me know what I should do and I'll fix it.  I'd prefer to write some tests as well but it wasn't super obvious to me where the factory tests should belong.  Thanks!