### PR TITLE
Don't mutate model classes

### DIFF
--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -24,6 +24,9 @@ export default function(db) {
     var _this = this;
     type = camelize(type);
 
+    // Avoid mutating original class, because we may want to reuse it across many tests
+    ModelClass = ModelClass.extend();
+
     // Store model & fks in registry
     this._registry[type] = this._registry[type] || {class: null, foreignKeys: []}; // we may have created this key before, if another model added fks to it
     this._registry[type].class = ModelClass;
@@ -34,7 +37,7 @@ export default function(db) {
     ModelClass.prototype.associationKeys = [];       // ex: address.user, user.addresses
     ModelClass.prototype.associationIdKeys = [];     // ex: address.user_id, user.address_ids. may or may not be a fk.
 
-    Object.keys(ModelClass.prototype).forEach(function(key) {
+    for (var key in ModelClass.prototype) {
       if (ModelClass.prototype[key] instanceof Association) {
         var association = ModelClass.prototype[key];
         var associatedType = association.type || singularize(key);
@@ -51,7 +54,7 @@ export default function(db) {
         // Augment the Model's class with any methods added by this association
         association.addMethodsToModelClass(ModelClass, key, _this);
       }
-    });
+    }
 
     // Create a db collection for this model, if doesn't exist
     var collection = pluralize(type);

--- a/tests/integration/schema/reinitialize-associations-test.js
+++ b/tests/integration/schema/reinitialize-associations-test.js
@@ -1,0 +1,38 @@
+import Mirage from 'ember-cli-mirage';
+import Model from 'ember-cli-mirage/orm/model';
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+import {module, test} from 'qunit';
+
+// Model classes are defined statically, just like in a typical app
+var User = Model.extend({
+  address: Mirage.hasMany()
+});
+var Address = Model.extend();
+
+module('Integration | Schema | reinitialize associations', {
+  beforeEach: function() {
+    this.db = new Db({
+      users: [],
+      addresses: []
+    });
+    this.schema = new Schema(this.db);
+
+    this.schema.registerModels({
+      address: Address,
+      user: User
+    });
+
+    this.schema.user.create({ id: 1, name: 'Link' });
+    this.schema.address.create({ id: 1, country: 'Hyrule', userId: 1 });
+  }
+});
+
+// By running two tests, we force the statically-defined classes to be
+// registered twice.
+test('safely initializes associations', function(assert) {
+  assert.equal(this.schema.user.find(1).address[0].country, 'Hyrule');
+});
+test('safely initializes associations again', function(assert) {
+  assert.equal(this.schema.user.find(1).address[0].country, 'Hyrule');
+});


### PR DESCRIPTION
Model classes with associations can only be correctly registered with a Schema once, because the registration process mutates them. This change extends them instead so that we don't mutate the originals.

I needed to switch to `for ... in` instead of `Object.keys` because now we definitely need to walk the prototype chain to find associations. This was probably a separate latent bug, since users can put associations onto ancestor classes.