### PR TITLE
Port #429, #430, and #431 to the v0.2.x docs

### DIFF
--- a/docs/v0.2.x/factories.md
+++ b/docs/v0.2.x/factories.md
@@ -34,7 +34,7 @@ import Mirage from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
   name: function(i) {
-    return 'User' + i
+    return 'User ' + i
   }
 });
 ```
@@ -42,7 +42,7 @@ export default Mirage.Factory.extend({
 The first user generated (per test) would have a name of `User 1`, the second a name of `User 2`, and so on.
 
 <aside class='Docs-page__aside'>
-  <p>Currently, you cannot reference dynamic attributes, although this is [in the works](https://github.com/samselikoff/ember-cli-mirage/issues/27).</p>
+  <p>Currently, you cannot reference dynamic attributes, although this is <a href='https://github.com/samselikoff/ember-cli-mirage/issues/27'>in the works</a></p>
 </aside>
 
 Finally, you can also reference static attributes (numbers, strings or booleans) within your dynamic attributes via `this`:

--- a/docs/v0.2.x/manually-starting-mirage.md
+++ b/docs/v0.2.x/manually-starting-mirage.md
@@ -11,7 +11,7 @@ Eventually we'll extract Mirage's initializer, but for now you can use this work
 // tests/helpers/setup-mirage-for-integration.js
 import mirageInitializer from '../../initializers/ember-cli-mirage';
 
-export default function setupMirage(container) {
+export default function startMirage(container) {
   mirageInitializer.initialize(container);
 }
 ```


### PR DESCRIPTION
This is a series of changes made to the v0.1.x docs that should probably be merged into the upcoming release docs.

I did not _back_ update to prior versions but could do the same if that's appropriate?