### PR TITLE
Camelize type of schema._collectionForType

### DIFF
--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -112,7 +112,7 @@ export default function(db) {
     Private methods
   */
   this._collectionForType = function(type) {
-    var collection = pluralize(type);
+    var collection = pluralize(camelize(type));
     if (!this.db[collection]) {
       throw 'Mirage: You\'re trying to find model(s) of type ' + type + ' but this collection doesn\'t exist in the database.';
     }


### PR DESCRIPTION
This fixes dasherlized collection finding error like `schema.find('item-option', 1)`
in route handlers.
I'm not sure if this is a bug or a feature. But I guess it would be nice that you can
write with dasherized `schema.find('foo-bar', id)` same as `server.createList('foo-bar', 10)`.