### PR TITLE
Accept JSON:API requests which contain no model attributes.

### DIFF
--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -65,9 +65,11 @@ export default class BaseShorthandRouteHandler {
     let id = this._getIdForRequest(request, json);
 
     assert(
-      json.data && json.data.attributes,
+      json.data,
       `You're using a shorthand but your serializer's normalize function did not return a valid JSON:API document. http://www.ember-cli-mirage.com/docs/v0.2.x/serializers/#normalizejson`
     );
+
+    json.data.attributes = json.data.attributes || {};
 
     let attrs = Object.keys(json.data.attributes).reduce((sum, key) => {
       sum[camelize(key)] = json.data.attributes[key];

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -47,3 +47,11 @@ test('it can read the id from the request body', function(assert) {
   let jsonApiDoc = { data: { id: 'jsonapi-id' } };
   assert.equal(this.handler._getIdForRequest(request, jsonApiDoc), 'jsonapi-id', 'it returns id from json api data.');
 });
+
+test('it accepts JSON:API requests which contain no attributes (regression, samselikoff/ember-cli-mirage#534)', function(assert) {
+  let serializerOrRegistry = { normalize: function() { return { data: { } }; } };
+  let handler = new BaseShorthandRouteHandler(null, serializerOrRegistry);
+  let request = { requestBody: '{}' };
+
+  assert.ok(handler._getAttrsForRequest(request, 'orphan'), 'it does not throw an exception');
+});


### PR DESCRIPTION
See #534.