### PR TITLE
Check if relationship exists before trying to persist

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -178,7 +178,7 @@ class Model {
     Object.keys(this.belongsToAssociations).forEach(key => {
       var association = this.belongsToAssociations[key];
       var parent = this[key];
-      if (parent.isNew()) {
+      if (parent && parent.isNew()) {
         var fk = association.getForeignKey();
         parent.save();
         this.update(fk, parent.id);


### PR DESCRIPTION
When saving a model with a `null` relationship, mirage throws an error. This allows nullable relationships using `Mirage.Model`. I'm not sure how to test this change.