### PR TITLE
Throw Errors instead of `console.error`

### DIFF
--- a/addon/route-handler.js
+++ b/addon/route-handler.js
@@ -60,7 +60,7 @@ export default class RouteHandler {
     try {
       response = handler.handle(request);
     } catch(error) {
-      console.error('Mirage: Your handler for the url ' + request.url + ' threw an error:', error.message, error.stack);
+      throw new Error('Mirage: Your handler for the url ' + request.url + ' threw an error:', error.message, error.stack);
     }
 
     return this._toMirageResponse(response);

--- a/addon/route-handlers/shorthands/delete.js
+++ b/addon/route-handlers/shorthands/delete.js
@@ -17,7 +17,7 @@ export default class DeleteShorthandRouteHandler extends BaseShorthandRouteHandl
     if (dbOrSchema instanceof Db) {
       let db = dbOrSchema;
       if (!db[collection]) {
-        console.error("Mirage: The route handler for " + request.url + " is trying to remove data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
+        throw new Error("Mirage: The route handler for " + request.url + " is trying to remove data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
       }
 
       db[collection].remove(id);
@@ -47,7 +47,7 @@ export default class DeleteShorthandRouteHandler extends BaseShorthandRouteHandl
     if (dbOrSchema instanceof Db) {
       let db = dbOrSchema;
       if (!db[parentCollection]) {
-        console.error("Mirage: The route handler for " + request.url + " is trying to remove data from the " + parentCollection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
+        throw new Error("Mirage: The route handler for " + request.url + " is trying to remove data from the " + parentCollection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
       }
 
       db[parentCollection].remove(id);
@@ -60,7 +60,7 @@ export default class DeleteShorthandRouteHandler extends BaseShorthandRouteHandl
         var collection = pluralize(type);
 
         if (!db[collection]) {
-          console.error("Mirage: The route handler for " + request.url + " is trying to remove data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
+          throw new Error("Mirage: The route handler for " + request.url + " is trying to remove data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
         }
 
         db[collection].remove(query);

--- a/addon/route-handlers/shorthands/get.js
+++ b/addon/route-handlers/shorthands/get.js
@@ -24,7 +24,7 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
       let record;
 
       if (!db[collection]) {
-        console.error("Mirage: The route handler for " + request.url + " is requesting data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
+        throw new Error("Mirage: The route handler for " + request.url + " is requesting data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
       }
 
       if (id) {
@@ -78,7 +78,7 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
         var collection = pluralize(key);
 
         if (!db[collection]) {
-          console.error("Mirage: The route handler for " + request.url + " is requesting data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
+          throw new Error("Mirage: The route handler for " + request.url + " is requesting data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
         }
 
         // There's an owner. Find only related.

--- a/addon/route-handlers/shorthands/post.js
+++ b/addon/route-handlers/shorthands/post.js
@@ -19,7 +19,7 @@ export default class PostShorthandRouteHandler extends BaseShorthandRouteHandler
       let attrs = payload[type];
       let db = dbOrSchema;
       if (!db[collection]) {
-        console.error("Mirage: The route handler for " + request.url + " is trying to insert data into the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
+        throw new Error("Mirage: The route handler for " + request.url + " is trying to insert data into the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
       }
 
       let model = db[collection].insert(attrs);

--- a/addon/route-handlers/shorthands/put.js
+++ b/addon/route-handlers/shorthands/put.js
@@ -18,7 +18,7 @@ export default class PutShorthandRouteHandler extends BaseShorthandRouteHandler 
       let attrs = payload[type];
       let db = dbOrSchema;
       if (!db[collection]) {
-        console.error("Mirage: The route handler for " + request.url + " is trying to modify data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
+        throw new Error("Mirage: The route handler for " + request.url + " is trying to modify data from the " + collection + " collection, but that collection doesn't exist. To create it, create an empty fixture file or factory.");
       }
 
       var data = db[collection].update(id, attrs);


### PR DESCRIPTION
In the same spirit as [#329].

> While TDDing, test failure feedback is very important. We prefer loud
> failures of quiet ones.
>
> Unfortunately, `console.log` won't cause a test failure while running
> `ember test --serve`. If a Mirage route is undefined, tests tend to
> hang.

> Upon further investigation in a UI-backed browser like Chrome or
> Firefox, the `console.log` message is visible.

> This feedback is still useful, but we'd prefer to see it in the
>  console, without having to resort to a visual browser.

[#329]: https://github.com/samselikoff/ember-cli-mirage/pull/329