### PR TITLE
Throw an Error when Mirage route is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Ember CLI Mirage Changelog
 
+Changes:
+
+  - [BREAKING CHANGE] missing routes will now throw an Error instead of logging
+    to the Logger's `error` channel.
+
 ## 0.1.9
 
 Update notes:
@@ -42,12 +47,12 @@ Changes:
 
 Update notes:
   - If you happened to be manipulating db objects using object references instead of the db API, e.g.
-  
+
     ```
     let contact = db.contacts.find(1);
     contact.name = 'Gandalf';
     ```
-  
+
     this will no longer work, as the db query methods now return copies of db data. This was considered a private API. You'll need to use the db api (e.g. `db.update`) to make changes to db data.
 
 Changes:
@@ -70,7 +75,7 @@ Changes:
 Update notes:
   - If you run the generator to update deps, the blueprint will put a file under `/scenarios/default.js`. The presence of this file will mean your fixtures will be ignored during development. If you'd still like to use your fixtures, delete the `/scenarios` directory.
 
-Changes: 
+Changes:
   - [IMPROVEMENT] factory-focused initial blueprints
 
 ## 0.1.3
@@ -181,9 +186,9 @@ Change:
 Update notes:
   - Rename your `/app/mirage/data` directory to `/app/mirage/fixtures`.
   - Move your `/tests/factories` directory to `/app/mirage/factories`.
-  - `store`, the data cache your routes interact with, has been renamed to `db` and its API has changed. 
+  - `store`, the data cache your routes interact with, has been renamed to `db` and its API has changed.
 
-    Your shorthand routes should not be affected, but you'll need to update any routes where you passed in a function and interacted with the store.See [the wiki entry](../../wiki/Database) for more details, and the new API. 
+    Your shorthand routes should not be affected, but you'll need to update any routes where you passed in a function and interacted with the store.See [the wiki entry](../../wiki/Database) for more details, and the new API.
 
 Changes:
 
@@ -191,7 +196,7 @@ Changes:
  - [BREAKING CHANGE] Move `/tests/factories` directory to `app/mirage/factories`
  - #41 [BREAKING CHANGE] Renamed `store` to `db`, and changed API. See [the wiki entry](../../wiki/Database).
  - #42 [ENHANCEMENT] Add ability to change timing within tests, e.g. to test the UI on long delays.
- - #6 [ENHANCEMENT] Add ability to force an error response from a route. 
+ - #6 [ENHANCEMENT] Add ability to force an error response from a route.
  - [ENHANCEMENT] Return POJO from route
  - [BUGFIX] ignore assets if Mirage isn't being used
 

--- a/addon/server.js
+++ b/addon/server.js
@@ -35,7 +35,7 @@ export default class Server {
 
       this.unhandledRequest = function(verb, path) {
         path = decodeURI(path);
-        console.error("Mirage: Your Ember app tried to " + verb + " '" + path +
+        throw new Error("Mirage: Your Ember app tried to " + verb + " '" + path +
                       "', but there was no route defined to handle this " +
                       "request. Define a route that matches this path in your " +
                       "mirage/config.js file. Did you forget to add your namespace?");


### PR DESCRIPTION
While TDDing, test failure feedback is very important. We prefer loud
failures of quiet ones.

Unfortunately, `console.log` won't cause a test failure while running
`ember test --serve`. If a Mirage route is undefined, tests tend to
hang.

Upon further investigation in a UI-backed browser like Chrome or
Firefox, the `console.log` message is visible.

This feedback is still useful, but we'd prefer to see it in the console,
without having to resort to a visual browser.