### PR TITLE
Always include original message on rethrow errors

### DIFF
--- a/addon/route-handler.js
+++ b/addon/route-handler.js
@@ -65,7 +65,8 @@ export default class RouteHandler {
       if (e instanceof MirageError) {
         throw e;
       } else {
-        throw new MirageError(`Your handler for the url ${request.url} threw an error: ${e.message}`);
+        let message = (typeOf(e) === 'string') ? e : e.message;
+        throw new MirageError(`Your handler for the url ${request.url} threw an error: ${message}`);
       }
     }
 


### PR DESCRIPTION
This only fixes the case in `RouteHandler#_getMirageResponseForRequest`. I'm not particularly familiar with the architecture of Ember CLI Mirage, so this might not be the ideal fix.

The issue that I encountered was due to my having setup two models with a hasMany/belongsTo association, and then writing fixtures for them which did not specify the IDs required to make that association work.

What ultimately happened was the model property generated by `BelongsTo#addMethodsToModelClass` had [an assert in its `set` function](https://github.com/samselikoff/ember-cli-mirage/blob/b0c7ef511796d1cb44fc18dbbbd2c6e5664cb215/addon/orm/associations/belongs-to.js#L47) which was ultimately throwing a bare JS string.

Eventually that exception unwound until it hit [the catch block in `RouteHandler#_getMirageResponseForRequest`](https://github.com/samselikoff/ember-cli-mirage/blob/b0c7ef511796d1cb44fc18dbbbd2c6e5664cb215/addon/route-handler.js#L65-L69) which expects all exceptions to be either `MirageError` or another kind of error object with the `message` attribute.

As a result, I received the following exception message in my browser console:
`Error while processing route: problems Pretender intercepted GET /problems but encountered an error: Mirage: Your handler for the url /problems threw an error: undefined Mirage: MirageError@http://localhost:4200/assets/vendor.js:126020:15`.

With the changes from this PR, I receive the following exception message under the same circumstances:
`Error while processing route: problems Pretender intercepted GET /problems but encountered an error: Mirage: Your handler for the url /problems threw an error: Couldn't find emojivator with id = 1 Mirage: MirageError@http://localhost:4200/assets/vendor.js:126020:15`.