### PR TITLE
Adds a mirage-serializer blueprint

### DIFF
--- a/blueprints/mirage-serializer/files/__root__/mirage/serializers/__name__.js
+++ b/blueprints/mirage-serializer/files/__root__/mirage/serializers/__name__.js
@@ -1,0 +1,4 @@
+import JsonApiSerializer from 'ember-cli-mirage/serializers/json-api-serializer';
+
+export default JsonApiSerializer.extend({
+});

--- a/blueprints/mirage-serializer/index.js
+++ b/blueprints/mirage-serializer/index.js
@@ -1,0 +1,21 @@
+/*jshint node:true*/
+
+'use strict';
+
+var path = require('path');
+
+module.exports = {
+  description: 'Generates a Mirage serializer.',
+
+  fileMapTokens: function() {
+    return {
+      __root__: function(options) {
+        if (options.inAddon) {
+          return path.join('tests', 'dummy');
+        }
+
+        return '/';
+      }
+    };
+  },
+};


### PR DESCRIPTION
Because why not :wink: 

FYI, the blueprint defaults to `JsonApiSerializer`.