### PR TITLE
Fixes #548: Use json api id when available.

### DIFF
--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -2,8 +2,6 @@ import _isArray from 'lodash/lang/isArray';
 import assert from 'ember-cli-mirage/assert';
 import { camelize, singularize, dasherize } from 'ember-cli-mirage/utils/inflector';
 
-const allDigitsRegex = /^\d+$/;
-
 export default class BaseShorthandRouteHandler {
 
   constructor(schema, serializerOrRegistry, shorthand, path, options={}) {
@@ -44,14 +42,12 @@ export default class BaseShorthandRouteHandler {
   handleStringShorthand() { }
   handleArrayShorthand() { }
 
-  _getIdForRequest(request) {
+  _getIdForRequest(request, jsonApiDoc) {
     let id;
     if (request && request.params && request.params.id) {
       id = request.params.id;
-      // If parses, coerce to integer
-      if (typeof id === "string" && allDigitsRegex.test(id)) {
-        id = parseInt(request.params.id, 10);
-      }
+    } else if (jsonApiDoc && jsonApiDoc.data && jsonApiDoc.data.id) {
+      id = jsonApiDoc.data.id;
     }
     return id;
   }
@@ -65,8 +61,8 @@ export default class BaseShorthandRouteHandler {
   }
 
   _getAttrsForRequest(request, modelName) {
-    let id = this._getIdForRequest(request);
     let json = this._getJsonApiDocForRequest(request, modelName);
+    let id = this._getIdForRequest(request, json);
 
     assert(
       json.data && json.data.attributes,

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -6,12 +6,6 @@ module('Unit | Route handlers | Shorthands | BaseShorthandRouteHandler', {
   beforeEach: function() {
     this.handler = new BaseShorthandRouteHandler();
     this.request = { params: {id: ''} };
-    this.jsonApiDoc = {
-      data: {
-        type: 'test',
-        attributes: {}
-      }
-    };
   }
 });
 
@@ -43,12 +37,13 @@ test('getModelClassFromPath works', function (assert) {
   assert.equal(this.handler.getModelClassFromPath(urlWithIdAndSlash, true), 'fancy-user', 'it returns a singular model name');
 });
 
-test('it reads id from request params or json api data.', function(assert) {
-  this.request.params.id = "test-id";
-
-  assert.equal(this.handler._getIdForRequest(this.request), "test-id", 'it returns id from parameters.');
-  this.request.params = {};
-  this.jsonApiDoc.data.id = 'jsonapi-id';
-  assert.equal(this.handler._getIdForRequest(this.request, this.jsonApiDoc), 'jsonapi-id', 'it returns id from json api data.');
+test('it can read the id from the url', function(assert) {
+  let request = { params: { id: 'test-id' } };
+  assert.equal(this.handler._getIdForRequest(request), 'test-id', 'it returns id from url parameters.');
 });
 
+test('it can read the id from the request body', function(assert) {
+  let request = { params: {} };
+  let jsonApiDoc = { data: { id: 'jsonapi-id' } };
+  assert.equal(this.handler._getIdForRequest(request, jsonApiDoc), 'jsonapi-id', 'it returns id from json api data.');
+});

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -6,6 +6,12 @@ module('Unit | Route handlers | Shorthands | BaseShorthandRouteHandler', {
   beforeEach: function() {
     this.handler = new BaseShorthandRouteHandler();
     this.request = { params: {id: ''} };
+    this.jsonApiDoc = {
+      data: {
+        type: 'test',
+        attributes: {}
+      }
+    };
   }
 });
 
@@ -35,5 +41,14 @@ test('getModelClassFromPath works', function (assert) {
 
   assert.equal(this.handler.getModelClassFromPath(urlWithSlash), 'fancy-user', 'it returns a singular model name');
   assert.equal(this.handler.getModelClassFromPath(urlWithIdAndSlash, true), 'fancy-user', 'it returns a singular model name');
+});
+
+test('it reads id from request params or json api data.', function(assert) {
+  this.request.params.id = "test-id";
+
+  assert.equal(this.handler._getIdForRequest(this.request), "test-id", 'it returns id from parameters.');
+  this.request.params = {};
+  this.jsonApiDoc.data.id = 'jsonapi-id';
+  assert.equal(this.handler._getIdForRequest(this.request, this.jsonApiDoc), 'jsonapi-id', 'it returns id from json api data.');
 });
 


### PR DESCRIPTION
This allows using an id value that is passed as part of the submitted json api resource when a value is not specified in the request params.  It also removes integer parsing of ids per #462.  I've tried to add a test as well although I'm having a hard time running the tests locally to verify :(