### PR TITLE
always pass Serializer.serialize the request as a second argument

### DIFF
--- a/tests/integration/serializers/base/override-serialize-test.js
+++ b/tests/integration/serializers/base/override-serialize-test.js
@@ -6,13 +6,6 @@ import { module, test } from 'qunit';
 module('Integration | Serializers | Base | Overriding Serialize', {
   beforeEach() {
     this.schema = schemaHelper.setup();
-    this.registry = new SerializerRegistry(this.schema, {
-      wordSmith: Serializer.extend({
-        serialize(response, request) {
-          return 'blah';
-        }
-      })
-    });
   },
   afterEach() {
     this.schema.db.emptyData();
@@ -20,6 +13,14 @@ module('Integration | Serializers | Base | Overriding Serialize', {
 });
 
 test(`it can use a completely custom serialize function`, function(assert) {
+  this.registry = new SerializerRegistry(this.schema, {
+    wordSmith: Serializer.extend({
+      serialize(response, request) {
+        return 'blah';
+      }
+    })
+  });
+
   let wordSmith = this.schema.wordSmith.create({
     id: 1,
     title: 'Link',
@@ -29,5 +30,27 @@ test(`it can use a completely custom serialize function`, function(assert) {
 
   assert.deepEqual(result, {
     wordSmith: 'blah'
+  });
+});
+
+test(`it can access the request in a custom serialize function`, function(assert) {
+  this.registry = new SerializerRegistry(this.schema, {
+    wordSmith: Serializer.extend({
+      serialize(response, request) {
+        return request.queryParams.foo || 'blah';
+      }
+    })
+  });
+
+  let wordSmith = this.schema.wordSmith.create({
+    id: 1,
+    title: 'Link',
+  });
+
+  let request = {url: '/word-smiths/1?foo=bar', params: {id: '1'}, queryParams: {foo: 'bar'}};
+  let result = this.registry.serialize(wordSmith, request);
+
+  assert.deepEqual(result, {
+    wordSmith: 'bar'
   });
 });


### PR DESCRIPTION
http://www.ember-cli-mirage.com/docs/v0.2.0-beta.3/serializers/#serializeresponse-request

Sometimes while on the way to the serializer's serialize function, the request argument gets left behind. These changes should make sure it gets there.