### PR TITLE
Make link to issue via HTML anchor tag.

### DIFF
--- a/docs/v0.1.x/factories.md
+++ b/docs/v0.1.x/factories.md
@@ -42,7 +42,7 @@ export default Mirage.Factory.extend({
 The first user generated (per test) would have a name of `User 1`, the second a name of `User 2`, and so on.
 
 <aside class='Docs-page__aside'>
-  <p>Currently, you cannot reference dynamic attributes, although this is [in the works](https://github.com/samselikoff/ember-cli-mirage/issues/27).</p>
+  <p>Currently, you cannot reference dynamic attributes, although this is <a href='https://github.com/samselikoff/ember-cli-mirage/issues/27'>in the works</a></p>
 </aside>
 
 Finally, you can also reference static attributes (numbers, strings or booleans) within your dynamic attributes via `this`:


### PR DESCRIPTION
It appears that Markdown-style links do not work within HTML tags.  Use HTML
instead!

<img width="727" alt="Before!" src="https://cloud.githubusercontent.com/assets/996477/11771758/e8c3deec-a1d1-11e5-82c4-fac283902055.png">

<img width="696" alt="After!" src="https://cloud.githubusercontent.com/assets/996477/11771757/e8c2d114-a1d1-11e5-8a32-0944722e382a.png">
