### PR TITLE
Do not reinitialize mirage config during each test

### DIFF
--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -13,7 +13,7 @@ export default {
     }
     let environment = ENV.environment;
 
-    if (_shouldUseMirage(environment, ENV['ember-cli-mirage'])) {
+    if (_shouldUseMirage(environment, ENV['ember-cli-mirage']) && !_isMirageServerRunning(environment)) {
       let modules = readModules(ENV.modulePrefix);
       let options = _assign(modules, {environment, baseConfig, testConfig})
 
@@ -21,6 +21,14 @@ export default {
     }
   }
 };
+
+/*
+ Returns a Boolean specifying if a mirage server is already 
+ configured and running
+*/
+function _isMirageServerRunning(env) {
+  return env === 'test' && window.server;
+}
 
 function _shouldUseMirage(env, addonConfig) {
   let userDeclaredEnabled = typeof addonConfig.enabled !== 'undefined';


### PR DESCRIPTION
During each acceptance test, the initializer creates a new pretender server and adds all the config, even if a `window.server` exists.

Actually, I faced an issue in my work app, where each acceptance test would add a new server with listeners and eventually hang. I am not able to isolate it into a reproduction.

I believe it is okay to skip doing all the work in subsequent tests, after the initializer has booted the mirage server once.