### PR TITLE
Add iteration argument to faker.list.cycle

### DIFF
--- a/docs/v0.2.0-beta.3/factories.md
+++ b/docs/v0.2.0-beta.3/factories.md
@@ -89,8 +89,8 @@ We've also added two methods on the `faker` namespace, `list.cycle` and `list.ra
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name() {
-    return faker.list.cycle('Economics', 'Philosophy', 'English', 'History', 'Mathematics')();
+  name(i) {
+    return faker.list.cycle('Economics', 'Philosophy', 'English', 'History', 'Mathematics')(i);
   },
   students() {
     return faker.list.random(100, 200, 300, 400, 500)();


### PR DESCRIPTION
`faker.list.cycle` returns a function that expects an iteration to be passed: https://github.com/samselikoff/ember-cli-mirage/blob/dfd7f620277e3f9bddf6d817a19fd5802e5aaf33/addon/faker.js#L13