### PR TITLE
Update serializers documentation for "include" rather than "relationships"

### DIFF
--- a/docs/v0.2.0-beta.5/serializers.md
+++ b/docs/v0.2.0-beta.5/serializers.md
@@ -114,7 +114,7 @@ and the payload would look like
 
 ---
 
-## relationships
+## include
 
 Use this property on a model serializer to specify related models you'd like to include in your JSON payload.
 
@@ -127,7 +127,7 @@ export default Model.extend({
 });
 ```
 
-and you wanted to sideload these, specify so in the `relationships` key:
+and you wanted to sideload these, specify so in the `include` key:
 
 ```js
 // mirage/serializers/authors.j


### PR DESCRIPTION
The example is updated but the surrounding text still says "relationships" rather than "include"