### PR TITLE
Apply serializer to any array of Model

### DIFF
--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -238,7 +238,7 @@ export default class SerializerRegistry {
   }
 
   _isCollection(object) {
-    return object instanceof Collection;
+    return object instanceof Collection || (_isArray(object) && this._isModel(object[0]));
   }
 
   _isModelOrCollection(object) {

--- a/tests/integration/serializers/base/serialize-array-of-models-test.js
+++ b/tests/integration/serializers/base/serialize-array-of-models-test.js
@@ -1,0 +1,30 @@
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+import Serializer from 'ember-cli-mirage/serializer';
+import schemaHelper from '../schema-helper';
+import { module, test } from 'qunit';
+
+module('Integration | Serializers | Base | Array of Models', {
+  beforeEach() {
+    this.schema = schemaHelper.setup();
+    this.schema.wordSmith.create({ id: 1, title: 'Link' });
+  },
+  afterEach() {
+    this.schema.db.emptyData();
+  }
+});
+
+test(`it applies correct serializer when the response is an array of models`, function(assert) {
+  assert.expect(1);
+
+  let wordSmiths = this.schema.wordSmith.all().filter(() => true);
+  let registry = new SerializerRegistry(this.schema, {
+    wordSmith: Serializer.extend({
+      serialize(response, request) {
+        assert.ok('serializer ran');
+        return {};
+      }
+    })
+  });
+
+  registry.serialize(wordSmiths);
+});


### PR DESCRIPTION
This ensures that we will correctly serialize any array of `Model`. It's helpful because many natural transforms of `Collection` do not result in a new `instanceof Collection`. For example:

    schema.posts.all().filter(post => post.upVotes > 100)

Without this change, an example like the above returns unserialized results.