### PR TITLE
Fix check for belongsTo relationship and use null data.

### DIFF
--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -78,8 +78,8 @@ export default class BaseShorthandRouteHandler {
       Object.keys(json.data.relationships).forEach((key) => {
         let relationship = json.data.relationships[key];
 
-        if (typeof relationship.data === "object") {
-          attrs[`${camelize(key)}Id`] = relationship.data.id;
+        if (!_isArray(relationship.data)) {
+          attrs[`${camelize(key)}Id`] = relationship.data && relationship.data.id;
         }
       }, {});
     }

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -67,6 +67,12 @@ test('_getAttrsForRequest works', function(assert) {
             'id': '1',
             'type': 'github-accounts'
           }
+        },
+        'something': {
+          'data': null
+        },
+        'many-things': {
+          'data': []
         }
       },
       'type': 'github-account'
@@ -81,7 +87,14 @@ test('_getAttrsForRequest works', function(assert) {
 
   assert.deepEqual(
     attrs,
-    {id: undefined, name: 'Sam', doesMirage: true, companyId: '1', githubAccountId: '1'},
+    {
+      id: undefined,
+      name: 'Sam',
+      doesMirage: true,
+      companyId: '1',
+      githubAccountId: '1',
+      somethingId: null
+    },
     'it normalizes data correctly.'
   );
 });


### PR DESCRIPTION
typeof can produce inconsistent behavior here since typeof `[]` and
`null` is 'object'.

We still want to pass `null` as the id since that is valid when for
example removing the link to the other object.