### PR TITLE
attempt at #506, passing modelName to registry.normalize for AMS compatibility

### DIFF
--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -78,10 +78,10 @@ export default class BaseShorthandRouteHandler {
     return body;
   }
 
-  _getAttrsForRequest(request) {
+  _getAttrsForRequest(request, modelName) {
     let id = this._getIdForRequest(request);
     let json = this._getJsonBodyForRequest(request);
-    let jsonApiDoc = this.serializerOrRegistry.normalize(json);
+    let jsonApiDoc = this.serializerOrRegistry.normalize(json, modelName);
 
     assert(
       jsonApiDoc.data && jsonApiDoc.data.attributes,

--- a/addon/route-handlers/shorthands/post.js
+++ b/addon/route-handlers/shorthands/post.js
@@ -12,7 +12,7 @@ export default class PostShorthandRouteHandler extends BaseShorthandRouteHandler
   */
   handleStringShorthand(request, modelName) {
     let type = camelize(modelName);
-    let attrs = this._getAttrsForRequest(request);
+    let attrs = this._getAttrsForRequest(request, modelName);
     let modelClass = this.schema[type];
 
     assert(

--- a/addon/route-handlers/shorthands/put.js
+++ b/addon/route-handlers/shorthands/put.js
@@ -12,7 +12,7 @@ export default class PutShorthandRouteHandler extends BaseShorthandRouteHandler 
   handleStringShorthand(request, modelName) {
     let id = this._getIdForRequest(request);
     let type = camelize(modelName);
-    let attrs = this._getAttrsForRequest(request);
+    let attrs = this._getAttrsForRequest(request, modelName);
     let modelClass = this.schema[type];
 
     assert(

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -23,9 +23,8 @@ export default class SerializerRegistry {
     this._serializerMap = serializerMap;
   }
 
-  normalize(payload) {
-    let model = payload[Object.keys(payload)[0]];
-    return this._serializerFor(model.modelName).normalize(payload);
+  normalize(payload, modelName) {
+    return this._serializerFor(modelName).normalize(payload);
   }
 
   serialize(response, request) {


### PR DESCRIPTION
In #506, when AMS serializers used registry.normalize, they didn't have a model.modelName property. Now instead of discovering modelName from the payload props, we can pass it down from the shorthands. 