### PR TITLE
Expose `id` as sequence value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Changes:
   - [BREAKING CHANGE] missing routes will now throw an Error instead of logging
     to the Logger's `error` channel.
   - [BREAKING CHANGE] Move /app/mirage to /mirage
+  - [FEATURE] The `sequence` value in a dynamic attribute's callback is the same
+    value as the record's `id`. [#378]
+
+[#378]: https://github.com/samselikoff/ember-cli-mirage/pull/378
 
 ## 0.1.9
 

--- a/addon/factory.js
+++ b/addon/factory.js
@@ -2,7 +2,7 @@ import _assign from 'lodash/object/assign';
 import _keys from 'lodash/object/keys';
 
 var Factory = function() {
-  this.build = function(sequence) {
+  this.build = function(id) {
     var object = {};
     var attrs = this.attrs || {};
 
@@ -10,7 +10,7 @@ var Factory = function() {
       var type = typeof attrs[key];
 
       if (type === 'function') {
-        object[key] = attrs[key].call(attrs, sequence);
+        object[key] = attrs[key].call(attrs, id);
       } else {
         object[key] = attrs[key];
       }

--- a/addon/server.js
+++ b/addon/server.js
@@ -126,9 +126,11 @@ export default class Server {
   }
 
   create(type, overrides) {
+    overrides = overrides || {};
     var collection = this.schema ? pluralize(camelize(type)) : pluralize(type);
     var currentRecords = this.db[collection];
     var sequence = currentRecords ? currentRecords.length: 0;
+    var id = overrides.id || sequence + 1;
     if (!this._factoryMap || !this._factoryMap[type]) {
       throw "You're trying to create a " + type + ", but no factory for this type was found";
     }
@@ -136,7 +138,7 @@ export default class Server {
     var Factory = OriginalFactory.extend(overrides);
     var factory = new Factory();
 
-    var attrs = factory.build(sequence);
+    var attrs = factory.build(id);
     return this.db[collection].insert(attrs);
   }
 

--- a/addon/server.js
+++ b/addon/server.js
@@ -138,7 +138,7 @@ export default class Server {
     var Factory = OriginalFactory.extend(overrides);
     var factory = new Factory();
 
-    var attrs = factory.build(id);
+    var attrs = factory.build(typeof id === 'string' ? sequence + 1: id);
     return this.db[collection].insert(attrs);
   }
 

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -70,9 +70,7 @@ test('create exposes the new record id', function(assert) {
   });
 
   var contact = server.create('contact', {
-    dynamicAttribute(id) {
-      return id;
-    }
+    dynamicAttribute: id => id,
   });
   var contactRecord = server.db.contacts[0];
 
@@ -84,9 +82,7 @@ test('create exposes the new record id', function(assert) {
 
   var contactWithExplicitId = server.create('contact', {
     id: -100,
-    dynamicAttribute(id) {
-      return id;
-    }
+    dynamicAttribute: id => id,
   });
   var contactWithExplicitIdRecord = server.db.contacts[1];
 
@@ -94,6 +90,23 @@ test('create exposes the new record id', function(assert) {
     contactWithExplicitId.dynamicAttribute,
     contactWithExplicitIdRecord.id,
     'exposes the overridden `id` as the sequence value'
+  );
+
+  var contactWithStringId = server.create('contact', {
+    id: 'abc123',
+    dynamicAttribute: id => id,
+  });
+  var contactWithStringIdRecord = server.db.contacts[2];
+
+  assert.equal(
+    contactWithStringId.id,
+    contactWithStringIdRecord.id,
+    'accepts overriding `id`'
+  );
+  assert.equal(
+    contactWithStringId.dynamicAttribute,
+    server.db.contacts.length,
+    'sequence is always a number'
   );
 });
 

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -64,6 +64,39 @@ test('create fails when an expected factory isn\'t registered', function(assert)
   });
 });
 
+test('create exposes the new record id', function(assert) {
+  server.loadFactories({
+    contact: Factory.extend({name: 'Sam'})
+  });
+
+  var contact = server.create('contact', {
+    dynamicAttribute(id) {
+      return id;
+    }
+  });
+  var contactRecord = server.db.contacts[0];
+
+  assert.equal(
+    contact.dynamicAttribute,
+    contactRecord.id,
+    'exposes the record `id` as the sequence value'
+  );
+
+  var contactWithExplicitId = server.create('contact', {
+    id: -100,
+    dynamicAttribute(id) {
+      return id;
+    }
+  });
+  var contactWithExplicitIdRecord = server.db.contacts[1];
+
+  assert.equal(
+    contactWithExplicitId.dynamicAttribute,
+    contactWithExplicitIdRecord.id,
+    'exposes the overridden `id` as the sequence value'
+  );
+});
+
 test('create adds the data to the db', function(assert) {
   server.loadFactories({
     contact: Factory.extend({name: 'Sam'})
@@ -179,9 +212,9 @@ test('createList respects sequences', function(assert) {
 
   var contacts = server.createList('contact', 3);
 
-  assert.deepEqual(contacts[0], {id: 1, name: 'name0'});
-  assert.deepEqual(contacts[1], {id: 2, name: 'name1'});
-  assert.deepEqual(contacts[2], {id: 3, name: 'name2'});
+  assert.deepEqual(contacts[0], {id: 1, name: 'name1'});
+  assert.deepEqual(contacts[1], {id: 2, name: 'name2'});
+  assert.deepEqual(contacts[2], {id: 3, name: 'name3'});
 });
 
 test('createList respects attr overrides', function(assert) {


### PR DESCRIPTION
Expose `id` as sequence value for records with dynamic attributes
 that depend on the `id` -- like the `links` hash:

```js
export default Mirage.Factory.extend({
  links(id) {
    return {
      posts: `/api/users/${id}/posts`,
    };
  }
});
```

Previously, the `sequence` value was an auto-incrementing value starting
from `0`. ID generation behaved exactly the same, but started from `1`.

This commit changes the sequence to generated exactly the same as the
`id`.

Additionally, in the case of the consumer overriding the `id`, the
sequence value defer to the overriding value:

```js
const author = server.create('user', { id: 100 });

assert.equal(author.links.posts, '/api/users/100/posts');
```