### PR TITLE
fixes issue with quotes when body is string

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -30,7 +30,11 @@ export default class Server {
 
     this.pretender = this.interceptor = new Pretender(function() {
       this.prepareBody = function(body) {
-        return body ? JSON.stringify(body) : '{"error": "not found"}';
+        if (body) {
+          return typeof body !== 'string' ? JSON.stringify(body) : body;
+        } else {
+          return '{"error": "not found"}';
+        }
       };
 
       this.unhandledRequest = function(verb, path) {

--- a/tests/acceptance/custom-handlers-test.js
+++ b/tests/acceptance/custom-handlers-test.js
@@ -39,7 +39,7 @@ test("You can customize the response code of a custom handler passing the code a
   });
 });
 
-test("You can can programatically returns a taylored response by returning a Mirage.Response", function(assert) {
+test("You can can programatically returns a tailored response by returning a Mirage.Response", function(assert) {
   var done = assert.async();
   var request = Ember.$.ajax({
     url: '/pets',

--- a/tests/integration/response-string-test.js
+++ b/tests/integration/response-string-test.js
@@ -1,0 +1,33 @@
+import {module, test} from 'qunit';
+import Server from 'ember-cli-mirage/server';
+import Response from 'ember-cli-mirage/response';
+
+module('Integration | HTTP Verbs', {
+  beforeEach: function() {
+    this.server = new Server({
+      environment: 'development'
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+  },
+  afterEach: function() {
+    this.server.shutdown();
+  }
+});
+
+test('mirage response string is not serialized to string', function(assert) {
+  assert.expect(1);
+  var done = assert.async();
+
+  this.server.get('/contacts', function() {
+    return new Response(200, {'Content-Type': 'text/csv'}, "firstname,lastname\nbob,dylon");
+  });
+
+  $.ajax({
+    method: 'GET',
+    url: '/contacts'
+  }).done(function(res) {
+    assert.equal(res, "firstname,lastname\nbob,dylon");
+    done();
+  });
+});


### PR DESCRIPTION
```javascript
  this.get('/historydata/', function() {
    return new Mirage.Response(200, {'Content-Type': 'text/csv'},"firstname,lastname\nbob,dylon");
  });
```
was being send as `""firstname,lastname\nbob,dylon""` with extra quotes around them, this fixes it 