### PR TITLE
Updating ember-cli and related deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,9 +5,7 @@
     "ember": "2.3.0",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-load-initializers": "0.1.7",
     "ember-qunit-notifications": "0.1.0",
-    "loader.js": "^3.5.0",
     "pretender": "~0.10.1",
     "Faker": "~3.0.0",
     "sinonjs": "~1.17.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "broccoli-asset-rev": "^2.2.0",
     "chai": "2.0.0",
     "ember-ajax": "0.7.1",
-    "ember-cli": "^2.3.0-beta.1",
+    "ember-cli": "^2.3.0-beta.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.2.0",
@@ -44,9 +44,11 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.3.0",
     "ember-try": "~0.0.8",
+    "loader.js": "^4.0.0",
     "mocha": "^2.1.0"
   },
   "keywords": [


### PR DESCRIPTION
Starting with ember-cli 2.3.0-beta.2 these two dependencies move from bower to npm.