### PR TITLE
🎉 Support for `included` query param in JsonApiSerializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ testem.log
 .floo
 _site
 jekyll-tmp
+
+# IDE
+/.idea/
+/*.iml

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -104,6 +104,8 @@ class Model {
       .forEach(function(attr) {
         _this[attr] = attrs[attr];
       });
+
+    return this;
   }
 
 

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -19,7 +19,7 @@ export default class SerializerRegistry {
     return this._serializerFor(payload[Object.keys(payload)[0]]).normalize(payload);
   }
 
-  serialize(response) {
+  serialize(response, request) {
     this.alreadySerialized = {};
 
     if (this._isModelOrCollection(response)) {
@@ -35,14 +35,14 @@ export default class SerializerRegistry {
         and calling serialize.serialize.
       */
       if (serializer instanceof JsonApiSerializer) {
-        return serializer.serialize(response);
+        return serializer.serialize(response, request);
       }
 
       if (serializer.embed) {
         let json;
 
         if (this._isModel(response)) {
-          json = this._serializeModel(response);
+          json = this._serializeModel(response, request);
         } else {
           json = response.reduce((allAttrs, model) => {
             allAttrs.push(this._serializeModel(model));
@@ -55,7 +55,7 @@ export default class SerializerRegistry {
         return this._formatResponse(response, json);
 
       } else {
-        return this._serializeSideloadedModelOrCollection(response);
+        return this._serializeSideloadedModelOrCollection(response, request);
       }
 
     /*

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -2,7 +2,7 @@ import Model from 'ember-cli-mirage/orm/model';
 import Collection from 'ember-cli-mirage/orm/collection';
 import Serializer from 'ember-cli-mirage/serializer';
 import JsonApiSerializer from 'ember-cli-mirage/serializers/json-api-serializer';
-import { pluralize } from './utils/inflector';
+import { pluralize, camelize } from './utils/inflector';
 
 import _assign from 'lodash/object/assign';
 import _isArray from 'lodash/lang/isArray';
@@ -116,7 +116,7 @@ export default class SerializerRegistry {
 
     // Traverse this model's relationships
     serializer.relationships
-      .map(key => model[key])
+      .map(key => model[camelize(key)])
       .forEach(relationship => {
         let relatedModels = this._isModel(relationship) ? [relationship] : relationship;
 
@@ -177,7 +177,7 @@ export default class SerializerRegistry {
 
     if (embedRelatedIds) {
       serializer.relationships
-        .map(key => model[key])
+        .map(key => model[camelize(key)])
         .filter(relatedCollection => this._isCollection(relatedCollection))
         .forEach(relatedCollection => {
           attrs[serializer.keyForRelationshipIds(relatedCollection.type)] = relatedCollection.map(obj => obj.id);
@@ -191,10 +191,10 @@ export default class SerializerRegistry {
     let serializer = this._serializerFor(model);
 
     return serializer.relationships.reduce((attrs, key) => {
-      let relatedAttrs = this._serializeModelOrCollection(model[key]);
+      let relatedAttrs = this._serializeModelOrCollection(model[camelize(key)]);
 
       if (relatedAttrs) {
-        attrs[key] = relatedAttrs;
+        attrs[camelize(key)] = relatedAttrs;
       }
 
       return attrs;

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -115,7 +115,7 @@ export default class SerializerRegistry {
     }
 
     // Traverse this model's relationships
-    serializer.relationships
+    serializer.include
       .map(key => model[camelize(key)])
       .forEach(relationship => {
         let relatedModels = this._isModel(relationship) ? [relationship] : relationship;
@@ -176,7 +176,7 @@ export default class SerializerRegistry {
     }
 
     if (embedRelatedIds) {
-      serializer.relationships
+      serializer.include
         .map(key => model[camelize(key)])
         .filter(relatedCollection => this._isCollection(relatedCollection))
         .forEach(relatedCollection => {
@@ -190,7 +190,7 @@ export default class SerializerRegistry {
   _attrsForRelationships(model) {
     let serializer = this._serializerFor(model);
 
-    return serializer.relationships.reduce((attrs, key) => {
+    return serializer.include.reduce((attrs, key) => {
       let relatedAttrs = this._serializeModelOrCollection(model[camelize(key)]);
 
       if (relatedAttrs) {

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -123,7 +123,7 @@ class Serializer {
 }
 
 // Defaults
-Serializer.prototype.relationships = [];
+Serializer.prototype.include = [];
 Serializer.prototype.root = true;
 Serializer.prototype.embed = false;
 

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -1,7 +1,8 @@
 import Model from './orm/model';
 import _assign from 'lodash/object/assign';
+import _compose from 'lodash/function/compose';
 import extend from './utils/extend';
-import { singularize, pluralize } from './utils/inflector';
+import { singularize, pluralize, camelize } from './utils/inflector';
 
 class Serializer {
 
@@ -25,7 +26,7 @@ class Serializer {
     Used to format the key of a primary collection.
   */
   keyForCollection(type) {
-    return pluralize(this.keyForModel(type));
+    return _compose(camelize, pluralize)(this.keyForModel(type));
   }
 
   /*
@@ -54,7 +55,7 @@ class Serializer {
     }
   */
   keyForRelationship(type) {
-    return pluralize(type);
+    return _compose(camelize, pluralize)(type);
   }
 
   /*

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -1,5 +1,5 @@
 import extend from '../utils/extend';
-import { dasherize, pluralize } from '../utils/inflector';
+import { dasherize, pluralize, camelize } from '../utils/inflector';
 import Model from 'ember-cli-mirage/orm/model';
 import Collection from 'ember-cli-mirage/orm/collection';
 import _assign from 'lodash/object/assign';
@@ -58,7 +58,7 @@ class JsonApiSerializer {
 
     if (serializer.relationships && serializer.relationships.length) {
       serializer.relationships.forEach(type => {
-        let relationship = model[type];
+        let relationship = model[camelize(type)];
 
         if (relationship instanceof Model) {
           this._serializeIncludedModel(relationship);
@@ -93,11 +93,12 @@ class JsonApiSerializer {
 
     if (serializer.relationships && serializer.relationships.length) {
       serializer.relationships.forEach(type => {
-        let relationship = model[type];
+        const camelizedType = camelize(type);
+        let relationship = model[camelizedType];
 
         if (this._isCollection(relationship)) {
           if (!obj.relationships) { obj.relationships = {}; }
-          obj.relationships[type] = {
+          obj.relationships[camelizedType] = {
             data: relationship.map(model => {
               return {
                 type: this.typeKeyForModel(model),
@@ -107,7 +108,7 @@ class JsonApiSerializer {
           };
         } else if (relationship) {
           if (!obj.relationships) { obj.relationships = {}; }
-          obj.relationships[type] = {
+          obj.relationships[camelizedType] = {
             data: {
               type: this.typeKeyForModel(relationship),
               id: relationship.id

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -3,6 +3,7 @@ import { dasherize, pluralize } from '../utils/inflector';
 import Model from 'ember-cli-mirage/orm/model';
 import Collection from 'ember-cli-mirage/orm/collection';
 import _assign from 'lodash/object/assign';
+import _compose from 'lodash/function/compose';
 
 class JsonApiSerializer {
 
@@ -124,7 +125,7 @@ class JsonApiSerializer {
   }
 
   typeKeyForModel(model) {
-    return pluralize(model.type);
+    return _compose(pluralize, dasherize)(model.type);
   }
 
   normalize(json) {

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -93,12 +93,11 @@ class JsonApiSerializer {
 
     if (serializer.relationships && serializer.relationships.length) {
       serializer.relationships.forEach(type => {
-        const camelizedType = camelize(type);
-        let relationship = model[camelizedType];
+        let relationship = model[camelize(type)];
 
         if (this._isCollection(relationship)) {
           if (!obj.relationships) { obj.relationships = {}; }
-          obj.relationships[camelizedType] = {
+          obj.relationships[type] = {
             data: relationship.map(model => {
               return {
                 type: this.typeKeyForModel(model),
@@ -108,7 +107,7 @@ class JsonApiSerializer {
           };
         } else if (relationship) {
           if (!obj.relationships) { obj.relationships = {}; }
-          obj.relationships[camelizedType] = {
+          obj.relationships[type] = {
             data: {
               type: this.typeKeyForModel(relationship),
               id: relationship.id

--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -5,7 +5,6 @@
 
 import Ember from 'ember';
 import _keys from 'lodash/object/keys';
-import { camelize } from 'ember-cli-mirage/utils/inflector';
 
 /*
   This function looks through all files that have been loaded by Ember CLI and
@@ -28,7 +27,7 @@ export default function(prefix) {
     }
     let moduleParts = moduleName.split('/');
     let moduleType = moduleParts[moduleParts.length - 2];
-    let moduleKey = camelize(moduleParts[moduleParts.length - 1]);
+    let moduleKey = moduleParts[moduleParts.length - 1];
     Ember.assert('Subdirectories under ' + moduleType + ' are not supported',
                  moduleParts[moduleParts.length - 3] === 'mirage');
     if (moduleType === 'scenario'){

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.18.0",
     "pretender": "~0.9.0",
-    "Faker": "~3.0.0"
+    "Faker": "~3.0.0",
+    "sinonjs": "~1.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
+    "ember-sinon": "0.3.0",
     "ember-try": "0.0.6",
     "mocha": "^2.1.0"
   },

--- a/tests/dummy/app/initializers/es2015-polyfills.js
+++ b/tests/dummy/app/initializers/es2015-polyfills.js
@@ -1,0 +1,85 @@
+export function initialize(/* container, application */) {
+  // Production steps of ECMA-262, Edition 6, 22.1.2.1
+  // Reference: https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.from
+  if (!Array.from) {
+    Array.from = (function () {
+      var toStr = Object.prototype.toString;
+      var isCallable = function (fn) {
+        return typeof fn === 'function' || toStr.call(fn) === '[object Function]';
+      };
+      var toInteger = function (value) {
+        var number = Number(value);
+        if (isNaN(number)) { return 0; }
+        if (number === 0 || !isFinite(number)) { return number; }
+        return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+      };
+      var maxSafeInteger = Math.pow(2, 53) - 1;
+      var toLength = function (value) {
+        var len = toInteger(value);
+        return Math.min(Math.max(len, 0), maxSafeInteger);
+      };
+
+      // The length property of the from method is 1.
+      return function from(arrayLike/*, mapFn, thisArg */) {
+        // 1. Let C be the this value.
+        var C = this;
+
+        // 2. Let items be ToObject(arrayLike).
+        var items = Object(arrayLike);
+
+        // 3. ReturnIfAbrupt(items).
+        if (arrayLike == null) {
+          throw new TypeError("Array.from requires an array-like object - not null or undefined");
+        }
+
+        // 4. If mapfn is undefined, then let mapping be false.
+        var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+        var T;
+        if (typeof mapFn !== 'undefined') {
+          // 5. else
+          // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
+          if (!isCallable(mapFn)) {
+            throw new TypeError('Array.from: when provided, the second argument must be a function');
+          }
+
+          // 5. b. If thisArg was supplied, let T be thisArg; else let T be undefined.
+          if (arguments.length > 2) {
+            T = arguments[2];
+          }
+        }
+
+        // 10. Let lenValue be Get(items, "length").
+        // 11. Let len be ToLength(lenValue).
+        var len = toLength(items.length);
+
+        // 13. If IsConstructor(C) is true, then
+        // 13. a. Let A be the result of calling the [[Construct]] internal method of C with an argument list containing the single item len.
+        // 14. a. Else, Let A be ArrayCreate(len).
+        var A = isCallable(C) ? Object(new C(len)) : new Array(len);
+
+        // 16. Let k be 0.
+        var k = 0;
+        // 17. Repeat, while k < len… (also steps a - h)
+        var kValue;
+        while (k < len) {
+          kValue = items[k];
+          if (mapFn) {
+            A[k] = typeof T === 'undefined' ? mapFn(kValue, k) : mapFn.call(T, kValue, k);
+          } else {
+            A[k] = kValue;
+          }
+          k += 1;
+        }
+        // 18. Let putStatus be Put(A, "length", len, true).
+        A.length = len;
+        // 20. Return A.
+        return A;
+      };
+    }());
+  }
+}
+
+export default {
+  name: 'es2015-polyfills',
+  initialize: initialize
+};

--- a/tests/integration/serializers/active-model-serializer-test.js
+++ b/tests/integration/serializers/active-model-serializer-test.js
@@ -29,7 +29,7 @@ module('Integration | Serializer | ActiveModelSerializer', {
       application: ActiveModelSerializer,
       wordSmith: ActiveModelSerializer.extend({
         attrs: ['id', 'name'],
-        relationships: ['blog-posts']
+        include: ['blogPosts']
       })
     });
   },

--- a/tests/integration/serializers/active-model-serializer-test.js
+++ b/tests/integration/serializers/active-model-serializer-test.js
@@ -29,7 +29,7 @@ module('Integration | Serializer | ActiveModelSerializer', {
       application: ActiveModelSerializer,
       wordSmith: ActiveModelSerializer.extend({
         attrs: ['id', 'name'],
-        relationships: ['blogPosts']
+        relationships: ['blog-posts']
       })
     });
   },

--- a/tests/integration/serializers/base/associations/embedded-collection-test.js
+++ b/tests/integration/serializers/base/associations/embedded-collection-test.js
@@ -29,7 +29,7 @@ test(`it can embed a collection with a has-many relationship`, function(assert) 
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts']
+      include: ['blogPosts']
     })
   });
 
