### PR TITLE
Polymorphic relations and different model types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ jekyll-tmp
 # IDE
 /.idea/
 /*.iml
+.DS_Store

--- a/addon/index.js
+++ b/addon/index.js
@@ -6,11 +6,12 @@ import Serializer from './serializer';
 import HasMany from './orm/associations/has-many';
 import BelongsTo from './orm/associations/belongs-to';
 
-function hasMany(type) {
-  return new HasMany(type);
+function hasMany(type, options) {
+  return new HasMany(type, options);
 }
-function belongsTo(type) {
-  return new BelongsTo(type);
+
+function belongsTo(type, options) {
+  return new BelongsTo(type, options);
 }
 
 export {
@@ -27,5 +28,5 @@ export default {
   Factory,
   Response,
   hasMany,
-  belongsTo
+  belongsTo,
 };

--- a/addon/orm/associations/association.js
+++ b/addon/orm/associations/association.js
@@ -1,6 +1,6 @@
 class Association {
 
-  constructor(type) {
+  constructor(type, options = {}) {
     this.type = type;
 
     // The model type that owns this association
@@ -8,6 +8,10 @@ class Association {
 
     // The model type this association refers to
     this.target = '';
+
+    this.options = options;
+
+    this.key = '';
   }
 
 }

--- a/addon/orm/collection.js
+++ b/addon/orm/collection.js
@@ -8,11 +8,13 @@ var Collection = function(type, ...args) {
   if (!type || typeof type !== 'string') {
     throw 'You must pass a type into a Collection';
   }
+
   this.type = type;
 
   if (_isArray(args[0])) {
     args = args[0];
   }
+
   this.push.apply(this, args);
 
   this.update = function(key, val) {

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -16,6 +16,7 @@ class Model {
 
   constructor(schema, type, attrs, fks) {
     if (!schema) { throw 'Mirage: A model requires a schema'; }
+
     if (!type) { throw 'Mirage: A model requires a type'; }
 
     this._schema = schema;
@@ -108,7 +109,6 @@ class Model {
     return this;
   }
 
-
   // Private
   /*
     model.attrs represents the persistable attributes, i.e. your db
@@ -154,8 +154,11 @@ class Model {
 
     // Define the getter/setter
     Object.defineProperty(this, attr, {
-      get: function () { return this.attrs[attr]; },
-      set: function (val) { this.attrs[attr] = val; return this; },
+      get: function() { return this.attrs[attr]; },
+
+      set: function(val) {
+        this.attrs[attr] = val; return this;
+      },
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-cli-mirage",
-  "version": "0.2.0-beta.1",
-  "description": "A client-side mock HTTP server to develop, test and demo your Ember app",
-  "license": "MIT",
-  "directories": {
-    "doc": "doc",
-    "test": "tests"
-  },
+    "version": "0.2.0-beta.1",
+    "description": "A client-side mock HTTP server to develop, test and demo your Ember app",
+    "license": "MIT",
+    "directories": {
+      "doc": "doc",
+      "test": "tests"
+    },
   "scripts": {
     "start": "ember server",
     "build": "ember build",

--- a/tests/integration/schema/belongs-to/model-types-test.js
+++ b/tests/integration/schema/belongs-to/model-types-test.js
@@ -1,0 +1,52 @@
+import Mirage from 'ember-cli-mirage';
+import Model from 'ember-cli-mirage/orm/model';
+
+import Schema from 'ember-cli-mirage/orm/schema';
+
+import Db from 'ember-cli-mirage/db';
+import {module, test} from 'qunit';
+
+module('Integration | Schema | belongsTo different model`s types', {
+  beforeEach: function() {
+    var User = Model.extend({
+      posts: Mirage.hasMany('post', {inverse: 'writer'}),
+    });
+
+    var Post = Model.extend({
+      writer: Mirage.belongsTo('user'),
+      editor: Mirage.belongsTo('user'),
+    });
+
+    this.db = new Db({
+      users: [],
+      posts: [],
+    });
+    this.schema = new Schema(this.db);
+
+    this.schema.registerModels({
+      user: User,
+      post: Post,
+    });
+  },
+});
+
+test('post has a writer as user type', function(assert) {
+  this.schema.create('user', {name: 'Exelord'});
+  this.schema.create('post', {title: 'Post about polymorphic', writerId: 1});
+
+  let user = this.schema.user.find(1);
+  let post = this.schema.post.find(1);
+
+  assert.equal(post.writer.id, user.id);
+});
+
+test('user has many posts through writer type', function(assert) {
+  this.schema.create('user', {name: 'Exelord'});
+  this.schema.create('user', {name: 'Exelord The Best Editor'});
+  this.schema.create('post', {title: 'Post about polymorphic', writerId: 1, editorId: 2});
+
+  let user = this.schema.user.find(1);
+  let post = this.schema.post.find(1);
+
+  assert.equal(user.posts[0].id, post.id);
+});

--- a/tests/integration/schema/belongs-to/polymorphic-test.js
+++ b/tests/integration/schema/belongs-to/polymorphic-test.js
@@ -1,0 +1,63 @@
+import Mirage from 'ember-cli-mirage';
+import Model from 'ember-cli-mirage/orm/model';
+
+import Schema from 'ember-cli-mirage/orm/schema';
+
+import Db from 'ember-cli-mirage/db';
+import {module, test} from 'qunit';
+
+module('Integration | Schema | belongsTo polymorphic relations', {
+  beforeEach: function() {
+    var Member = Model.extend({
+      resource: Mirage.belongsTo('resource', {polymorphic: true}),
+    });
+
+    var Resource = Model.extend({
+      members: Mirage.hasMany(),
+    });
+
+    var Post = Resource.extend();
+
+    this.db = new Db({
+      members: [],
+      posts: [],
+    });
+
+    this.schema = new Schema(this.db);
+
+    this.schema.registerModels({
+      member: Member,
+      post: Post,
+    });
+  },
+});
+
+test('create polymorphic relation', function(assert) {
+  this.schema.create('post', {title: 'Resource with polymorphic relation'});
+  this.schema.create('member', {name: 'Exelord', resourceId: 1, resourceType: 'post'});
+
+  let member = this.schema.member.find(1);
+  let post = this.schema.post.find(1);
+
+  assert.equal(member.resource.id, post.id);
+  assert.equal(post.members[0].id, member.id);
+});
+
+test('update polymorphic relation', function(assert) {
+  this.schema.create('post', {title: 'Resource with polymorphic relation'});
+  this.schema.create('post', {title: 'Another Resource with polymorphic relation'});
+
+  this.schema.create('member', {name: 'Exelord', resourceId: 1, resourceType: 'post'});
+  this.schema.create('member', {name: 'Maciej', resourceId: 2, resourceType: 'post'});
+
+  let member = this.schema.member.find(1);
+  let anotherMember = this.schema.member.find(2);
+  let post = this.schema.post.find(1);
+  let anotherPost = this.schema.post.find(2);
+
+  member.update({resource: anotherPost});
+  post.update({members: [anotherMember]});
+
+  assert.equal(member.resource.id, anotherPost.id);
+  assert.equal(post.members[0].id, anotherMember.id);
+});


### PR DESCRIPTION
Hey,
I just created new branch for better developing the feature.

So, what i implemented here:
## You can create polymorphic relations

Here is an example of model structure:

``` js
    var Member = Model.extend({
      resource: Mirage.belongsTo('resource', {polymorphic: true}),
    });

    var Resource = Model.extend({
      members: Mirage.hasMany(),
    });

    var Post = Resource.extend();
```

I have to still write a better tests for that because there is a lot of edge cases. But It seams works if you care :)!
## You can change the type of `belongsTo` models if you wish

And here is an example of structure:

``` js
    var User = Model.extend({
      posts: Mirage.hasMany('post', {inverse: 'writer'}),
    });

    var Post = Model.extend({
      writer: Mirage.belongsTo('user'),
      editor: Mirage.belongsTo('user'),
    });

```

> Warning! For now it only works for `belongsTo`
### The problems I have unresolved :(

If i have 

``` js
    var User = Model.extend({
      account: Mirage.belongsTo(),
    });

    var Account = Model.extend({
      users: Mirage.hasMany(),
    });


    this.schema.create('user', {name: 'Exelord'});
    this.schema.create('user', {name: 'Sam'});
```

and I create an associated `Account`:

```
this.schema.create('account', {name: 'Apple', userIds: [1,2]});
```

It drops into infinity loop :/ Probably on model find() methods :/

Have you any ideas? It's also a bug on master branch.
