### PR TITLE
shorthands cleanup

### DIFF
--- a/addon/route-handlers/shorthands/delete.js
+++ b/addon/route-handlers/shorthands/delete.js
@@ -10,10 +10,10 @@ export default class DeleteShorthandRouteHandler extends BaseShorthandRouteHandl
     This would remove the user with id :id:
       Ex: this.del('/contacts/:id', 'user');
   */
-  handleStringShorthand(modelName, schema, request) {
+  handleStringShorthand(request, modelName) {
     let id = this._getIdForRequest(request);
     let type = camelize(modelName);
-    let modelClass = schema[type];
+    let modelClass = this.schema[type];
 
     assert(
       modelClass,
@@ -30,11 +30,11 @@ export default class DeleteShorthandRouteHandler extends BaseShorthandRouteHandl
     as this contact's addresses and phone numbers.
       Ex: this.del('/contacts/:id', ['contact', 'addresses', 'numbers');
   */
-  handleArrayShorthand(array, schema, request) {
+  handleArrayShorthand(request, array) {
     let id = this._getIdForRequest(request);
     let parentType = camelize(array[0]);
     let childTypes = array.slice(1).map(camelize);
-    let parent = schema[parentType].find(id);
+    let parent = this.schema[parentType].find(id);
 
     // Delete related children
     childTypes.forEach(type => {

--- a/addon/route-handlers/shorthands/get.js
+++ b/addon/route-handlers/shorthands/get.js
@@ -11,10 +11,10 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
       this.get('/contacts', 'contact');
       this.get('/contacts/:id', 'contact');
   */
-  handleStringShorthand(modelName, schema, request, options = {}) {
+  handleStringShorthand(request, modelName) {
     let id = this._getIdForRequest(request);
     let type = camelize(modelName);
-    let modelClass = schema[type];
+    let modelClass = this.schema[type];
 
     assert(
       modelClass,
@@ -23,7 +23,7 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
 
     if (id) {
       return modelClass.find(id);
-    } else if (options.coalesce && request.queryParams && request.queryParams.ids) {
+    } else if (this.options.coalesce && request.queryParams && request.queryParams.ids) {
       return modelClass.find(request.queryParams.ids);
     } else {
       return modelClass.all();
@@ -35,7 +35,7 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
 
     Ex: this.get('/home', ['contacts', 'pictures']);
   */
-  handleArrayShorthand(array, schema, request) {
+  handleArrayShorthand(request, array) {
     let keys = array;
 
     let id = this._getIdForRequest(request);
@@ -57,7 +57,7 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
       model, adding the relationships there.`
     );
 
-    return keys.map(type => schema[singularize(type)].all());
+    return keys.map(type => this.schema[singularize(type)].all());
   }
 
 }

--- a/addon/route-handlers/shorthands/post.js
+++ b/addon/route-handlers/shorthands/post.js
@@ -10,10 +10,10 @@ export default class PostShorthandRouteHandler extends BaseShorthandRouteHandler
     For example, this will push a 'user':
       this.post('/contacts', 'user');
   */
-  handleStringShorthand(modelName, schema, request) {
+  handleStringShorthand(request, modelName) {
     let type = camelize(modelName);
     let attrs = this._getAttrsForRequest(request);
-    let modelClass = schema[type];
+    let modelClass = this.schema[type];
 
     assert(
       modelClass,

--- a/addon/route-handlers/shorthands/put.js
+++ b/addon/route-handlers/shorthands/put.js
@@ -9,11 +9,11 @@ export default class PutShorthandRouteHandler extends BaseShorthandRouteHandler 
 
       this.put('/contacts/:id', 'user');
   */
-  handleStringShorthand(modelName, schema, request) {
+  handleStringShorthand(request, modelName) {
     let id = this._getIdForRequest(request);
     let type = camelize(modelName);
     let attrs = this._getAttrsForRequest(request);
-    let modelClass = schema[type];
+    let modelClass = this.schema[type];
 
     assert(
       modelClass,


### PR DESCRIPTION
* moved selecting request handler to constructor
* made more explicit selecting handler
* changed order and removed unnecessary arguments for handler methods