### PR TITLE
Add default passthroughs; fix #552

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -52,6 +52,11 @@ const defaultRouteOptions = {
   timing: undefined
 };
 
+const defaultPassthroughs = [
+  'http://localhost:0/chromecheckurl'
+];
+export { defaultPassthroughs };
+
 function isOption(option) {
   if (!option || typeof option !== 'object') { return false; }
   const allOptions = Object.keys(defaultRouteOptions);
@@ -128,6 +133,10 @@ export default class Server {
       options.scenarios.default(this);
     } else {
       this.loadFixtures();
+    }
+
+    if (options.useDefaultPassthroughs) {
+      this._configureDefaultPassthroughs();
     }
   }
 
@@ -326,4 +335,9 @@ export default class Server {
     return fullPath;
   }
 
+  _configureDefaultPassthroughs() {
+    defaultPassthroughs.forEach(passthroughUrl => {
+      this.passthrough(passthroughUrl);
+    });
+  }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,6 +19,7 @@ function usingProxy() {
 module.exports = function(environment, appConfig) {
   appConfig['ember-cli-mirage'] = appConfig['ember-cli-mirage'] || {};
   appConfig['ember-cli-mirage']['usingProxy'] = usingProxy();
+  appConfig['ember-cli-mirage']['useDefaultPassthroughs'] = true;
 
   return {};
 };

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -1,4 +1,4 @@
-import Server from 'ember-cli-mirage/server';
+import Server, { defaultPassthroughs } from 'ember-cli-mirage/server';
 import {module, test} from 'qunit';
 import Factory from 'ember-cli-mirage/factory';
 
@@ -422,4 +422,31 @@ test('buildList respects attr overrides', function(assert) {
   assert.deepEqual(sams[1], {name: 'Sam'});
   assert.deepEqual(links[0], {name: 'Link'});
   assert.deepEqual(links[1], {name: 'Link'});
+});
+
+
+module('Unit | Server #defaultPassthroughs');
+
+test('server configures default passthroughs when useDefaultPassthroughs is true', function(assert) {
+  var server = new Server({ useDefaultPassthroughs: true });
+
+  assert.expect(defaultPassthroughs.length);
+  defaultPassthroughs.forEach(passthroughUrl => {
+    var passthroughRequest = { method: 'GET', url: passthroughUrl },
+        isPassedThrough = server.pretender.checkPassthrough(passthroughRequest);
+
+    assert.ok(isPassedThrough);
+  });
+});
+
+test('server does not configure default passthroughs when useDefaultPassthroughs is false', function(assert) {
+  var server = new Server({ useDefaultPassthroughs: false });
+
+  assert.expect(defaultPassthroughs.length);
+  defaultPassthroughs.forEach(passthroughUrl => {
+    var passthroughRequest = { method: 'GET', url: passthroughUrl },
+        isPassedThrough = server.pretender.checkPassthrough(passthroughRequest);
+
+    assert.ok(!isPassedThrough);
+  });
 });


### PR DESCRIPTION
This PR adds a `defaultPassthroughs` array to `server.js`, and automatically configures passthroughs for all URLs in the array when `ENV['ember-cli-mirage'].useDefaultPassthroughs` is true (defaults to true).

For more, see #552 & [the related blog post](http://blog.isleofcode.com/configuring-ember-cli-mirage-and-pretender-for-production/)