### PR TITLE
Extract startMirage from initializer

### DIFF
--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -11,16 +11,20 @@ export default {
       var container = arguments[0],
           application = arguments[1];
     }
-    let environment = ENV.environment;
 
-    if (_shouldUseMirage(environment, ENV['ember-cli-mirage'])) {
-      let modules = readModules(ENV.modulePrefix);
-      let options = _assign(modules, {environment, baseConfig, testConfig})
-
-      new Server(options);
+    if (_shouldUseMirage(ENV.environment, ENV['ember-cli-mirage'])) {
+      startMirage(ENV);
     }
   }
 };
+
+export function startMirage(env = ENV) {
+  let environment = env.environment;
+  let modules = readModules(env.modulePrefix);
+  let options = _assign(modules, {environment, baseConfig, testConfig});
+
+  return new Server(options);
+}
 
 function _shouldUseMirage(env, addonConfig) {
   let userDeclaredEnabled = typeof addonConfig.enabled !== 'undefined';

--- a/tests/acceptance/manually-starting-test.js
+++ b/tests/acceptance/manually-starting-test.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import {module, test} from 'qunit';
+import startApp from '../helpers/start-app';
+import { startMirage } from 'dummy/initializers/ember-cli-mirage';
+import ENV from 'dummy/config/environment';
+
+let App;
+
+module('Acceptance: Manually starting Mirage', {
+  beforeEach: function() {
+    ENV['ember-cli-mirage'] = { enabled: false };
+    App = startApp();
+  },
+
+  afterEach: function() {
+    server.shutdown();
+    Ember.run(App, 'destroy');
+    ENV['ember-cli-mirage'] = undefined;
+  }
+});
+
+test("The server can be started manually when configured with { enabled: false }", function(assert) {
+  assert.equal(window.server, undefined, 'There is no server at first');
+  startMirage();
+  assert.ok(window.server, 'There is a server after starting');
+
+  let contact = server.create('contact');
+  visit('/1');
+
+  andThen(function() {
+    assert.equal(currentRouteName(), 'contact');
+    assert.equal(find('p:first').text(), 'The contact is ' + contact.name, 'The manually started server works');
+  });
+});


### PR DESCRIPTION
Even though this was partially resolved in https://github.com/samselikoff/ember-cli-mirage/issues/183, I had a situation where I only wanted to start Mirage in specific tests as it was being introduced to a project.

Let me know what you think:
  * Is there a better place to put `startMirage` rather than in the initializer file?
  * Is `startMirage` a good name?
  * Any other testing approaches?

Once this is resolved I'd be happy to update the cookbook documentation as well.
