### PR TITLE
filtering for existence

### DIFF
--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -126,6 +126,7 @@ export default class SerializerRegistry {
     // Traverse this model's relationships
     serializer.include
       .map(key => model[camelize(key)])
+      .filter(Boolean)
       .forEach(relationship => {
         let relatedModels = isModel(relationship) ? [relationship] : relationship;
 

--- a/tests/integration/serializers/base/associations/sideloading-collection-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-collection-test.js
@@ -193,3 +193,21 @@ test(`it can sideload a collection with a chain of belongs-to relationships`, fu
     ]
   });
 });
+
+test(`it skips an empty belongs-to relationship`, function(assert) {
+  let registry = new SerializerRegistry(this.schema, {
+    application: this.BaseSerializer,
+    foo: this.BaseSerializer.extend({
+      include: ['bar']
+    })
+  });
+
+  let foo1 = this.schema.foo.create({name: 'test foo'});
+  let result = registry.serialize(foo1);
+
+  assert.deepEqual(result, {
+    foo:
+      {id: '1', name: 'test foo', barId: null}
+  });
+});
+


### PR DESCRIPTION
Just this one traversal function wasn't checking for null relatedModels.