@@ -59,10 +59,10 @@ test(`it can embed a collection with a chain of has-many relationships`, functio
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts']
+      include: ['blogPosts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['fine-comments']
+      include: ['fineComments']
     })
   });
 
@@ -102,7 +102,7 @@ test(`it can embed a collection with a belongs-to relationship`, function(assert
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -129,10 +129,10 @@ test(`it can embed a collection with a chain of belongs-to relationships`, funct
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     fineComment: this.BaseSerializer.extend({
-      relationships: ['blog-post']
+      include: ['blogPost']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith']
+      include: ['wordSmith']
     })
   });
 

--- a/tests/integration/serializers/base/associations/embedded-collection-test.js
+++ b/tests/integration/serializers/base/associations/embedded-collection-test.js
@@ -29,7 +29,7 @@ test(`it can embed a collection with a has-many relationship`, function(assert) 
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     })
   });
 
@@ -59,10 +59,10 @@ test(`it can embed a collection with a chain of has-many relationships`, functio
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['fineComments']
+      relationships: ['fine-comments']
     })
   });
 
@@ -102,7 +102,7 @@ test(`it can embed a collection with a belongs-to relationship`, function(assert
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -129,10 +129,10 @@ test(`it can embed a collection with a chain of belongs-to relationships`, funct
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     fineComment: this.BaseSerializer.extend({
-      relationships: ['blogPost']
+      relationships: ['blog-post']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 

--- a/tests/integration/serializers/base/associations/embedded-model-test.js
+++ b/tests/integration/serializers/base/associations/embedded-model-test.js
@@ -29,7 +29,7 @@ test(`it can embed has-many relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     })
   });
 
@@ -52,10 +52,10 @@ test(`it can embed a chain of has-many relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['fineComments']
+      relationships: ['fine-comments']
     })
   });
 
@@ -81,7 +81,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
     application: this.BaseSerializer,
     blogPost: this.BaseSerializer.extend({
       embed: true,
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -101,10 +101,10 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     fineComment: this.BaseSerializer.extend({
-      relationships: ['blogPost']
+      relationships: ['blog-post']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -130,10 +130,10 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -157,13 +157,13 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
       embed: true,
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith', 'fineComments']
+      relationships: ['word-smith', 'fine-comments']
     }),
     fineComment: this.BaseSerializer.extend({
-      relationships: ['blogPost']
+      relationships: ['blog-post']
     })
   });
 

--- a/tests/integration/serializers/base/associations/embedded-model-test.js
+++ b/tests/integration/serializers/base/associations/embedded-model-test.js
@@ -29,7 +29,7 @@ test(`it can embed has-many relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts']
+      include: ['blogPosts']
     })
   });
 
@@ -52,10 +52,10 @@ test(`it can embed a chain of has-many relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts']
+      include: ['blogPosts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['fine-comments']
+      include: ['fineComments']
     })
   });
 
@@ -81,7 +81,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
     application: this.BaseSerializer,
     blogPost: this.BaseSerializer.extend({
       embed: true,
-      relationships: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -101,10 +101,10 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     fineComment: this.BaseSerializer.extend({
-      relationships: ['blog-post']
+      include: ['blogPost']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -130,10 +130,10 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts']
+      include: ['blogPosts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -157,13 +157,13 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
       embed: true,
-      relationships: ['blog-posts']
+      include: ['blogPosts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith', 'fine-comments']
+      include: ['word-smith', 'fine-comments']
     }),
     fineComment: this.BaseSerializer.extend({
-      relationships: ['blog-post']
+      include: ['blogPost']
     })
   });
 

--- a/tests/integration/serializers/base/associations/sideloading-assorted-collections-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-assorted-collections-test.js
@@ -12,7 +12,7 @@ module('Integration | Serializers | Base | Associations | Sideloading Assorted C
     this.registry = new SerializerRegistry(this.schema, {
       application: BaseSerializer,
       wordSmith: BaseSerializer.extend({
-        relationships: ['blogPosts']
+        relationships: ['blog-posts']
       }),
       greatPhoto: BaseSerializer.extend({
         attrs: ['id', 'title']

--- a/tests/integration/serializers/base/associations/sideloading-assorted-collections-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-assorted-collections-test.js
@@ -12,7 +12,7 @@ module('Integration | Serializers | Base | Associations | Sideloading Assorted C
     this.registry = new SerializerRegistry(this.schema, {
       application: BaseSerializer,
       wordSmith: BaseSerializer.extend({
-        relationships: ['blog-posts']
+        include: ['blogPosts']
       }),
       greatPhoto: BaseSerializer.extend({
         attrs: ['id', 'title']

--- a/tests/integration/serializers/base/associations/sideloading-collection-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-collection-test.js
@@ -30,7 +30,7 @@ test(`it throws an error if embed is false and root is false`, function(assert) 
   let registry = new SerializerRegistry(this.schema, {
     wordSmith: this.BaseSerializer.extend({
       root: false,
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     })
   });
 
@@ -46,7 +46,7 @@ test(`it can sideload an empty collection`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     })
   });
 
@@ -62,7 +62,7 @@ test(`it can sideload a collection with a has-many relationship`, function(asser
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     })
   });
 
@@ -87,10 +87,10 @@ test(`it can sideload a collection with a chain of has-many relationships`, func
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['fineComments'],
+      relationships: ['fine-comments'],
     })
   });
 
@@ -118,10 +118,10 @@ test(`it avoids circularity when serializing a collection`, function(assert) {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith'],
+      relationships: ['word-smith'],
     })
   });
 
@@ -146,7 +146,7 @@ test(`it can sideload a collection with a belongs-to relationship`, function(ass
     application: this.BaseSerializer,
     blogPost: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['wordSmith'],
+      relationships: ['word-smith'],
     })
   });
 
@@ -171,10 +171,10 @@ test(`it can sideload a collection with a chain of belongs-to relationships`, fu
     application: this.BaseSerializer,
     fineComment: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['blogPost'],
+      relationships: ['blog-post'],
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith'],
+      relationships: ['word-smith'],
     })
   });
 

--- a/tests/integration/serializers/base/associations/sideloading-collection-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-collection-test.js
@@ -30,7 +30,7 @@ test(`it throws an error if embed is false and root is false`, function(assert) 
   let registry = new SerializerRegistry(this.schema, {
     wordSmith: this.BaseSerializer.extend({
       root: false,
-      relationships: ['blog-posts'],
+      include: ['blogPosts'],
     })
   });
 
@@ -46,7 +46,7 @@ test(`it can sideload an empty collection`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts'],
+      include: ['blogPosts'],
     })
   });
 
@@ -62,7 +62,7 @@ test(`it can sideload a collection with a has-many relationship`, function(asser
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['blog-posts'],
+      include: ['blogPosts'],
     })
   });
 
@@ -87,10 +87,10 @@ test(`it can sideload a collection with a chain of has-many relationships`, func
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['blog-posts'],
+      include: ['blogPosts'],
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['fine-comments'],
+      include: ['fineComments'],
     })
   });
 
@@ -118,10 +118,10 @@ test(`it avoids circularity when serializing a collection`, function(assert) {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['blog-posts'],
+      include: ['blogPosts'],
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith'],
+      include: ['wordSmith'],
     })
   });
 
@@ -146,7 +146,7 @@ test(`it can sideload a collection with a belongs-to relationship`, function(ass
     application: this.BaseSerializer,
     blogPost: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['word-smith'],
+      include: ['wordSmith'],
     })
   });
 
@@ -171,10 +171,10 @@ test(`it can sideload a collection with a chain of belongs-to relationships`, fu
     application: this.BaseSerializer,
     fineComment: this.BaseSerializer.extend({
       embed: false,
-      relationships: ['blog-post'],
+      include: ['blogPost'],
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith'],
+      include: ['wordSmith'],
     })
   });
 

--- a/tests/integration/serializers/base/associations/sideloading-model-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-model-test.js
@@ -29,7 +29,7 @@ test(`it throws an error if embed is false and root is false`, function(assert) 
   let registry = new SerializerRegistry(this.schema, {
     wordSmith: this.BaseSerializer.extend({
       root: false,
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     })
   });
 
@@ -44,7 +44,7 @@ test(`it can sideload a model with a has-many relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     })
   });
 
@@ -68,10 +68,10 @@ test(`it can sideload a model with a chain of has-many relationships`, function(
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['fineComments']
+      relationships: ['fine-comments']
     })
   });
 
@@ -98,10 +98,10 @@ test(`it avoids circularity when serializing a model`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -125,7 +125,7 @@ test(`it can sideload a model with a belongs-to relationship`, function(assert) 
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -146,10 +146,10 @@ test(`it can sideload a model with a chain of belongs-to relationships`, functio
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     fineComment: this.BaseSerializer.extend({
-      relationships: ['blogPost']
+      relationships: ['blog-post']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 

--- a/tests/integration/serializers/base/associations/sideloading-model-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-model-test.js
@@ -29,7 +29,7 @@ test(`it throws an error if embed is false and root is false`, function(assert) 
   let registry = new SerializerRegistry(this.schema, {
     wordSmith: this.BaseSerializer.extend({
       root: false,
-      relationships: ['blog-posts'],
+      include: ['blogPosts'],
     })
   });
 
@@ -44,7 +44,7 @@ test(`it can sideload a model with a has-many relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts'],
+      include: ['blogPosts'],
     })
   });
 
