### PR TITLE
Make lodash a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-lodash": "0.0.5",
     "ember-try": "0.0.6",
     "mocha": "^2.1.0"
   },
@@ -62,6 +61,7 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-unwatched-tree": "^0.1.1",
     "ember-cli-babel": "^5.1.3",
+    "ember-lodash": "0.0.5",
     "ember-inflector": "^1.9.2"
   }
 }


### PR DESCRIPTION
ember-lodash is always needed -- not just when ember-cli-mirage is under development.