### PR TITLE
Add docs to migrate from 0.1.x to 0.2.x

### DIFF
--- a/docs/v0.2.x/installing-and-updating.md
+++ b/docs/v0.2.x/installing-and-updating.md
@@ -45,3 +45,12 @@ To use beta, run
 ```sh
 ember install ember-cli-mirage@v0.2.0-beta.1
 ```
+
+### Updating to beta
+
+If your app uses `0.1.x` and you want to upgrade to `0.2.x`, run
+
+```sh
+rm -fr mirage
+mv app/mirage mirage
+```


### PR DESCRIPTION
When migrating from `0.1.x` to `0.2.x`, the default folder for Mirage moves from `/app/mirage` to `/mirage`.

Having files in both folders __do__ conflict, I've spent quite some time figuring out why `/mirage/config.js` was not interpreted.
The reason is `/app/mirage/config.js` takes precedence.
The fix is to move everything from `/app/mirage` to `/mirage`.

Maybe a code-based solution should be planned, but a documentation quickfix might help potential users meanwhile.