@@ -68,10 +68,10 @@ test(`it can sideload a model with a chain of has-many relationships`, function(
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts']
+      include: ['blogPosts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['fine-comments']
+      include: ['fineComments']
     })
   });
 
@@ -98,10 +98,10 @@ test(`it avoids circularity when serializing a model`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     wordSmith: this.BaseSerializer.extend({
-      relationships: ['blog-posts']
+      include: ['blogPosts']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -125,7 +125,7 @@ test(`it can sideload a model with a belongs-to relationship`, function(assert) 
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -146,10 +146,10 @@ test(`it can sideload a model with a chain of belongs-to relationships`, functio
   let registry = new SerializerRegistry(this.schema, {
     application: this.BaseSerializer,
     fineComment: this.BaseSerializer.extend({
-      relationships: ['blog-post']
+      include: ['blogPost']
     }),
     blogPost: this.BaseSerializer.extend({
-      relationships: ['word-smith']
+      include: ['wordSmith']
     })
   });
 

--- a/tests/integration/serializers/base/full-request-test.js
+++ b/tests/integration/serializers/base/full-request-test.js
@@ -28,7 +28,7 @@ module('Integration | Serializers | Base | Full Request', {
         author: Serializer.extend({
           embed: true,
           attrs: ['id', 'first'],
-          relationships: ['posts']
+          include: ['posts']
         })
       }
     });

--- a/tests/integration/serializers/json-api-serializer/associations/collection-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/collection-test.js
@@ -34,7 +34,7 @@ test(`it can serialize a collection with a has-many relationship`, function(asse
   assert.deepEqual(result, {
     data: [
       {
-        type: 'wordSmiths',
+        type: 'word-smiths',
         id: 1,
         attributes: {
           'first-name': 'Link',
@@ -42,14 +42,14 @@ test(`it can serialize a collection with a has-many relationship`, function(asse
         relationships: {
           blogPosts: {
             data: [
-              {type: 'blogPosts', id: 1},
-              {type: 'blogPosts', id: 2},
+              {type: 'blog-posts', id: 1},
+              {type: 'blog-posts', id: 2},
             ]
           }
         }
       },
       {
-        type: 'wordSmiths',
+        type: 'word-smiths',
         id: 2,
         attributes: {
           'first-name': 'Zelda'
@@ -63,14 +63,14 @@ test(`it can serialize a collection with a has-many relationship`, function(asse
     ],
     included: [
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 1,
         attributes: {
           title: 'Lorem'
         }
       },
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 2,
         attributes: {
           title: 'Ipsum'
@@ -97,7 +97,7 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
   assert.deepEqual(result, {
     data: [
       {
-        type: 'wordSmiths',
+        type: 'word-smiths',
         id: 1,
         attributes: {
           'first-name': 'Link',
@@ -105,14 +105,14 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
         relationships: {
           blogPosts: {
             data: [
-              {type: 'blogPosts', id: 1},
-              {type: 'blogPosts', id: 2},
+              {type: 'blog-posts', id: 1},
+              {type: 'blog-posts', id: 2},
             ]
           }
         }
       },
       {
-        type: 'wordSmiths',
+        type: 'word-smiths',
         id: 2,
         attributes: {
           'first-name': 'Zelda'
@@ -126,7 +126,7 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
     ],
     included: [
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 1,
         attributes: {
           title: 'Lorem'
@@ -134,20 +134,20 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
         relationships: {
           fineComments: {
             data: [
-              {type: 'fineComments', id: 1}
+              {type: 'fine-comments', id: 1}
             ]
           }
         }
       },
       {
-        type: 'fineComments',
+        type: 'fine-comments',
         id: 1,
         attributes: {
           text: 'pwned'
         }
       },
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 2,
         attributes: {
           title: 'Ipsum'
@@ -176,33 +176,33 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
   assert.deepEqual(result, {
     data: [
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 1,
         attributes: {
           title: 'Lorem'
         },
         relationships: {
           wordSmith: {
-            data: {type: 'wordSmiths', id: 1}
+            data: {type: 'word-smiths', id: 1}
           }
         }
       },
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 2,
         attributes: {
           title: 'Ipsum'
         },
         relationships: {
           wordSmith: {
-            data: {type: 'wordSmiths', id: 1}
+            data: {type: 'word-smiths', id: 1}
           }
         }
       }
     ],
     included: [
       {
-        type: 'wordSmiths',
+        type: 'word-smiths',
         id: 1,
         attributes: {
           'first-name': 'Link',
@@ -229,33 +229,33 @@ test(`it can serialize a collection with a chain of belongs-to relationships`, f
   assert.deepEqual(result, {
     data: [
       {
-        type: 'fineComments',
+        type: 'fine-comments',
         id: 1,
         attributes: {
           text: 'pwned'
         },
         relationships: {
           blogPost: {
-            data: {type: 'blogPosts', id: 1}
+            data: {type: 'blog-posts', id: 1}
           }
         }
       }
     ],
     included: [
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 1,
         attributes: {
           title: 'Lorem'
         },
         relationships: {
           wordSmith: {
-            data: {type: 'wordSmiths', id: 1}
+            data: {type: 'word-smiths', id: 1}
           }
         }
       },
       {
-        type: 'wordSmiths',
+        type: 'word-smiths',
         id: 1,
         attributes: {
           'first-name': 'Link'
@@ -278,30 +278,30 @@ test(`it can serialize a collection of models that have both belongs-to and has-
 
   assert.deepEqual(result, {
     data: {
-      type: 'blogPosts',
+      type: 'blog-posts',
       id: 1,
       attributes: {
         title: 'Lorem'
       },
       relationships: {
         wordSmith: {
-          data: {type: 'wordSmiths', id: 1}
+          data: {type: 'word-smiths', id: 1}
         },
         fineComments: {
-          data: [{type: 'fineComments', id: 1}]
+          data: [{type: 'fine-comments', id: 1}]
         }
       }
     },
     included: [
       {
-        type: 'wordSmiths',
+        type: 'word-smiths',
         id: 1,
         attributes: {
           'first-name': 'Link'
         }
       },
       {
-        type: 'fineComments',
+        type: 'fine-comments',
         id: 1,
         attributes: {
           'text': 'pwned'

--- a/tests/integration/serializers/json-api-serializer/associations/collection-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/collection-test.js
@@ -24,7 +24,7 @@ test(`it can serialize a collection with a has-many relationship`, function(asse
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      include: ['blog-posts'],
+      include: ['blogPosts'],
     })
   });
 
@@ -102,10 +102,10 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      include: ['blog-posts']
+      include: ['blogPosts']
     }),
     blogPost: JsonApiSerializer.extend({
-      include: ['fine-comments']
+      include: ['fineComments']
     })
   });
 
@@ -195,7 +195,7 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -261,10 +261,10 @@ test(`it can serialize a collection with a chain of belongs-to relationships`, f
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     fineComment: JsonApiSerializer.extend({
-      include: ['blog-post']
+      include: ['blogPost']
     }),
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -336,7 +336,7 @@ test(`it can serialize a collection of models that have both belongs-to and has-
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith', 'fine-comments']
+      include: ['wordSmith', 'fineComments']
     })
   });
 

--- a/tests/integration/serializers/json-api-serializer/associations/collection-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/collection-test.js
@@ -40,7 +40,7 @@ test(`it can serialize a collection with a has-many relationship`, function(asse
           'first-name': 'Link',
         },
         relationships: {
-          blogPosts: {
+          'blog-posts': {
             data: [
               {type: 'blog-posts', id: 1},
               {type: 'blog-posts', id: 2},
@@ -55,7 +55,7 @@ test(`it can serialize a collection with a has-many relationship`, function(asse
           'first-name': 'Zelda'
         },
         relationships: {
-          blogPosts: {
+          'blog-posts': {
             data: []
           }
         }
@@ -103,7 +103,7 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
           'first-name': 'Link',
         },
         relationships: {
-          blogPosts: {
+          'blog-posts': {
             data: [
               {type: 'blog-posts', id: 1},
               {type: 'blog-posts', id: 2},
@@ -118,7 +118,7 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
           'first-name': 'Zelda'
         },
         relationships: {
-          blogPosts: {
+          'blog-posts': {
             data: []
           }
         }
@@ -132,7 +132,7 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
           title: 'Lorem'
         },
         relationships: {
-          fineComments: {
+          'fine-comments': {
             data: [
               {type: 'fine-comments', id: 1}
             ]
@@ -153,7 +153,7 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
           title: 'Ipsum'
         },
         relationships: {
-          fineComments: {
+          'fine-comments': {
             data: []
           }
         }
@@ -182,7 +182,7 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
           title: 'Lorem'
         },
         relationships: {
-          wordSmith: {
+          'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
         }
@@ -194,7 +194,7 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
           title: 'Ipsum'
         },
         relationships: {
-          wordSmith: {
+          'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
         }
@@ -235,7 +235,7 @@ test(`it can serialize a collection with a chain of belongs-to relationships`, f
           text: 'pwned'
         },
         relationships: {
-          blogPost: {
+          'blog-post': {
             data: {type: 'blog-posts', id: 1}
           }
         }
@@ -249,7 +249,7 @@ test(`it can serialize a collection with a chain of belongs-to relationships`, f
           title: 'Lorem'
         },
         relationships: {
-          wordSmith: {
+          'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
         }
@@ -284,10 +284,10 @@ test(`it can serialize a collection of models that have both belongs-to and has-
         title: 'Lorem'
       },
       relationships: {
-        wordSmith: {
+        'word-smith': {
           data: {type: 'word-smiths', id: 1}
         },
-        fineComments: {
+        'fine-comments': {
           data: [{type: 'fine-comments', id: 1}]
         }
       }

--- a/tests/integration/serializers/json-api-serializer/associations/collection-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/collection-test.js
@@ -24,7 +24,7 @@ test(`it can serialize a collection with a has-many relationship`, function(asse
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     })
   });
 
@@ -84,10 +84,10 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blogPosts']
+      relationships: ['blog-posts']
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['fineComments']
+      relationships: ['fine-comments']
     })
   });
 
@@ -166,7 +166,7 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -216,10 +216,10 @@ test(`it can serialize a collection with a chain of belongs-to relationships`, f
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     fineComment: JsonApiSerializer.extend({
-      relationships: ['blogPost']
+      relationships: ['blog-post']
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -269,7 +269,7 @@ test(`it can serialize a collection of models that have both belongs-to and has-
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['wordSmith', 'fineComments']
+      relationships: ['word-smith', 'fine-comments']
     })
   });
 

--- a/tests/integration/serializers/json-api-serializer/associations/collection-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/collection-test.js
@@ -24,70 +24,7 @@ test(`it can serialize a collection with a has-many relationship`, function(asse
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blog-posts'],
-    })
-  });
-
-  let wordSmiths = this.schema.wordSmith.all();
-  let result = registry.serialize(wordSmiths);
-
-  assert.deepEqual(result, {
-    data: [
-      {
-        type: 'word-smiths',
-        id: 1,
-        attributes: {
-          'first-name': 'Link',
-        },
-        relationships: {
-          'blog-posts': {
-            data: [
-              {type: 'blog-posts', id: 1},
-              {type: 'blog-posts', id: 2},
-            ]
-          }
-        }
-      },
-      {
-        type: 'word-smiths',
-        id: 2,
-        attributes: {
-          'first-name': 'Zelda'
-        },
-        relationships: {
-          'blog-posts': {
-            data: []
-          }
-        }
-      }
-    ],
-    included: [
-      {
-        type: 'blog-posts',
-        id: 1,
-        attributes: {
-          title: 'Lorem'
-        }
-      },
-      {
-        type: 'blog-posts',
-        id: 2,
-        attributes: {
-          title: 'Ipsum'
-        }
-      }
-    ]
-  });
-});
-
-test(`it can serialize a collection with a chain of has-many relationships`, function(assert) {
-  let registry = new SerializerRegistry(this.schema, {
-    application: JsonApiSerializer,
-    wordSmith: JsonApiSerializer.extend({
-      relationships: ['blog-posts']
-    }),
-    blogPost: JsonApiSerializer.extend({
-      relationships: ['fine-comments']
+      include: ['blog-posts'],
     })
   });
 
@@ -136,14 +73,10 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
             data: [
               {type: 'fine-comments', id: 1}
             ]
+          },
+          'word-smith': {
+            data: {type: 'word-smiths', id: 1}
           }
-        }
-      },
-      {
-        type: 'fine-comments',
-        id: 1,
-        attributes: {
-          text: 'pwned'
         }
       },
       {
@@ -155,6 +88,102 @@ test(`it can serialize a collection with a chain of has-many relationships`, fun
         relationships: {
           'fine-comments': {
             data: []
+          },
+          'word-smith': {
+            data: {type: 'word-smiths', id: 1}
+          }
+        }
+      }
+    ]
+  });
+});
+
+test(`it can serialize a collection with a chain of has-many relationships`, function(assert) {
+  let registry = new SerializerRegistry(this.schema, {
+    application: JsonApiSerializer,
+    wordSmith: JsonApiSerializer.extend({
+      include: ['blog-posts']
+    }),
+    blogPost: JsonApiSerializer.extend({
+      include: ['fine-comments']
+    })
+  });
+
+  let wordSmiths = this.schema.wordSmith.all();
+  let result = registry.serialize(wordSmiths);
+
+  assert.deepEqual(result, {
+    data: [
+      {
+        type: 'word-smiths',
+        id: 1,
+        attributes: {
+          'first-name': 'Link',
+        },
+        relationships: {
+          'blog-posts': {
+            data: [
+              {type: 'blog-posts', id: 1},
+              {type: 'blog-posts', id: 2},
+            ]
+          }
+        }
+      },
+      {
+        type: 'word-smiths',
+        id: 2,
+        attributes: {
+          'first-name': 'Zelda'
+        },
+        relationships: {
+          'blog-posts': {
+            data: []
+          }
+        }
+      }
+    ],
+    included: [
+      {
+        type: 'blog-posts',
+        id: 1,
+        attributes: {
+          title: 'Lorem'
+        },
+        relationships: {
+          'fine-comments': {
+            data: [
+              {type: 'fine-comments', id: 1}
+            ]
+          },
+          'word-smith': {
+            data: {type: 'word-smiths', id: 1}
+          }
+        }
+      },
+      {
+        type: 'fine-comments',
+        id: 1,
+        attributes: {
+          text: 'pwned'
+        },
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
+      },
+      {
+        type: 'blog-posts',
+        id: 2,
+        attributes: {
+          title: 'Ipsum'
+        },
+        relationships: {
+          'fine-comments': {
+            data: []
+          },
+          'word-smith': {
+            data: {type: 'word-smiths', id: 1}
           }
         }
       }
@@ -166,7 +195,7 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith']
+      include: ['word-smith']
     })
   });
 
@@ -182,6 +211,11 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
           title: 'Lorem'
         },
         relationships: {
+          'fine-comments': {
+            data: [
+              {type: 'fine-comments', id: 1}
+            ]
+          },
           'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
@@ -194,6 +228,9 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
           title: 'Ipsum'
         },
         relationships: {
+          'fine-comments': {
+            data: []
+          },
           'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
@@ -206,6 +243,14 @@ test(`it can serialize a collection with a belongs-to relationship`, function(as
         id: 1,
         attributes: {
           'first-name': 'Link',
+        },
+        relationships: {
+          'blog-posts': {
+            data: [
+              {type: 'blog-posts', id: 1},
+              {type: 'blog-posts', id: 2}
+            ]
+          }
         }
       }
     ]
@@ -216,10 +261,10 @@ test(`it can serialize a collection with a chain of belongs-to relationships`, f
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     fineComment: JsonApiSerializer.extend({
-      relationships: ['blog-post']
+      include: ['blog-post']
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith']
+      include: ['word-smith']
     })
   });
 
@@ -249,6 +294,14 @@ test(`it can serialize a collection with a chain of belongs-to relationships`, f
           title: 'Lorem'
         },
         relationships: {
+          "fine-comments": {
+            data: [
+              {
+                  id: 1,
+                type: "fine-comments"
+              }
+            ]
+          },
           'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
@@ -259,6 +312,20 @@ test(`it can serialize a collection with a chain of belongs-to relationships`, f
         id: 1,
         attributes: {
           'first-name': 'Link'
+        },
+        relationships: {
+          "blog-posts": {
+            data: [
+              {
+                id: 1,
+                type: "blog-posts"
+              },
+              {
+                id: 2,
+                type: "blog-posts"
+              }
+            ]
+          }
         }
       }
     ]
@@ -269,7 +336,7 @@ test(`it can serialize a collection of models that have both belongs-to and has-
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith', 'fine-comments']
+      include: ['word-smith', 'fine-comments']
     })
   });
 
@@ -298,6 +365,20 @@ test(`it can serialize a collection of models that have both belongs-to and has-
         id: 1,
         attributes: {
           'first-name': 'Link'
+        },
+        relationships: {
+          "blog-posts": {
+            data: [
+              {
+                id: 1,
+                type: "blog-posts"
+              },
+              {
+                id: 2,
+                type: "blog-posts"
+              }
+            ]
+          }
         }
       },
       {
@@ -305,6 +386,14 @@ test(`it can serialize a collection of models that have both belongs-to and has-
         id: 1,
         attributes: {
           'text': 'pwned'
+        },
+        relationships: {
+          "blog-post": {
+            data: {
+              id: 1,
+              type: "blog-posts"
+            }
+          }
         }
       }
     ]

--- a/tests/integration/serializers/json-api-serializer/associations/included-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/included-test.js
@@ -1,0 +1,239 @@
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+import JsonApiSerializer from 'ember-cli-mirage/serializers/json-api-serializer';
+import schemaHelper from '../../schema-helper';
+import { module, test } from 'qunit';
+
+module('Integration | Serializers | JSON API Serializer | Associations | Included', {
+  beforeEach: function() {
+    this.schema = schemaHelper.setup();
+
+    const smith = this.schema.wordSmith.create();
+    const post = smith.createBlogPost();
+    post.createFineComment();
+    post.createFineComment();
+    this.schema.blogPost.create();
+  },
+  afterEach() {
+    this.schema.db.emptyData();
+  }
+});
+
+test(`model: it can include relationships specified by the include query param`, function(assert) {
+  const registry = new SerializerRegistry(this.schema, {
+    application: JsonApiSerializer
+  });
+
+  const post = this.schema.blogPost.find(1);
+  const request = {
+    queryParams: {
+      include: "word-smith,fine-comments"
+    }
+  };
+  const result = registry.serialize(post, request);
+
+  assert.propEqual(result, {
+    data: {
+      type: 'blog-posts',
+      id: 1,
+      attributes: {},
+      relationships: {
+        'word-smith': {
+          data: {type: 'word-smiths', id: 1}
+        },
+        'fine-comments': {
+          data: [
+            {type: 'fine-comments', id: 1},
+            {type: 'fine-comments', id: 2}
+          ]
+        }
+      }
+    },
+    included: [
+      {
+        type: 'word-smiths',
+        id: 1,
+        attributes: {}
+      },
+      {
+        type: 'fine-comments',
+        id: 1,
+        attributes: {}
+      },
+      {
+        type: 'fine-comments',
+        id: 2,
+        attributes: {}
+      }
+    ]
+  });
+});
+
+test(`model: it can include relationships specified by a combination of the include query param (hasMany) and serializer.relationships (belongsTo)`, function(assert) {
+  const registry = new SerializerRegistry(this.schema, {
+    application: JsonApiSerializer,
+    blogPost: JsonApiSerializer.extend({
+      relationships: ['word-smith'],
+    })
+  });
+
+  const post = this.schema.blogPost.find(1);
+  const request = {
+    queryParams: {
+      include: "fine-comments"
+    }
+  };
+  const result = registry.serialize(post, request);
+
+  assert.propEqual(result, {
+    data: {
+      type: 'blog-posts',
+      id: 1,
+      attributes: {},
+      relationships: {
+        'word-smith': {
+          data: {type: 'word-smiths', id: 1}
+        },
+        'fine-comments': {
+          data: [
+            {type: 'fine-comments', id: 1},
+            {type: 'fine-comments', id: 2}
+          ]
+        }
+      }
+    },
+    included: [
+      {
+        type: 'word-smiths',
+        id: 1,
+        attributes: {}
+      },
+      {
+        type: 'fine-comments',
+        id: 1,
+        attributes: {}
+      },
+      {
+        type: 'fine-comments',
+        id: 2,
+        attributes: {}
+      }
+    ]
+  });
+});
+
+
+test(`model: it can include relationships specified by a combination of the include query param (belongsTo) and serializer.relationships (hasMany)`, function(assert) {
+  const registry = new SerializerRegistry(this.schema, {
+    application: JsonApiSerializer,
+    blogPost: JsonApiSerializer.extend({
+      relationships: ['fine-comments'],
+    })
+  });
+
+  const post = this.schema.blogPost.find(1);
+  const request = {
+    queryParams: {
+      include: "word-smith"
+    }
+  };
+  const result = registry.serialize(post, request);
+
+  assert.propEqual(result, {
+    data: {
+      type: 'blog-posts',
+      id: 1,
+      attributes: {},
+      relationships: {
+        'word-smith': {
+          data: {type: 'word-smiths', id: 1}
+        },
+        'fine-comments': {
+          data: [
+            {type: 'fine-comments', id: 1},
+            {type: 'fine-comments', id: 2}
+          ]
+        }
+      }
+    },
+    included: [
+      {
+        type: 'fine-comments',
+        id: 1,
+        attributes: {}
+      },
+      {
+        type: 'fine-comments',
+        id: 2,
+        attributes: {}
+      },
+      {
+        type: 'word-smiths',
+        id: 1,
+        attributes: {}
+      }
+    ]
+  });
+});
+
+
+test(`collection: it can include relationships specified by the include query param`, function(assert) {
+  const registry = new SerializerRegistry(this.schema, {
+    application: JsonApiSerializer
+  });
+
+  const post = this.schema.blogPost.find([1, 2]);
+  const request = {
+    queryParams: {
+      include: "word-smith,fine-comments"
+    }
+  };
+  const result = registry.serialize(post, request);
+
+  assert.propEqual(result, {
+    data: [
+      {
+        type: 'blog-posts',
+        id: 1,
+        attributes: {},
+        relationships: {
+          'word-smith': {
+            data: {type: 'word-smiths', id: 1}
+          },
+          'fine-comments': {
+            data: [
+              {type: 'fine-comments', id: 1},
+              {type: 'fine-comments', id: 2}
+            ]
+          }
+        }
+      },
+      {
+        type: 'blog-posts',
+        id: 2,
+        attributes: {},
+        relationships: {
+          'fine-comments': {
+            data: []
+          }
+        }
+      }
+    ],
+    included: [
+      {
+        type: 'word-smiths',
+        id: 1,
+        attributes: {}
+      },
+      {
+        type: 'fine-comments',
+        id: 1,
+        attributes: {}
+      },
+      {
+        type: 'fine-comments',
+        id: 2,
+        attributes: {}
+      }
+    ]
+  });
+});

--- a/tests/integration/serializers/json-api-serializer/associations/included-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/included-test.js
@@ -52,17 +52,34 @@ test(`model: it can include relationships specified by the include query param`,
       {
         type: 'word-smiths',
         id: 1,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-posts': {
+            data: [
+              {type: 'blog-posts', id: 1}
+            ]
+          }
+        }
       },
       {
         type: 'fine-comments',
         id: 1,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
       },
       {
         type: 'fine-comments',
         id: 2,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
       }
     ]
   });
@@ -72,7 +89,7 @@ test(`model: it can include relationships specified by a combination of the incl
   const registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith'],
+      include: ['word-smith'],
     })
   });
 
@@ -105,17 +122,34 @@ test(`model: it can include relationships specified by a combination of the incl
       {
         type: 'word-smiths',
         id: 1,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-posts': {
+            data: [
+              {type: 'blog-posts', id: 1}
+            ]
+          }
+        }
       },
       {
         type: 'fine-comments',
         id: 1,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
       },
       {
         type: 'fine-comments',
         id: 2,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
       }
     ]
   });
@@ -126,7 +160,7 @@ test(`model: it can include relationships specified by a combination of the incl
   const registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['fine-comments'],
+      include: ['fine-comments'],
     })
   });
 
@@ -159,17 +193,34 @@ test(`model: it can include relationships specified by a combination of the incl
       {
         type: 'fine-comments',
         id: 1,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
       },
       {
         type: 'fine-comments',
         id: 2,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
       },
       {
         type: 'word-smiths',
         id: 1,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-posts': {
+            data: [
+              {type: 'blog-posts', id: 1}
+            ]
+          }
+        }
       }
     ]
   });
@@ -222,17 +273,34 @@ test(`collection: it can include relationships specified by the include query pa
       {
         type: 'word-smiths',
         id: 1,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-posts': {
+            data: [
+              {type: 'blog-posts', id: 1}
+            ]
+          }
+        }
       },
       {
         type: 'fine-comments',
         id: 1,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
       },
       {
         type: 'fine-comments',
         id: 2,
-        attributes: {}
+        attributes: {},
+        relationships: {
+          'blog-post': {
+            data: {type: 'blog-posts', id: 1}
+          }
+        }
       }
     ]
   });

--- a/tests/integration/serializers/json-api-serializer/associations/included-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/included-test.js
@@ -89,7 +89,7 @@ test(`model: it can include relationships specified by a combination of the incl
   const registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith'],
+      include: ['wordSmith'],
     })
   });
 
@@ -148,7 +148,7 @@ test(`model: it can include relationships specified by a combination of the incl
   const registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      include: ['fine-comments'],
+      include: ['fineComments'],
     })
   });
 

--- a/tests/integration/serializers/json-api-serializer/associations/included-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/included-test.js
@@ -12,6 +12,29 @@ module('Integration | Serializers | JSON API Serializer | Associations | Include
     post.createFineComment();
     post.createFineComment();
     this.schema.blogPost.create();
+
+    const foo = this.schema.foo.create();
+    const bar = foo.createBar();
+    foo.save();
+    const baz = bar.createBaz();
+    bar.save();
+    const quux1 = baz.createQuux();
+    const quux2 = baz.createQuux();
+    baz.save();
+    const zomg1 = quux1.createZomg();
+    const zomg2 = quux1.createZomg();
+    quux1.save();
+    const zomg3 = quux2.createZomg();
+    const zomg4 = quux2.createZomg();
+    quux2.save();
+    zomg1.createLol();
+    zomg2.createLol();
+    zomg3.createLol();
+    zomg4.createLol();
+    zomg1.save();
+    zomg2.save();
+    zomg3.save();
+    zomg4.save();
   },
   afterEach() {
     this.schema.db.emptyData();
@@ -270,6 +293,56 @@ test(`collection: it can include relationships specified by the include query pa
           }
         }
       }
+    ]
+  });
+});
+
+
+test(`dot-paths in include query params include query param`, function(assert) {
+  const registry = new SerializerRegistry(this.schema, {
+    application: JsonApiSerializer
+  });
+
+  const foo = this.schema.foo.find(1);
+  const request = {
+    queryParams: {
+      include: "bar.baz.quuxes.zomgs.lol"
+    }
+  };
+  const result = registry.serialize(foo, request);
+
+  assert.propEqual(result, {
+    data: {
+      type: 'foos',
+      id: 1,
+      attributes: {},
+      relationships: {
+        'bar': {
+          data: {type: 'bars', id: 1}
+        }
+      }
+    },
+    included: [
+      {
+        type: 'lols',
+        id: 1,
+        attributes: {},
+      },
+      {
+        type: 'lols',
+        id: 2,
+        attributes: {},
+      },
+      {
+        type: 'lols',
+        id: 3,
+        attributes: {},
+      },
+      {
+        type: 'lols',
+        id: 4,
+        attributes: {},
+      },
     ]
   });
 });

--- a/tests/integration/serializers/json-api-serializer/associations/included-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/included-test.js
@@ -85,7 +85,7 @@ test(`model: it can include relationships specified by the include query param`,
   });
 });
 
-test(`model: it can include relationships specified by a combination of the include query param (hasMany) and serializer.relationships (belongsTo)`, function(assert) {
+test(`model: it can include relationships specified by a combination of the include query param (hasMany) and serializer.relationships (belongsTo, ignored)`, function(assert) {
   const registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
@@ -120,18 +120,6 @@ test(`model: it can include relationships specified by a combination of the incl
     },
     included: [
       {
-        type: 'word-smiths',
-        id: 1,
-        attributes: {},
-        relationships: {
-          'blog-posts': {
-            data: [
-              {type: 'blog-posts', id: 1}
-            ]
-          }
-        }
-      },
-      {
         type: 'fine-comments',
         id: 1,
         attributes: {},
@@ -156,7 +144,7 @@ test(`model: it can include relationships specified by a combination of the incl
 });
 
 
-test(`model: it can include relationships specified by a combination of the include query param (belongsTo) and serializer.relationships (hasMany)`, function(assert) {
+test(`model: it can include relationships specified by a combination of the include query param (belongsTo) and serializer.relationships (hasMany, ignored)`, function(assert) {
   const registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
@@ -190,26 +178,6 @@ test(`model: it can include relationships specified by a combination of the incl
       }
     },
     included: [
-      {
-        type: 'fine-comments',
-        id: 1,
-        attributes: {},
-        relationships: {
-          'blog-post': {
-            data: {type: 'blog-posts', id: 1}
-          }
-        }
-      },
-      {
-        type: 'fine-comments',
-        id: 2,
-        attributes: {},
-        relationships: {
-          'blog-post': {
-            data: {type: 'blog-posts', id: 1}
-          }
-        }
-      },
       {
         type: 'word-smiths',
         id: 1,

--- a/tests/integration/serializers/json-api-serializer/associations/model-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/model-test.js
@@ -33,7 +33,7 @@ test(`it can include a has many relationship`, function(assert) {
 
   assert.deepEqual(result, {
     data: {
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 1,
       attributes: {
         'first-name': 'Link',
@@ -41,22 +41,22 @@ test(`it can include a has many relationship`, function(assert) {
       relationships: {
         blogPosts: {
           data: [
-            {type: 'blogPosts', id: 1},
-            {type: 'blogPosts', id: 2},
+            {type: 'blog-posts', id: 1},
+            {type: 'blog-posts', id: 2},
           ]
         }
       }
     },
     included: [
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 1,
         attributes: {
           title: 'Lorem'
         }
       },
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 2,
         attributes: {
           title: 'Ipsum'
@@ -82,7 +82,7 @@ test(`it can include a chain of has-many relationships`, function(assert) {
 
   assert.deepEqual(result, {
     data: {
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 1,
       attributes: {
         'first-name': 'Link',
@@ -90,15 +90,15 @@ test(`it can include a chain of has-many relationships`, function(assert) {
       relationships: {
         blogPosts: {
           data: [
-            {type: 'blogPosts', id: 1},
-            {type: 'blogPosts', id: 2},
+            {type: 'blog-posts', id: 1},
+            {type: 'blog-posts', id: 2},
           ]
         }
       }
     },
     included: [
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 1,
         attributes: {
           title: 'Lorem'
@@ -106,20 +106,20 @@ test(`it can include a chain of has-many relationships`, function(assert) {
         relationships: {
           fineComments: {
             data: [
-              {type: 'fineComments', id: 1},
+              {type: 'fine-comments', id: 1},
             ]
           }
         }
       },
       {
-        type: 'fineComments',
+        type: 'fine-comments',
         id: 1,
         attributes: {
           text: 'pwned'
         }
       },
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 2,
         attributes: {
           title: 'Ipsum'
@@ -147,7 +147,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
 
   assert.deepEqual(result, {
     data: {
-      type: 'blogPosts',
+      type: 'blog-posts',
       id: 1,
       attributes: {
         title: 'Lorem'
@@ -156,7 +156,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
         wordSmith: {
           data: {
             id: 1,
-            type: "wordSmiths"
+            type: "word-smiths"
           }
         }
       },
@@ -167,7 +167,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
           'first-name': "Link"
         },
         id: 1,
-        type: "wordSmiths"
+        type: "word-smiths"
       }
     ]
   });
@@ -187,7 +187,7 @@ test(`it gracefully handles null belongs-to relationship`, function(assert) {
 
   assert.deepEqual(result, {
     data: {
-      type: 'blogPosts',
+      type: 'blog-posts',
       id: 3,
       attributes: {
         title: 'Lorem3'
@@ -212,7 +212,7 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
 
   assert.deepEqual(result, {
     data: {
-      type: 'fineComments',
+      type: 'fine-comments',
       id: 1,
       attributes: {
         text: 'pwned'
@@ -221,14 +221,14 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
         blogPost: {
           data: {
             id: 1,
-            type: "blogPosts"
+            type: "blog-posts"
           }
         }
       },
     },
     "included": [
       {
-        type: 'blogPosts',
+        type: 'blog-posts',
         id: 1,
         attributes: {
           title: 'Lorem'
@@ -236,14 +236,14 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
         relationships: {
           wordSmith: {
             data: {
-              type: 'wordSmiths',
+              type: 'word-smiths',
               id: 1
             }
           }
         }
       },
       {
-        type: "wordSmiths",
+        type: "word-smiths",
         id: 1,
         attributes: {
           'first-name': "Link"
@@ -276,12 +276,12 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
       relationships: {
         blogPosts: {
           data: [
-            {type: 'blogPosts', id: 1},
-            {type: 'blogPosts', id: 2},
+            {type: 'blog-posts', id: 1},
+            {type: 'blog-posts', id: 2},
           ]
         }
       },
-      type: "wordSmiths"
+      type: "word-smiths"
     },
     included: [
       {
@@ -291,20 +291,20 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
         id: 1,
         relationships: {
           wordSmith: {
-            data: {type: 'wordSmiths', id: 1}
+            data: {type: 'word-smiths', id: 1}
           }
         },
-        type: "blogPosts"
+        type: "blog-posts"
       },
       {
-        type: "blogPosts",
+        type: "blog-posts",
         id: 2,
         attributes: {
           title: "Ipsum"
         },
         relationships: {
           wordSmith: {
-            data: {type: 'wordSmiths', id: 1}
+            data: {type: 'word-smiths', id: 1}
           }
         },
       }
@@ -338,52 +338,52 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
       relationships: {
         blogPosts: {
           data: [
-            {type: 'blogPosts', id: 1},
-            {type: 'blogPosts', id: 2},
+            {type: 'blog-posts', id: 1},
+            {type: 'blog-posts', id: 2},
           ]
         }
       },
-      type: "wordSmiths"
+      type: "word-smiths"
     },
     included: [
       {
-        type: "blogPosts",
+        type: "blog-posts",
         id: 1,
         attributes: {
           title: "Lorem"
         },
         relationships: {
           wordSmith: {
-            data: {type: 'wordSmiths', id: 1}
+            data: {type: 'word-smiths', id: 1}
           },
           fineComments: {
             data: [
-              {type: 'fineComments', id: 1}
+              {type: 'fine-comments', id: 1}
             ]
           }
         },
       },
       {
-        type: "fineComments",
+        type: "fine-comments",
         id: 1,
         attributes: {
           text: 'pwned'
         },
         relationships: {
           blogPost: {
-            data: {type: 'blogPosts', id: 1}
+            data: {type: 'blog-posts', id: 1}
           }
         },
       },
       {
-        type: "blogPosts",
+        type: "blog-posts",
         id: 2,
         attributes: {
           title: "Ipsum"
         },
         relationships: {
           wordSmith: {
-            data: {type: 'wordSmiths', id: 1}
+            data: {type: 'word-smiths', id: 1}
           },
           fineComments: {
             data: []

--- a/tests/integration/serializers/json-api-serializer/associations/model-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/model-test.js
@@ -24,7 +24,7 @@ test(`it can include a has many relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      include: ['blog-posts'],
+      include: ['blogPosts'],
     })
   });
 
@@ -97,10 +97,10 @@ test(`it can include a chain of has-many relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      include: ['blog-posts'],
+      include: ['blogPosts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      include: ['fine-comments'],
+      include: ['fineComments'],
     })
   });
 
@@ -185,7 +185,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith'],
+      include: ['wordSmith'],
     })
   });
 
@@ -246,7 +246,7 @@ test(`it gracefully handles null belongs-to relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith']
+      include: ['wordSmith']
     })
   });
 
@@ -274,10 +274,10 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith'],
+      include: ['wordSmith'],
     }),
     fineComment: JsonApiSerializer.extend({
-      include: ['blog-post'],
+      include: ['blogPost'],
     })
   });
 
@@ -353,10 +353,10 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      include: ['blog-posts'],
+      include: ['blogPosts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith'],
+      include: ['wordSmith'],
     })
   });
 
@@ -423,13 +423,13 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      include: ['blog-posts'],
+      include: ['blogPosts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      include: ['word-smith', 'fine-comments'],
+      include: ['wordSmith', 'fineComments'],
     }),
     fineComment: JsonApiSerializer.extend({
-      include: ['blog-post']
+      include: ['blogPost']
     })
   });
 

--- a/tests/integration/serializers/json-api-serializer/associations/model-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/model-test.js
@@ -24,7 +24,7 @@ test(`it can include a has many relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blog-posts'],
+      include: ['blog-posts'],
     })
   });
 
@@ -53,6 +53,22 @@ test(`it can include a has many relationship`, function(assert) {
         id: 1,
         attributes: {
           title: 'Lorem'
+        },
+        relationships: {
+          "fine-comments": {
+            data: [
+              {
+                id: 1,
+                type: "fine-comments"
+              }
+            ]
+          },
+          "word-smith": {
+            data: {
+              id: 1,
+              type: "word-smiths"
+            }
+          }
         }
       },
       {
@@ -60,6 +76,17 @@ test(`it can include a has many relationship`, function(assert) {
         id: 2,
         attributes: {
           title: 'Ipsum'
+        },
+        relationships: {
+          "fine-comments": {
+            data: []
+          },
+          "word-smith": {
+            data: {
+              id: 1,
+              type: "word-smiths"
+            }
+          }
         }
       }
     ]
@@ -70,10 +97,10 @@ test(`it can include a chain of has-many relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blog-posts'],
+      include: ['blog-posts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['fine-comments'],
+      include: ['fine-comments'],
     })
   });
 
@@ -108,6 +135,12 @@ test(`it can include a chain of has-many relationships`, function(assert) {
             data: [
               {type: 'fine-comments', id: 1},
             ]
+          },
+          "word-smith": {
+            data: {
+              id: 1,
+              type: "word-smiths"
+            }
           }
         }
       },
@@ -116,6 +149,14 @@ test(`it can include a chain of has-many relationships`, function(assert) {
         id: 1,
         attributes: {
           text: 'pwned'
+        },
+        relationships: {
+          "blog-post": {
+            data: {
+              id: 1,
+              type: "blog-posts"
+            }
+          }
         }
       },
       {
@@ -127,6 +168,12 @@ test(`it can include a chain of has-many relationships`, function(assert) {
         relationships: {
           'fine-comments': {
             data: []
+          },
+          "word-smith": {
+            data: {
+              id: 1,
+              type: "word-smiths"
+            }
           }
         }
       }
@@ -138,7 +185,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith'],
+      include: ['word-smith'],
     })
   });
 
@@ -153,6 +200,14 @@ test(`it can embed a belongs-to relationship`, function(assert) {
         title: 'Lorem'
       },
       relationships: {
+        "fine-comments": {
+          data: [
+            {
+              id: 1,
+              type: "fine-comments"
+            }
+          ]
+        },
         'word-smith': {
           data: {
             id: 1,
@@ -167,7 +222,21 @@ test(`it can embed a belongs-to relationship`, function(assert) {
           'first-name': "Link"
         },
         id: 1,
-        type: "word-smiths"
+        type: "word-smiths",
+        relationships: {
+          "blog-posts": {
+            data: [
+              {
+                id: 1,
+                type: "blog-posts"
+              },
+              {
+                id: 2,
+                type: "blog-posts"
+              }
+            ]
+          }
+        }
       }
     ]
   });
@@ -177,7 +246,7 @@ test(`it gracefully handles null belongs-to relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith']
+      include: ['word-smith']
     })
   });
 
@@ -191,6 +260,11 @@ test(`it gracefully handles null belongs-to relationship`, function(assert) {
       id: 3,
       attributes: {
         title: 'Lorem3'
+      },
+      relationships: {
+        "fine-comments": {
+          data: []
+        }
       }
     }
   });
@@ -200,10 +274,10 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith'],
+      include: ['word-smith'],
     }),
     fineComment: JsonApiSerializer.extend({
-      relationships: ['blog-post'],
+      include: ['blog-post'],
     })
   });
 
@@ -234,6 +308,14 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
           title: 'Lorem'
         },
         relationships: {
+          "fine-comments": {
+            data: [
+              {
+                id: 1,
+                type: "fine-comments"
+              }
+            ]
+          },
           'word-smith': {
             data: {
               type: 'word-smiths',
@@ -248,6 +330,20 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
         attributes: {
           'first-name': "Link"
         },
+        relationships: {
+          "blog-posts": {
+            data: [
+              {
+                id: 1,
+                type: "blog-posts"
+              },
+              {
+                id: 2,
+                type: "blog-posts"
+              }
+            ]
+          }
+        }
       }
     ]
   });
@@ -257,10 +353,10 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blog-posts'],
+      include: ['blog-posts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith'],
+      include: ['word-smith'],
     })
   });
 
@@ -290,6 +386,14 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
         },
         id: 1,
         relationships: {
+          "fine-comments": {
+            data: [
+              {
+                id: 1,
+                type: "fine-comments"
+              }
+            ]
+          },
           'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
@@ -303,6 +407,9 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
           title: "Ipsum"
         },
         relationships: {
+          "fine-comments": {
+            data: []
+          },
           'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
@@ -316,13 +423,13 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blog-posts'],
+      include: ['blog-posts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['word-smith', 'fine-comments'],
+      include: ['word-smith', 'fine-comments'],
     }),
     fineComment: JsonApiSerializer.extend({
-      relationships: ['blog-post']
+      include: ['blog-post']
     })
   });
 

--- a/tests/integration/serializers/json-api-serializer/associations/model-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/model-test.js
@@ -24,7 +24,7 @@ test(`it can include a has many relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     })
   });
 
@@ -70,10 +70,10 @@ test(`it can include a chain of has-many relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['fineComments'],
+      relationships: ['fine-comments'],
     })
   });
 
@@ -138,7 +138,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['wordSmith'],
+      relationships: ['word-smith'],
     })
   });
 
@@ -177,7 +177,7 @@ test(`it gracefully handles null belongs-to relationship`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['wordSmith']
+      relationships: ['word-smith']
     })
   });
 
@@ -200,10 +200,10 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     blogPost: JsonApiSerializer.extend({
-      relationships: ['wordSmith'],
+      relationships: ['word-smith'],
     }),
     fineComment: JsonApiSerializer.extend({
-      relationships: ['blogPost'],
+      relationships: ['blog-post'],
     })
   });
 
@@ -257,10 +257,10 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['wordSmith'],
+      relationships: ['word-smith'],
     })
   });
 
@@ -316,13 +316,13 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
   let registry = new SerializerRegistry(this.schema, {
     application: JsonApiSerializer,
     wordSmith: JsonApiSerializer.extend({
-      relationships: ['blogPosts'],
+      relationships: ['blog-posts'],
     }),
     blogPost: JsonApiSerializer.extend({
-      relationships: ['wordSmith', 'fineComments'],
+      relationships: ['word-smith', 'fine-comments'],
     }),
     fineComment: JsonApiSerializer.extend({
-      relationships: ['blogPost']
+      relationships: ['blog-post']
     })
   });
 

--- a/tests/integration/serializers/json-api-serializer/associations/model-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/model-test.js
@@ -39,7 +39,7 @@ test(`it can include a has many relationship`, function(assert) {
         'first-name': 'Link',
       },
       relationships: {
-        blogPosts: {
+        'blog-posts': {
           data: [
             {type: 'blog-posts', id: 1},
             {type: 'blog-posts', id: 2},
@@ -88,7 +88,7 @@ test(`it can include a chain of has-many relationships`, function(assert) {
         'first-name': 'Link',
       },
       relationships: {
-        blogPosts: {
+        'blog-posts': {
           data: [
             {type: 'blog-posts', id: 1},
             {type: 'blog-posts', id: 2},
@@ -104,7 +104,7 @@ test(`it can include a chain of has-many relationships`, function(assert) {
           title: 'Lorem'
         },
         relationships: {
-          fineComments: {
+          'fine-comments': {
             data: [
               {type: 'fine-comments', id: 1},
             ]
@@ -125,7 +125,7 @@ test(`it can include a chain of has-many relationships`, function(assert) {
           title: 'Ipsum'
         },
         relationships: {
-          fineComments: {
+          'fine-comments': {
             data: []
           }
         }
@@ -153,7 +153,7 @@ test(`it can embed a belongs-to relationship`, function(assert) {
         title: 'Lorem'
       },
       relationships: {
-        wordSmith: {
+        'word-smith': {
           data: {
             id: 1,
             type: "word-smiths"
@@ -218,7 +218,7 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
         text: 'pwned'
       },
       relationships: {
-        blogPost: {
+        'blog-post': {
           data: {
             id: 1,
             type: "blog-posts"
@@ -234,7 +234,7 @@ test(`it can serialize a chain of belongs-to relationships`, function(assert) {
           title: 'Lorem'
         },
         relationships: {
-          wordSmith: {
+          'word-smith': {
             data: {
               type: 'word-smiths',
               id: 1
@@ -274,7 +274,7 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
       },
       id: 1,
       relationships: {
-        blogPosts: {
+        'blog-posts': {
           data: [
             {type: 'blog-posts', id: 1},
             {type: 'blog-posts', id: 2},
@@ -290,7 +290,7 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
         },
         id: 1,
         relationships: {
-          wordSmith: {
+          'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
         },
@@ -303,7 +303,7 @@ test(`it ignores relationships that refer to serialized ancestor resources`, fun
           title: "Ipsum"
         },
         relationships: {
-          wordSmith: {
+          'word-smith': {
             data: {type: 'word-smiths', id: 1}
           }
         },
@@ -336,7 +336,7 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
       },
       id: 1,
       relationships: {
-        blogPosts: {
+        'blog-posts': {
           data: [
             {type: 'blog-posts', id: 1},
             {type: 'blog-posts', id: 2},
@@ -353,10 +353,10 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
           title: "Lorem"
         },
         relationships: {
-          wordSmith: {
+          'word-smith': {
             data: {type: 'word-smiths', id: 1}
           },
-          fineComments: {
+          'fine-comments': {
             data: [
               {type: 'fine-comments', id: 1}
             ]
@@ -370,7 +370,7 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
           text: 'pwned'
         },
         relationships: {
-          blogPost: {
+          'blog-post': {
             data: {type: 'blog-posts', id: 1}
           }
         },
@@ -382,10 +382,10 @@ test(`it ignores relationships that refer to serialized ancestor resources, mult
           title: "Ipsum"
         },
         relationships: {
-          wordSmith: {
+          'word-smith': {
             data: {type: 'word-smiths', id: 1}
           },
-          fineComments: {
+          'fine-comments': {
             data: []
           }
         },

--- a/tests/integration/serializers/json-api-serializer/attribute-key-formatting-test.js
+++ b/tests/integration/serializers/json-api-serializer/attribute-key-formatting-test.js
@@ -32,7 +32,7 @@ test(`keyForAttribute formats the attributes of a model`, function(assert) {
 
   assert.deepEqual(result, {
     data: {
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 1,
       attributes: {
         age: 323,
@@ -52,14 +52,14 @@ test(`keyForAttribute also formats the models in a collections`, function(assert
 
   assert.deepEqual(result, {
     data: [{
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 1,
       attributes: {
         'first_name': 'Link',
         'last_name': 'Jackson',
       }
     }, {
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 2,
       attributes: {
         'first_name': 'Zelda',

--- a/tests/integration/serializers/json-api-serializer/attribute-key-formatting-test.js
+++ b/tests/integration/serializers/json-api-serializer/attribute-key-formatting-test.js
@@ -38,6 +38,11 @@ test(`keyForAttribute formats the attributes of a model`, function(assert) {
         age: 323,
         first_name: 'Link',
         last_name: 'Jackson'
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }
   });
@@ -57,6 +62,11 @@ test(`keyForAttribute also formats the models in a collections`, function(assert
       attributes: {
         'first_name': 'Link',
         'last_name': 'Jackson',
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }, {
       type: 'word-smiths',
@@ -64,6 +74,11 @@ test(`keyForAttribute also formats the models in a collections`, function(assert
       attributes: {
         'first_name': 'Zelda',
         'last_name': 'Brown',
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }]
   });

--- a/tests/integration/serializers/json-api-serializer/attrs-test.js
+++ b/tests/integration/serializers/json-api-serializer/attrs-test.js
@@ -31,6 +31,11 @@ test(`it returns only the whitelisted attrs when serializing a model`, function(
       id: 1,
       attributes: {
         'first-name': 'Link'
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }
   });
@@ -50,12 +55,22 @@ test(`it returns only the whitelisted attrs when serializing a collection`, func
       id: 1,
       attributes: {
         'first-name': 'Link'
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }, {
       type: 'word-smiths',
       id: 2,
         attributes: {
         'first-name': 'Zelda'
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }]
   });

--- a/tests/integration/serializers/json-api-serializer/attrs-test.js
+++ b/tests/integration/serializers/json-api-serializer/attrs-test.js
@@ -27,7 +27,7 @@ test(`it returns only the whitelisted attrs when serializing a model`, function(
   var result = this.registry.serialize(user);
   assert.deepEqual(result, {
     data: {
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 1,
       attributes: {
         'first-name': 'Link'
@@ -46,15 +46,15 @@ test(`it returns only the whitelisted attrs when serializing a collection`, func
 
   assert.deepEqual(result, {
     data: [{
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 1,
       attributes: {
         'first-name': 'Link'
       }
     }, {
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 2,
-      attributes: {
+        attributes: {
         'first-name': 'Zelda'
       }
     }]

--- a/tests/integration/serializers/json-api-serializer/base-test.js
+++ b/tests/integration/serializers/json-api-serializer/base-test.js
@@ -25,7 +25,7 @@ test(`it includes all attributes for a model`, function(assert) {
   let result = this.registry.serialize(user);
   assert.deepEqual(result, {
     data: {
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 1,
       attributes: {
         'first-name': 'Link',
@@ -45,14 +45,14 @@ test(`it inclues all attributes for each model in a collection`, function(assert
 
   assert.deepEqual(result, {
     data: [{
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 1,
       attributes: {
         'first-name': 'Link',
         age: 123
       }
     }, {
-      type: 'wordSmiths',
+      type: 'word-smiths',
       id: 2,
       attributes: {
         'first-name': 'Zelda',

--- a/tests/integration/serializers/json-api-serializer/base-test.js
+++ b/tests/integration/serializers/json-api-serializer/base-test.js
@@ -35,7 +35,7 @@ test(`it includes all attributes for a model`, function(assert) {
   });
 });
 
-test(`it inclues all attributes for each model in a collection`, function(assert) {
+test(`it includes all attributes for each model in a collection`, function(assert) {
   let schema = this.schema;
   schema.wordSmith.create({id: 1, firstName: 'Link', age: 123});
   schema.wordSmith.create({id: 2, firstName: 'Zelda', age: 456});

--- a/tests/integration/serializers/json-api-serializer/base-test.js
+++ b/tests/integration/serializers/json-api-serializer/base-test.js
@@ -30,6 +30,11 @@ test(`it includes all attributes for a model`, function(assert) {
       attributes: {
         'first-name': 'Link',
         age: 123
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }
   });
@@ -50,6 +55,11 @@ test(`it includes all attributes for each model in a collection`, function(asser
       attributes: {
         'first-name': 'Link',
         age: 123
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }, {
       type: 'word-smiths',
@@ -57,6 +67,11 @@ test(`it includes all attributes for each model in a collection`, function(asser
       attributes: {
         'first-name': 'Zelda',
         age: 456
+      },
+      relationships: {
+        "blog-posts": {
+          data: []
+        }
       }
     }]
   });

--- a/tests/integration/serializers/schema-helper.js
+++ b/tests/integration/serializers/schema-helper.js
@@ -19,7 +19,24 @@ export default {
       fineComment: Model.extend({
         blogPost: Mirage.belongsTo()
       }),
-      greatPhoto: Model
+      greatPhoto: Model,
+
+      foo: Model.extend({
+        bar: Mirage.belongsTo()
+      }),
+      bar: Model.extend({
+        baz: Mirage.belongsTo()
+      }),
+      baz: Model.extend({
+        quuxes: Mirage.hasMany()
+      }),
+      quux: Model.extend({
+        zomgs: Mirage.hasMany()
+      }),
+      zomg: Model.extend({
+        lol: Mirage.belongsTo()
+      }),
+      lol: Model
     });
 
     return this.schema;

--- a/tests/unit/serializers/json-api-serializer-test.js
+++ b/tests/unit/serializers/json-api-serializer-test.js
@@ -11,7 +11,7 @@ module('Unit | Serializers | JsonApiSerializer', {
 test('_combineRelationships should combine relationships from serializer and request', function(assert) {
 
   const otherSerializer = {
-    relationships: ['foo', 'bar']
+    include: ['foo', 'bar']
   };
 
   const request = {
@@ -29,7 +29,7 @@ test('_combineRelationships should combine relationships from serializer and req
 test('_combineRelationships should not choke on missing request', function(assert) {
 
   const otherSerializer = {
-    relationships: ['foo', 'bar']
+    include: ['foo', 'bar']
   };
 
   const result = this.serializer._combineRelationships(otherSerializer);
@@ -41,7 +41,7 @@ test('_combineRelationships should not choke on missing request', function(asser
 test('_combineRelationships should not choke on empty request', function(assert) {
 
   const otherSerializer = {
-    relationships: ['foo', 'bar']
+    include: ['foo', 'bar']
   };
 
   const request = {};
@@ -55,7 +55,7 @@ test('_combineRelationships should not choke on empty request', function(assert)
 test('_combineRelationships should not choke on empty queryParams', function(assert) {
 
   const otherSerializer = {
-    relationships: ['foo', 'bar']
+    include: ['foo', 'bar']
   };
 
   const request = {queryParams: {}};
@@ -69,7 +69,7 @@ test('_combineRelationships should not choke on empty queryParams', function(ass
 test('_combineRelationships should not choke on empty included', function(assert) {
 
   const otherSerializer = {
-    relationships: ['foo', 'bar']
+    include: ['foo', 'bar']
   };
 
   const request = {

--- a/tests/unit/serializers/json-api-serializer-test.js
+++ b/tests/unit/serializers/json-api-serializer-test.js
@@ -11,7 +11,7 @@ module('Unit | Serializers | JsonApiSerializer', {
   }
 });
 
-test('_getRelationships should prefer relationships from request', function(assert) {
+test('_getRelationshipNames should prefer relationships from request', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
@@ -23,25 +23,25 @@ test('_getRelationships should prefer relationships from request', function(asse
     }
   };
 
-  const result = this.serializer._getRelationships(otherSerializer, request);
+  const result = this.serializer._getRelationshipNames(otherSerializer, request);
 
   assert.deepEqual(result, ['baz', 'quux']);
 });
 
 
-test('_getRelationships should not choke on missing request', function(assert) {
+test('_getRelationshipNames should not choke on missing request', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
   };
 
-  const result = this.serializer._getRelationships(otherSerializer);
+  const result = this.serializer._getRelationshipNames(otherSerializer);
 
   assert.deepEqual(result, ['foo', 'bar']);
 });
 
 
-test('_getRelationships should not choke on empty request', function(assert) {
+test('_getRelationshipNames should not choke on empty request', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
@@ -49,13 +49,13 @@ test('_getRelationships should not choke on empty request', function(assert) {
 
   const request = {};
 
-  const result = this.serializer._getRelationships(otherSerializer, request);
+  const result = this.serializer._getRelationshipNames(otherSerializer, request);
 
   assert.deepEqual(result, ['foo', 'bar']);
 });
 
 
-test('_getRelationships should not choke on empty queryParams', function(assert) {
+test('_getRelationshipNames should not choke on empty queryParams', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
@@ -63,13 +63,13 @@ test('_getRelationships should not choke on empty queryParams', function(assert)
 
   const request = {queryParams: {}};
 
-  const result = this.serializer._getRelationships(otherSerializer, request);
+  const result = this.serializer._getRelationshipNames(otherSerializer, request);
 
   assert.deepEqual(result, ['foo', 'bar']);
 });
 
 
-test('_getRelationships should not choke on empty included', function(assert) {
+test('_getRelationshipNames should not choke on empty included', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
@@ -81,13 +81,13 @@ test('_getRelationships should not choke on empty included', function(assert) {
     }
   };
 
-  const result = this.serializer._getRelationships(otherSerializer, request);
+  const result = this.serializer._getRelationshipNames(otherSerializer, request);
 
   assert.deepEqual(result, []);
 });
 
 
-test('_getRelationships should not choke on missing serializer.relationships', function(assert) {
+test('_getRelationshipNames should not choke on missing serializer.relationships', function(assert) {
 
   const request = {
     queryParams: {
@@ -95,7 +95,7 @@ test('_getRelationships should not choke on missing serializer.relationships', f
     }
   };
 
-  const result = this.serializer._getRelationships(undefined, request);
+  const result = this.serializer._getRelationshipNames(undefined, request);
 
   assert.deepEqual(result, ['baz', 'quux']);
 });

--- a/tests/unit/serializers/json-api-serializer-test.js
+++ b/tests/unit/serializers/json-api-serializer-test.js
@@ -1,0 +1,98 @@
+import JsonApiSerializer from 'ember-cli-mirage/serializers/json-api-serializer';
+
+import {module, test} from 'qunit';
+
+module('Unit | Serializers | JsonApiSerializer', {
+  beforeEach() {
+    this.serializer = new JsonApiSerializer();
+  }
+});
+
+test('_combineRelationships should combine relationships from serializer and request', function(assert) {
+
+  const otherSerializer = {
+    relationships: ['foo', 'bar']
+  };
+
+  const request = {
+    queryParams: {
+      include: 'baz,quux'
+    }
+  };
+
+  const result = this.serializer._combineRelationships(otherSerializer, request);
+
+  assert.deepEqual(result, ['foo', 'bar', 'baz', 'quux']);
+});
+
+
+test('_combineRelationships should not choke on missing request', function(assert) {
+
+  const otherSerializer = {
+    relationships: ['foo', 'bar']
+  };
+
+  const result = this.serializer._combineRelationships(otherSerializer);
+
+  assert.deepEqual(result, ['foo', 'bar']);
+});
+
+
+test('_combineRelationships should not choke on empty request', function(assert) {
+
+  const otherSerializer = {
+    relationships: ['foo', 'bar']
+  };
+
+  const request = {};
+
+  const result = this.serializer._combineRelationships(otherSerializer, request);
+
+  assert.deepEqual(result, ['foo', 'bar']);
+});
+
+
+test('_combineRelationships should not choke on empty queryParams', function(assert) {
+
+  const otherSerializer = {
+    relationships: ['foo', 'bar']
+  };
+
+  const request = {queryParams: {}};
+
+  const result = this.serializer._combineRelationships(otherSerializer, request);
+
+  assert.deepEqual(result, ['foo', 'bar']);
+});
+
+
+test('_combineRelationships should not choke on empty included', function(assert) {
+
+  const otherSerializer = {
+    relationships: ['foo', 'bar']
+  };
+
+  const request = {
+    queryParams: {
+      included: ''
+    }
+  };
+
+  const result = this.serializer._combineRelationships(otherSerializer, request);
+
+  assert.deepEqual(result, ['foo', 'bar']);
+});
+
+
+test('_combineRelationships should not choke on missing serializer.relationships', function(assert) {
+
+  const request = {
+    queryParams: {
+      include: 'baz,quux'
+    }
+  };
+
+  const result = this.serializer._combineRelationships(undefined, request);
+
+  assert.deepEqual(result, ['baz', 'quux']);
+});

--- a/tests/unit/serializers/json-api-serializer-test.js
+++ b/tests/unit/serializers/json-api-serializer-test.js
@@ -1,4 +1,7 @@
 import JsonApiSerializer from 'ember-cli-mirage/serializers/json-api-serializer';
+import schemaHelper from '../../integration/serializers/schema-helper';
+import _map from 'lodash/collection/map';
+import _includes from 'lodash/collection/includes';
 
 import {module, test} from 'qunit';
 
@@ -8,7 +11,7 @@ module('Unit | Serializers | JsonApiSerializer', {
   }
 });
 
-test('_combineRelationships should combine relationships from serializer and request', function(assert) {
+test('_getRelationships should prefer relationships from request', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
@@ -20,25 +23,25 @@ test('_combineRelationships should combine relationships from serializer and req
     }
   };
 
-  const result = this.serializer._combineRelationships(otherSerializer, request);
+  const result = this.serializer._getRelationships(otherSerializer, request);
 
-  assert.deepEqual(result, ['foo', 'bar', 'baz', 'quux']);
+  assert.deepEqual(result, ['baz', 'quux']);
 });
 
 
-test('_combineRelationships should not choke on missing request', function(assert) {
+test('_getRelationships should not choke on missing request', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
   };
 
-  const result = this.serializer._combineRelationships(otherSerializer);
+  const result = this.serializer._getRelationships(otherSerializer);
 
   assert.deepEqual(result, ['foo', 'bar']);
 });
 
 
-test('_combineRelationships should not choke on empty request', function(assert) {
+test('_getRelationships should not choke on empty request', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
@@ -46,13 +49,13 @@ test('_combineRelationships should not choke on empty request', function(assert)
 
   const request = {};
 
-  const result = this.serializer._combineRelationships(otherSerializer, request);
+  const result = this.serializer._getRelationships(otherSerializer, request);
 
   assert.deepEqual(result, ['foo', 'bar']);
 });
 
 
-test('_combineRelationships should not choke on empty queryParams', function(assert) {
+test('_getRelationships should not choke on empty queryParams', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
@@ -60,13 +63,13 @@ test('_combineRelationships should not choke on empty queryParams', function(ass
 
   const request = {queryParams: {}};
 
-  const result = this.serializer._combineRelationships(otherSerializer, request);
+  const result = this.serializer._getRelationships(otherSerializer, request);
 
   assert.deepEqual(result, ['foo', 'bar']);
 });
 
 
-test('_combineRelationships should not choke on empty included', function(assert) {
+test('_getRelationships should not choke on empty included', function(assert) {
 
   const otherSerializer = {
     include: ['foo', 'bar']
@@ -74,17 +77,17 @@ test('_combineRelationships should not choke on empty included', function(assert
 
   const request = {
     queryParams: {
-      included: ''
+      include: ''
     }
   };
 
-  const result = this.serializer._combineRelationships(otherSerializer, request);
+  const result = this.serializer._getRelationships(otherSerializer, request);
 
-  assert.deepEqual(result, ['foo', 'bar']);
+  assert.deepEqual(result, []);
 });
 
 
-test('_combineRelationships should not choke on missing serializer.relationships', function(assert) {
+test('_getRelationships should not choke on missing serializer.relationships', function(assert) {
 
   const request = {
     queryParams: {
@@ -92,7 +95,44 @@ test('_combineRelationships should not choke on missing serializer.relationships
     }
   };
 
-  const result = this.serializer._combineRelationships(undefined, request);
+  const result = this.serializer._getRelationships(undefined, request);
 
   assert.deepEqual(result, ['baz', 'quux']);
+});
+
+
+test('_getRelatedModelWithPath belongsTo', function(assert) {
+  const schema = schemaHelper.setup();
+
+  const foo = schema.foo.create();
+  const bar = foo.createBar();
+  foo.save();
+  const baz = bar.createBaz();
+  bar.save();
+  const quux1 = baz.createQuux();
+  const quux2 = baz.createQuux();
+  baz.save();
+  const zomg1 = quux1.createZomg();
+  const zomg2 = quux1.createZomg();
+  quux1.save();
+  const zomg3 = quux2.createZomg();
+  const zomg4 = quux2.createZomg();
+  quux2.save();
+  const lol1 = zomg1.createLol();
+  const lol2 = zomg2.createLol();
+  const lol3 = zomg3.createLol();
+  const lol4 = zomg4.createLol();
+  zomg1.save();
+  zomg2.save();
+  zomg3.save();
+  zomg4.save();
+
+  const result = this.serializer._getRelatedWithPath(foo, 'bar.baz.quuxes.zomgs.lol');
+  const ids = _map(result, 'id');
+
+  assert.equal(result.length, 4);
+  assert.ok(_includes(ids, lol1.id));
+  assert.ok(_includes(ids, lol2.id));
+  assert.ok(_includes(ids, lol3.id));
+  assert.ok(_includes(ids, lol4.id));
 });


### PR DESCRIPTION
### 1. Updated JsonApiSerializer to use dasherized types

JSONAPI [recommends](http://jsonapi.org/recommendations/#naming) to use dasherized types. Though not a strict requirement, that's what Ember uses. Ember ignores camel-cased types.


### 2. Updated serializer relationships to use dasherized strings rather than camelized

You said the convention is to use camel case in property keys and dashes in strings. It sucked to write `relationships: ['fooBar']`. I refactored the serializer layer to work with `relationships: ['foo-bar']`.


### 3. Support for `included` query param in JsonApiSerializer

Now JsonApiSerializer combines relationship names from `serializer.relationships` and `request.queryParams.include`.


### 4. `serializer.relationships` is changed to `serializer.include`

According to jsonapi.org, a resource object **MAY** contain a relationships object. However, members of the relationships object ("relationships") are said to "represent references from the resource object in which it's defined to other resource objects". I. e. it is not said that relationships are allowed to be omitted.

Rails' JSONAPI::Resources serializes all defined relationships unconditionally.

Also, I can't think of a use case where serialization of a relationship is undesired.

Thus, I renamed `serializer.relationships` to `serializer.include`. This property now only controls which resources should be sideloaded by default. As for relationships within resource objects, they are all serialized.

Tests updated accordingly.


* * *

Notes:

1. It might be more informative to look at changes per commit. I'm sorry it's all in one PR, but each subsequent commit is dependent on the previous one, so I was unable to file them separately against `origin/master`.
2. There's a fixup commit which I was unable to squash (there were changes already that disallowed changing the order of commits).
2. Everything is tested with automated tests. Existing tests updated, new tests written.
3. Tested in a real app.
4. There's repetetive use of `camelize(key)`. Might make sense to extract it into a method.
5. I had to assert against empty `relationships: {'blog-posts': { data: [] }}` into some tests. That's optional output, so making it a requirement is not very good. But that's what the serializer was returning, and I didn't bother to refactor `propEqual` into a more elaborate assertion that allows for optional empty relationships.
