### PR TITLE
Fix the fix on addon integration.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
     this.addonBuildConfig = this.app.options['ember-cli-mirage'] || {};
     if (this.addonBuildConfig['directory']) {
       this.mirageDirectory = this.addonBuildConfig['directory'];
-    } else if (app.project.pkg['ember-addon']) {
+    } else if (app.project.pkg['ember-addon'] && !app.project.pkg['ember-addon'].paths) {
       this.mirageDirectory = path.resolve(app.project.root, path.join('tests', 'dummy', 'mirage'))
     } else {
       this.mirageDirectory = path.join(this.app.project.root, '/mirage');


### PR DESCRIPTION
The check in #543 is correct, but if a project has "in-repo-addons" then
it will include `ember-addon` in `package.json` without it being an
addon.

The following shows how in-repo-addons are discovered https://github.com/ember-cli/ember-cli/blob/282641ba662292afb40cb88cdf31557a3e4cc6b7/lib/models/addon-discovery.js#L160

Without this #524 still happens if you have in-repo-addons..

cc @cibernox 