### PR TITLE
use startMirage function consistently

### DIFF
--- a/docs/v0.1.x/manually-starting-mirage.md
+++ b/docs/v0.1.x/manually-starting-mirage.md
@@ -11,7 +11,7 @@ Eventually we'll extract Mirage's initializer, but for now you can use this work
 // tests/helpers/setup-mirage-for-integration.js
 import mirageInitializer from '../../initializers/ember-cli-mirage';
 
-export default function setupMirage(container) {
+export default function startMirage(container) {
   mirageInitializer.initialize(container);
 }
 ```


### PR DESCRIPTION
Ensure that in both the component test and the helper we use the same `startMirage` function name.