### PR TITLE
Introduce `afterCreate` hook for Factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes:
   - [BREAKING CHANGE] missing routes will now throw an Error instead of logging
     to the Logger's `error` channel.
   - [BREAKING CHANGE] Move /app/mirage to /mirage
+  - [FEATURE] Introduce `afterCreate` hooks for Factories.
 
 ## 0.1.9
 

--- a/addon/factory.js
+++ b/addon/factory.js
@@ -9,7 +9,9 @@ var Factory = function() {
     _keys(attrs).forEach(function(key) {
       var type = typeof attrs[key];
 
-      if (type === 'function') {
+      if (key === 'afterCreate') {
+        // no op
+      } else if (type === 'function') {
         object[key] = attrs[key].call(attrs, sequence);
       } else {
         object[key] = attrs[key];

--- a/addon/server.js
+++ b/addon/server.js
@@ -11,15 +11,6 @@ import _isArray from 'lodash/lang/isArray';
 import _keys from 'lodash/object/keys';
 import _pick from 'lodash/object/pick';
 
-function extractAfterCreate(attrs) {
-  attrs = attrs || {};
-
-  var hook = attrs.afterCreate || Ember.K;
-  delete attrs.afterCreate;
-
-  return hook;
-}
-
 export default class Server {
 
   constructor(options = {}) {
@@ -147,7 +138,8 @@ export default class Server {
     var OriginalFactory = this._factoryMap[type];
     var originalAttrs = OriginalFactory.attrs || {};
 
-    afterCreates.push(extractAfterCreate(overrides));
+    afterCreates.push(overrides.afterCreate || Ember.K);
+    delete overrides.afterCreate;
 
     var Factory = OriginalFactory.extend(overrides);
     var factory = new Factory();

--- a/tests/unit/factory-test.js
+++ b/tests/unit/factory-test.js
@@ -70,3 +70,22 @@ test('it can use sequences', function(assert) {
   assert.deepEqual(post1, {likes: 5});
   assert.deepEqual(post2, {likes: 10});
 });
+
+test('it skips invoking `afterCreate`', function(assert) {
+  var skipped = true;
+  var PostFactory = Mirage.Factory.extend({
+    afterCreate() {
+      skipped = false;
+    }
+  });
+
+  var factory = new PostFactory();
+  var post = factory.build(0);
+
+  assert.ok(skipped, 'skips invoking `afterCreate`');
+  assert.equal(
+    typeof post.afterCreate,
+    'undefined',
+    'does not build `afterCreate` attribute'
+  );
+});

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -197,3 +197,36 @@ test('createList respects attr overrides', function(assert) {
   assert.deepEqual(links[0], {id: 3, name: 'Link'});
   assert.deepEqual(links[1], {id: 4, name: 'Link'});
 });
+
+test('invokes `afterCreate` hooks', function(assert) {
+  var afterCreateInvocations = 0;
+  var invocationArguments = [];
+  server.loadFactories({
+    post: Factory.extend({
+      title: 'the-title',
+
+      afterCreate(db) {
+        invocationArguments.push(db);
+        afterCreateInvocations++;
+      }
+    }),
+  });
+
+  server.create('post', {
+    afterCreate(db) {
+      invocationArguments.push(db);
+      afterCreateInvocations++;
+    },
+  });
+
+  assert.equal(
+    afterCreateInvocations,
+    2,
+    'calls `afterCreate`s defined in both the factory and the test'
+  );
+  assert.deepEqual(
+    invocationArguments,
+    [server.db, server.db],
+    'invoked with `db` as argument'
+  );
+});


### PR DESCRIPTION
The `afterCreate` hook will be invoked after `server.create` inserts the
record into the DB.

There are two ways to define an `afterCreate` hook:

* In the Factory definition. This will be invoked on each
  `server.create` call:

```js
export default Mirage.Factory.create({
  afterCreate(db) {
    db.posts.update(this.id, {
      links: {
        posts: `/api/authors/${this.id}/posts`,
      },
    });
  },
});
```

* In the overrides passed to the `server.create` call:

```js
server.create('post', {
  afterCreate(db) {
    db.author.insert({ name: 'Tobey Flenderson', post_ids: [this.id] });
  }
});
```