### PR TITLE
Allow Mirage to be disabled for non-production environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,12 @@ module.exports = {
 
   _shouldIncludeFiles: function() {
     var enabledInProd = this.app.env === 'production' && this.addonConfig.enabled;
-
-    return enabledInProd || (this.app.env !== 'production');
+    var explicitExcludeFiles = this.addonConfig.excludeFilesFromBuild;
+    if (enabledInProd && explicitExcludeFiles) {
+      throw new Error('Mirage was explicitly enabled in production, but its files were excluded ' +
+                      'from the build. Please, use only ENV[\'ember-cli-mirage\'].enabled in ' +
+                      'production environment.');
+    }
+    return enabledInProd || (this.app.env !== 'production' && explicitExcludeFiles !== true);
   }
 };


### PR DESCRIPTION
I only need Mirage for acceptance test, but it is included in 'development' environment as well. This PR changes the logic for determining when to include Mirage. It preserves the previous behavior where Mirage is included by default in all non-production environments and it can be enabled for 'production' environment. It adds ability to explicitly disable Mirage in other environments. It probably doesn't make any sense for disabling in 'testing', but it make sense to disable it for 'development' if the API server is fully implemented and there is no need for mocking.