### PR TITLE
Allow nested factory objects

### DIFF
--- a/addon/factory.js
+++ b/addon/factory.js
@@ -1,22 +1,32 @@
 import _assign from 'lodash/object/assign';
-import _keys from 'lodash/object/keys';
+import _isArray from 'lodash/lang/isArray';
+import _isFunction from 'lodash/lang/isFunction';
+import _isPlainObject from 'lodash/lang/isPlainObject';
+import _mapValues from 'lodash/object/mapValues';
 
 var Factory = function() {
   this.build = function(sequence) {
-    var object = {};
-    var attrs = this.attrs || {};
+    const topLevelAttrs = this.attrs || {};
+    let buildAttrs;
+    let buildSingleValue;
 
-    _keys(attrs).forEach(function(key) {
-      var type = typeof attrs[key];
+    buildAttrs = function(attrs) {
+      return _mapValues(attrs, buildSingleValue);
+    };
 
-      if (type === 'function') {
-        object[key] = attrs[key].call(attrs, sequence);
+    buildSingleValue = function(value) {
+      if (_isArray(value)) {
+        return value.map(buildSingleValue);
+      } else if (_isPlainObject(value)) {
+        return buildAttrs(value);
+      } else if (_isFunction(value)) {
+        return value.call(topLevelAttrs, sequence);
       } else {
-        object[key] = attrs[key];
+        return value;
       }
-    });
+    };
 
-    return object;
+    return buildAttrs(topLevelAttrs);
   };
 };
 

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -134,6 +134,44 @@ test('create allows for attr overrides with arrays', function(assert) {
   assert.deepEqual(noname, {id: 3, name: []});
 });
 
+test('create allows for nested attr overrides', function(assert) {
+  server.loadFactories({
+    contact: Factory.extend({
+      address: {
+        streetName: 'Main',
+        streetAddress(i) {
+          return 1000 + i;
+        }
+      }
+    })
+  });
+
+  var contact1 = server.create('contact');
+  var contact2 = server.create('contact');
+
+  assert.deepEqual(contact1, {id: 1, address: {streetName: 'Main', streetAddress: 1000}});
+  assert.deepEqual(contact2, {id: 2, address: {streetName: 'Main', streetAddress: 1001}});
+});
+
+test('create allows for arrays of attr overrides', function(assert) {
+  server.loadFactories({
+    contact: Factory.extend({
+      websites: [
+        'http://example.com',
+        function(i) {
+          return `http://placekitten.com/${320 + i}/${240 + i}`;
+        }
+      ]
+    })
+  });
+
+  var contact1 = server.create('contact');
+  var contact2 = server.create('contact');
+
+  assert.deepEqual(contact1, {id: 1, websites: ['http://example.com', 'http://placekitten.com/320/240']});
+  assert.deepEqual(contact2, {id: 2, websites: ['http://example.com', 'http://placekitten.com/321/241']});
+});
+
 module('Unit | Server #createList', {
   beforeEach: function() {
     server = new Server({environment: 'test'});


### PR DESCRIPTION
Recursively copies nested properties and calls nested functions in the factory definition. Not always as robust as factory relationships. But sometimes your API response format is trivially nested, and this gets ember-cli-mirage to match it quickly. Fixes #206.