### PR TITLE
Add space in Factory string

### DIFF
--- a/docs/v0.1.x/factories.md
+++ b/docs/v0.1.x/factories.md
@@ -34,7 +34,7 @@ import Mirage from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
   name: function(i) {
-    return 'User' + i
+    return 'User ' + i
   }
 });
 ```


### PR DESCRIPTION
This addition means that there is the stated space between `User` and the sequence-generated "id" in the `name` function.

I know this is a tiny nit-pick but it caught my eye!  I hope this is a reasonable (tiny tiny _tiny_) contribution to Mirage as I learn the system.