### PR TITLE
Fix: newModel.isNew is not a functioon when associating a belongsTo by plain object

### DIFF
--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -2,6 +2,7 @@ import Association from './association';
 import _assign from 'lodash/object/assign';
 import { capitalize, camelize } from 'ember-cli-mirage/utils/inflector';
 import assert from 'ember-cli-mirage/assert';
+import Ember from 'ember';
 
 class BelongsTo extends Association {
 
@@ -44,7 +45,7 @@ class BelongsTo extends Association {
       set(id) {
         assert(
           !id || schema[camelize(association.modelName)].find(id),
-          `Couldn\'t find ${association.modelName} with id = ' + id`
+          `Couldn't find ${association.modelName} with id = ${id}`
         );
 
         this.attrs[foreignKey] = id;
@@ -75,13 +76,20 @@ class BelongsTo extends Association {
           - sets the associated parent (via model)
       */
       set(newModel) {
-        if (newModel && newModel.isNew()) {
+        if (!Ember.isEmpty(newModel) && typeof newModel === 'object' && typeof newModel.isNew === 'function' && newModel.isNew()) {
+          // newModel is a model
           this[foreignKey] = null;
           association._tempParent = newModel;
-        } else if (newModel) {
+        } else if (!Ember.isEmpty(newModel) && typeof newModel === 'object' && !Ember.isEmpty(newModel.id)) {
+          // newModel is a simple object with id property
           association._tempParent = null;
           this[foreignKey] = newModel.id;
+        } else if (!Ember.isEmpty(newModel)) {
+          // newModel is an id
+          association._tempParent = null;
+          this[foreignKey] = newModel;
         } else {
+          // newModel is not present
           association._tempParent = null;
           this[foreignKey] = null;
         }


### PR DESCRIPTION
Fix: Your handler for the url ... threw an error: newModel.isNew is not a function

Error was thrown while using a plain object returned by `server.create()`:
```
const author = server.create('author');
server.create('blog-post', {author: author})
```

Also adds support for associating by passing id of model:
```
const author = server.create('author');
server.create('blog-post', {author: author.id});
```

Bug was mentioned in #560.