### PR TITLE
Add missing arrows

### DIFF
--- a/docs/v0.2.0-beta.1/defining-routes.md
+++ b/docs/v0.2.0-beta.1/defining-routes.md
@@ -277,7 +277,7 @@ export default Model.extend({
 `hasMany` tells Mirage that it can find this author's posts using the `authorId` field. Now, our route handler for deleting an author looks like this:
 
 ```js
-this.del('/authors/:id', (schema, request) {
+this.del('/authors/:id', (schema, request) => {
   let author = schema.author.find(request.params.id);
 
   author.posts.delete();

--- a/docs/v0.2.0-beta.1/route-handlers.md
+++ b/docs/v0.2.0-beta.1/route-handlers.md
@@ -77,7 +77,7 @@ this.get('/api/events', () => {
 You can also return an instance of `Mirage.Response` to dynamically set headers and the status code:
 
 ```js
-this.post('/api/messages', ({message}, request) {
+this.post('/api/messages', ({message}, request) => {
   var params = JSON.parse(request.requestBody);
 
   if (!params.title) {

--- a/docs/v0.2.0-beta.1/shorthands.md
+++ b/docs/v0.2.0-beta.1/shorthands.md
@@ -46,7 +46,7 @@ this.get('/contacts/:id', 'user'); // optionally specify the type as second para
 
 {% capture expanded %}
 {% highlight js %}
-this.get('/contacts/:id', ({ contact }, request) {
+this.get('/contacts/:id', ({ contact }, request) => {
   let id = request.params.id;
 
   return contact.find(id); // schema.user in the second case
@@ -69,7 +69,7 @@ this.get('/contacts', 'users', { coalesce: true });
 
 {% capture expanded %}
 {% highlight js %}
-this.get('/contacts', ({ contact }, request) {
+this.get('/contacts', ({ contact }, request) => {
   var ids = request.queryParams.ids;
 
   return contact.find(ids); // schema.user in the second case
@@ -96,7 +96,7 @@ this.post('/contacts', 'user');  // optionally specify the type as second param
 
 {% capture expanded %}
 {% highlight js %}
-this.post('/contacts', ({ contact }, request) {
+this.post('/contacts', ({ contact }, request) => {
   let json = JSON.parse(request.requestBody);
   let attrs = [getAttrsFromRequest](request);
 
@@ -122,7 +122,7 @@ this.put('/contacts/:id', 'user');  // optionally specify the type as second par
 
 {% capture expanded %}
 {% highlight js %}
-this.put('/contacts/:id', ({ contact }, request) {
+this.put('/contacts/:id', ({ contact }, request) => {
   let id = request.params.id;
   let attrs = [getAttrsFromRequest](request);
 
@@ -170,7 +170,7 @@ this.del('/contacts/:id', ['contact', 'addresses']);
 
 {% capture expanded %}
 {% highlight js %}
-this.del('/contacts/:id', ({ contact, address }, request) {
+this.del('/contacts/:id', ({ contact, address }, request) => {
   let id = request.params.id;
   let contact = contact.find(id);
 

--- a/docs/v0.2.0-beta.2/defining-routes.md
+++ b/docs/v0.2.0-beta.2/defining-routes.md
@@ -277,7 +277,7 @@ export default Model.extend({
 `hasMany` tells Mirage that it can find this author's posts using the `authorId` field. Now, our route handler for deleting an author looks like this:
 
 ```js
-this.del('/authors/:id', (schema, request) {
+this.del('/authors/:id', (schema, request) => {
   let author = schema.author.find(request.params.id);
 
   author.posts.delete();

--- a/docs/v0.2.0-beta.2/route-handlers.md
+++ b/docs/v0.2.0-beta.2/route-handlers.md
@@ -77,7 +77,7 @@ this.get('/api/events', () => {
 You can also return an instance of `Mirage.Response` to dynamically set headers and the status code:
 
 ```js
-this.post('/api/messages', ({message}, request) {
+this.post('/api/messages', ({message}, request) => {
   var params = JSON.parse(request.requestBody);
 
   if (!params.title) {

--- a/docs/v0.2.0-beta.2/shorthands.md
+++ b/docs/v0.2.0-beta.2/shorthands.md
@@ -46,7 +46,7 @@ this.get('/contacts/:id', 'user'); // optionally specify the type as second para
 
 {% capture expanded %}
 {% highlight js %}
-this.get('/contacts/:id', ({ contact }, request) {
+this.get('/contacts/:id', ({ contact }, request) => {
   let id = request.params.id;
 
   return contact.find(id); // schema.user in the second case
@@ -69,7 +69,7 @@ this.get('/contacts', 'users', { coalesce: true });
 
 {% capture expanded %}
 {% highlight js %}
-this.get('/contacts', ({ contact }, request) {
+this.get('/contacts', ({ contact }, request) => {
   var ids = request.queryParams.ids;
 
   return contact.find(ids); // schema.user in the second case
@@ -96,7 +96,7 @@ this.post('/contacts', 'user');  // optionally specify the type as second param
 
 {% capture expanded %}
 {% highlight js %}
-this.post('/contacts', ({ contact }, request) {
+this.post('/contacts', ({ contact }, request) => {
   let json = JSON.parse(request.requestBody);
   let attrs = [getAttrsFromRequest](request);
 
@@ -122,7 +122,7 @@ this.put('/contacts/:id', 'user');  // optionally specify the type as second par
 
 {% capture expanded %}
 {% highlight js %}
-this.put('/contacts/:id', ({ contact }, request) {
+this.put('/contacts/:id', ({ contact }, request) => {
   let id = request.params.id;
   let attrs = [getAttrsFromRequest](request);
 
@@ -170,7 +170,7 @@ this.del('/contacts/:id', ['contact', 'addresses']);
 
 {% capture expanded %}
 {% highlight js %}
-this.del('/contacts/:id', ({ contact, address }, request) {
+this.del('/contacts/:id', ({ contact, address }, request) => {
   let id = request.params.id;
   let contact = contact.find(id);
 

--- a/docs/v0.2.0-beta.3/defining-routes.md
+++ b/docs/v0.2.0-beta.3/defining-routes.md
@@ -277,7 +277,7 @@ export default Model.extend({
 `hasMany` tells Mirage that it can find this author's posts using the `authorId` field. Now, our route handler for deleting an author looks like this:
 
 ```js
-this.del('/authors/:id', (schema, request) {
+this.del('/authors/:id', (schema, request) => {
   let author = schema.author.find(request.params.id);
 
   author.posts.delete();

--- a/docs/v0.2.0-beta.3/route-handlers.md
+++ b/docs/v0.2.0-beta.3/route-handlers.md
@@ -106,7 +106,7 @@ this.get('/api/events', () => {
 You can also return an instance of `Mirage.Response` to dynamically set headers and the status code:
 
 ```js
-this.post('/api/messages', ({message}, request) {
+this.post('/api/messages', ({message}, request) => {
   var params = JSON.parse(request.requestBody);
 
   if (!params.title) {

--- a/docs/v0.2.0-beta.3/shorthands.md
+++ b/docs/v0.2.0-beta.3/shorthands.md
@@ -46,7 +46,7 @@ this.get('/contacts/:id', 'user'); // optionally specify the type as second para
 
 {% capture expanded %}
 {% highlight js %}
-this.get('/contacts/:id', ({ contact }, request) {
+this.get('/contacts/:id', ({ contact }, request) => {
   let id = request.params.id;
 
   return contact.find(id); // schema.user in the second case
@@ -69,7 +69,7 @@ this.get('/contacts', 'users', { coalesce: true });
 
 {% capture expanded %}
 {% highlight js %}
-this.get('/contacts', ({ contact }, request) {
+this.get('/contacts', ({ contact }, request) => {
   var ids = request.queryParams.ids;
 
   return contact.find(ids); // schema.user in the second case
@@ -96,7 +96,7 @@ this.post('/contacts', 'user');  // optionally specify the type as second param
 
 {% capture expanded %}
 {% highlight js %}
-this.post('/contacts', ({ contact }, request) {
+this.post('/contacts', ({ contact }, request) => {
   let json = JSON.parse(request.requestBody);
   let attrs = [getAttrsFromRequest](request);
 
@@ -122,7 +122,7 @@ this.put('/contacts/:id', 'user');  // optionally specify the type as second par
 
 {% capture expanded %}
 {% highlight js %}
-this.put('/contacts/:id', ({ contact }, request) {
+this.put('/contacts/:id', ({ contact }, request) => {
   let id = request.params.id;
   let attrs = [getAttrsFromRequest](request);
 
@@ -170,7 +170,7 @@ this.del('/contacts/:id', ['contact', 'addresses']);
 
 {% capture expanded %}
 {% highlight js %}
-this.del('/contacts/:id', ({ contact, address }, request) {
+this.del('/contacts/:id', ({ contact, address }, request) => {
   let id = request.params.id;
   let contact = contact.find(id);
 


### PR DESCRIPTION
Fixed some expressions apparently missing arrows.
I wish we could check the syntax of codes embedded in documents...