### PR TITLE
remove dev dependency on es5-shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ Ember CLI Mirage may be for you! It lets you create a client-side server using [
 ```sh
 ember install ember-cli-mirage  # install:addon for Ember CLI < 0.2.3
 ```
-### Requirements
-
-If you are using a version of PhantomJS before 2.0, ensure you have [ember-cli-es5-shim](https://github.com/pixelhandler/ember-cli-es5-shim) installed in your app because Mirage uses `.bind`.
 
 ## Updating
 

--- a/addon/db.js
+++ b/addon/db.js
@@ -29,7 +29,9 @@ class Db {
 
           ['insert', 'find', 'where', 'update', 'remove', 'firstOrCreate']
             .forEach(function(method) {
-              recordsCopy[method] = newCollection[method].bind(newCollection);
+              recordsCopy[method] = function () {
+                return newCollection[method](...arguments);
+              };
             });
 
           return recordsCopy;

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -61,11 +61,11 @@ export default function(db) {
 
     // Create the entity methods
     this[type] = {
-      new: this.new.bind(this, type),
-      create: this.create.bind(this, type),
-      all: this.all.bind(this, type),
-      find: this.find.bind(this, type),
-      where: this.where.bind(this, type)
+      new: (attrs) => this.new(type, attrs),
+      create: (attrs) => this.create(type, attrs),
+      all: (attrs) => this.all(type, attrs),
+      find: (attrs) => this.find(type, attrs),
+      where: (attrs) => this.where(type, attrs)
     };
 
     return this;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,7 +2,6 @@
 /* global require, module */
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
-var pickFiles = require('broccoli-static-compiler');
 var path = require('path');
 
 
@@ -21,11 +20,5 @@ module.exports = function(defaults) {
     }
   });
 
-  var es5Shim = pickFiles('node_modules/es5-shim', {
-    srcDir: '/',
-    files: ['es5-shim.js'],
-    destDir: '/assets'
-  });
-
-  return app.toTree([es5Shim]);
+  return app.toTree();
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "active-model-adapter": "1.13.6",
     "broccoli-asset-rev": "^2.1.2",
-    "broccoli-static-compiler": "^0.2.1",
     "chai": "2.0.0",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
@@ -46,7 +45,6 @@
     "ember-export-application-global": "^1.0.3",
     "ember-lodash": "0.0.5",
     "ember-try": "0.0.6",
-    "es5-shim": "^4.1.5",
     "mocha": "^2.1.0"
   },
   "keywords": [

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,7 +21,6 @@
 
     {{content-for 'body'}}
     {{content-for 'test-body'}}
-    <script src="assets/es5-shim.js"></script>
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>


### PR DESCRIPTION
Removing usage of `function.prototype.bind` means we can get rid of es5-shim.