### PR TITLE
Remove usage of lodash global

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -1,8 +1,9 @@
-/* global _ */
 import extend from '../utils/extend';
 import { dasherize, pluralize } from '../utils/inflector';
 import Model from 'ember-cli-mirage/orm/model';
 import Collection from 'ember-cli-mirage/orm/collection';
+
+import _assign from 'lodash/object/assign';
 
 class JsonApiSerializer {
 
@@ -139,7 +140,7 @@ class JsonApiSerializer {
         return memo;
       }, {});
     } else {
-      attrs = _.assign(attrs, model.attrs);
+      attrs = _assign(attrs, model.attrs);
     }
 
     delete attrs.id;


### PR DESCRIPTION
This one was added in between merging [my other PR](https://github.com/samselikoff/ember-cli-mirage/pull/273) and will fail since the lodash package is no longer included