### PR TITLE
Inverse Foreign Keys

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -8,11 +8,11 @@ import JSONAPISerializer from './serializers/json-api-serializer';
 import HasMany from './orm/associations/has-many';
 import BelongsTo from './orm/associations/belongs-to';
 
-function hasMany(modelName) {
-  return new HasMany(modelName);
+function hasMany(...args) {
+  return new HasMany(...args);
 }
-function belongsTo(modelName) {
-  return new BelongsTo(modelName);
+function belongsTo(...args) {
+  return new BelongsTo(...args);
 }
 
 export {

--- a/addon/orm/associations/association.js
+++ b/addon/orm/associations/association.js
@@ -1,8 +1,15 @@
 export default class Association {
 
-  constructor(modelName) {
-    // The modelName of the association
-    this.modelName = modelName;
+  constructor(modelName, opts) {
+    if (typeof modelName === 'object') {
+      // Received opts only
+      this.modelName = undefined;
+      this.opts = modelName;
+    } else {
+      // The modelName of the association
+      this.modelName = modelName;
+      this.opts = opts || {};
+    }
 
     // The key pointing to the association
     this.key = '';

--- a/addon/orm/associations/has-many.js
+++ b/addon/orm/associations/has-many.js
@@ -11,11 +11,11 @@ class HasMany extends Association {
     The hasMany association adds a fk to the target model of the association
   */
   getForeignKeyArray() {
-    return [camelize(this.modelName), `${camelize(this.ownerModelName)}Id`];
+    return [camelize(this.modelName), this.getForeignKey()];
   }
 
   getForeignKey() {
-    return `${camelize(this.ownerModelName)}Id`;
+    return `${this.opts.inverseOf || camelize(this.ownerModelName)}Id`;
   }
 
   addMethodsToModelClass(ModelClass, key, schema) {
@@ -134,7 +134,7 @@ class HasMany extends Association {
       object.newChild
         - creates a new unsaved associated child
     */
-    modelPrototype['new' + capitalize(camelize(association.modelName))] = function(attrs = {}) {
+    modelPrototype['new' + capitalize(camelize(singularize(association.key)))] = function(attrs = {}) {
       if (!this.isNew()) {
         attrs = _assign(attrs, { [foreignKey]: this.id });
       }
@@ -153,7 +153,7 @@ class HasMany extends Association {
           updates the association's foreign key
         - parent must be saved
     */
-    modelPrototype['create' + capitalize(camelize(association.modelName))] = function(attrs = {}) {
+    modelPrototype['create' + capitalize(camelize(singularize(association.key)))] = function(attrs = {}) {
       assert(!this.isNew(), 'You cannot call create unless the parent is saved');
 
       var augmentedAttrs = _assign(attrs, { [foreignKey]: this.id });

--- a/tests/integration/schema/has-many/accessor-test.js
+++ b/tests/integration/schema/has-many/accessor-test.js
@@ -1,40 +1,24 @@
 import HasManyHelper from './has-many-helper';
 import {module, test} from 'qunit';
 
-module('Integration | Schema | hasMany #accessor', {
-  beforeEach: function() {
-    this.helper = new HasManyHelper();
-  }
-});
+module('Integration | Schema | hasMany #accessor');
 
 /*
   #association behavior works regardless of the state of the parent
 */
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
+HasManyHelper.forEachScenario(scenario => {
+  test(`the references of a ${scenario.title} are correct`, function(assert) {
+    let { parent, children, accessor, idsAccessor } = scenario.go();
+    assert.equal(parent[accessor].length, children.length, 'parent has correct number of children');
+    assert.equal(parent[idsAccessor].length, children.length, 'parent has correct number of child ids');
 
-  test(`the references of a ${state} are correct`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
+    children.forEach(function(child, i) {
+      assert.deepEqual(parent[accessor][i], children[i], 'each child is in parent.children array');
 
-    assert.equal(user.homeAddresses.length, homeAddresses.length, 'parent has correct number of children');
-    assert.equal(user.homeAddressIds.length, homeAddresses.length, 'parent has correct number of child ids');
-
-    homeAddresses.forEach(function(homeAddress, i) {
-      assert.deepEqual(user.homeAddresses[i], homeAddresses[i], 'each child is in parent.children array');
-
-      if (!homeAddress.isNew()) {
-        assert.ok(user.homeAddressIds.indexOf(homeAddress.id) > -1, 'each saved child id is in parent.childrenIds array');
+      if (!child.isNew()) {
+        assert.ok(parent[idsAccessor].indexOf(child.id) > -1, 'each saved child id is in parent.childrenIds array');
       }
     });
   });
-
 });

--- a/tests/integration/schema/has-many/create-association-test.js
+++ b/tests/integration/schema/has-many/create-association-test.js
@@ -1,55 +1,43 @@
 import HasManyHelper from './has-many-helper';
 import {module, test} from 'qunit';
 
-module('Integration | Schema | hasMany #createAssociation', {
-  beforeEach: function() {
-    this.helper = new HasManyHelper();
+module('Integration | Schema | hasMany #createAssociation');
+
+HasManyHelper.forEachScenario(scenario => {
+  if (/^savedParent/.test(scenario.state)) {
+    test(`${scenario.title} can create an associated child`, function(assert) {
+      let { parent: user, children, accessor, idsAccessor, createAccessor, otherIdAccessor } = scenario.go();
+
+      var startingCount = children.length;
+
+      var springfield = user[createAccessor]({name: '1 Springfield ave'});
+
+      assert.ok(springfield.id, 'the child was persisted');
+      assert.equal(springfield[otherIdAccessor], 1, 'the fk is set');
+      assert.equal(user[accessor].length, startingCount + 1, 'the collection length is correct');
+      assert.deepEqual(user[accessor].filter(a => a.id === springfield.id)[0], springfield, 'the homeAddress was added to user.homeAddresses');
+      assert.ok(user[idsAccessor].indexOf(springfield.id) > -1, 'the id was added to the fks array');
+    });
+
+    test(`${scenario.title} can create an associated child without passing attrs (regression)`, function(assert) {
+      let { parent: user, accessor, createAccessor } = scenario.go();
+
+      var springfield = user[createAccessor]();
+
+      assert.deepEqual(user[accessor].filter(a => a.id === springfield.id)[0], springfield, `the homeAddress was added to user.${accessor}`);
+    });
   }
-});
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-].forEach(state => {
 
-  test(`a ${state} can create an associated child`, function(assert) {
-    var [user, children] = this.helper[state]();
-    var startingCount = children.length;
+  if (/^newParent/.test(scenario.state)) {
+    test(`${scenario.title} cannot create an associated child`, function(assert) {
+      var { parent, createAccessor } = scenario.go();
 
-    var springfield = user.createHomeAddress({name: '1 Springfield ave'});
+      assert.throws(function() {
+        parent[createAccessor]({name: '1 Springfield ave'});
+      }, /unless the parent is saved/);
+    });
 
-    assert.ok(springfield.id, 'the child was persisted');
-    assert.equal(springfield.userId, 1, 'the fk is set');
-    assert.equal(user.homeAddresses.length, startingCount + 1, 'the collection length is correct');
-    assert.deepEqual(user.homeAddresses.filter(a => a.id === springfield.id)[0], springfield, 'the homeAddress was added to user.homeAddresses');
-    assert.ok(user.homeAddressIds.indexOf(springfield.id) > -1, 'the id was added to the fks array');
-  });
-
-  test(`a ${state} can create an associated child without passing attrs (regression)`, function(assert) {
-    var [user] = this.helper[state]();
-
-    var springfield = user.createHomeAddress();
-
-    assert.deepEqual(user.homeAddresses.filter(a => a.id === springfield.id)[0], springfield, 'the homeAddress was added to user.homeAddresses');
-  });
-
-});
-
-[
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
-
-  test(`a ${state} cannot create an associated child`, function(assert) {
-    var [user] = this.helper[state]();
-
-    assert.throws(function() {
-      user.createHomeAddress({name: '1 Springfield ave'});
-    }, /unless the parent is saved/);
-  });
+  }
 
 });

--- a/tests/integration/schema/has-many/new-association-test.js
+++ b/tests/integration/schema/has-many/new-association-test.js
@@ -1,50 +1,38 @@
 import HasManyHelper from './has-many-helper';
 import {module, test} from 'qunit';
 
-module('Integration | Schema | hasMany #newAssociation', {
-  beforeEach: function() {
-    this.helper = new HasManyHelper();
-  }
-});
+module('Integration | Schema | hasMany #newAssociation');
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
+HasManyHelper.forEachScenario(scenario => {
 
-  test(`a ${state} can build a new associated parent`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
+  test(`${scenario.title} can build a new associated parent`, function(assert) {
+    let { parent: user, children: homeAddresses, newAccessor, accessor, otherIdAccessor } = scenario.go();
+
     var startingCount = homeAddresses.length;
 
-    var springfield = user.newHomeAddress({name: '1 Springfield ave'});
+    var springfield = user[newAccessor]({name: '1 Springfield ave'});
 
     assert.ok(!springfield.id, 'the child was not persisted');
-    assert.deepEqual(user.homeAddresses[startingCount], springfield, `the child is appended to the parent's collection`);
+    assert.deepEqual(user[accessor][startingCount], springfield, `the child is appended to the parent's collection`);
 
     if (!user.isNew()) {
-      assert.equal(springfield.userId, user.id, `the new address's fk reference the saved parent`);
+      assert.equal(springfield[otherIdAccessor], user.id, `the new address's fk reference the saved parent`);
     }
 
     user.save();
 
     assert.ok(springfield.id, 'saving the parent persists the child');
-    assert.equal(springfield.userId, user.id, 'the childs fk was updated');
+    assert.equal(springfield[otherIdAccessor], user.id, 'the childs fk was updated');
     assert.equal(springfield.name, '1 Springfield ave', 'the childs attrs were saved');
   });
 
-  test(`a ${state} can build a new associated parent without passing in attrs (regression)`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
+  test(`${scenario.title} can build a new associated parent without passing in attrs (regression)`, function(assert) {
+    let { parent: user, children: homeAddresses, newAccessor, accessor } = scenario.go();
     var startingCount = homeAddresses.length;
 
-    var springfield = user.newHomeAddress();
+    var springfield = user[newAccessor]();
 
-    assert.deepEqual(user.homeAddresses[startingCount], springfield, `the child is appended to the parent's collection`);
+    assert.deepEqual(user[accessor][startingCount], springfield, `the child is appended to the parent's collection`);
   });
 
 });

--- a/tests/integration/schema/has-many/set-association-ids-test.js
+++ b/tests/integration/schema/has-many/set-association-ids-test.js
@@ -1,81 +1,50 @@
 import HasManyHelper from './has-many-helper';
 import {module, test} from 'qunit';
 
-module('Integration | Schema | hasMany #setAssociationIds', {
-  beforeEach: function() {
-    this.helper = new HasManyHelper();
-  }
-});
+module('Integration | Schema | hasMany #setAssociationIds');
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
+HasManyHelper.forEachScenario(scenario => {
+  test(`${scenario.title} can update its associationIds to a list of saved child ids`, function(assert) {
+    let { parent: user, children: homeAddresses, helper, idsAccessor, accessor, otherIdAccessor } = scenario.go();
 
-  test(`a ${state} can update its associationIds to a list of saved child ids`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
-    var savedHomeAddress = this.helper.savedChild();
+    var savedHomeAddress = helper.savedChild();
 
-    user.homeAddressIds = [savedHomeAddress.id];
+    user[idsAccessor] = [savedHomeAddress.id];
     savedHomeAddress.reload();
 
-    assert.deepEqual(user.homeAddresses[0], savedHomeAddress);
+    assert.deepEqual(user[accessor][0], savedHomeAddress);
     homeAddresses.forEach(function(homeAddress) {
       if (homeAddress.isSaved()) {
         homeAddress.reload();
-        assert.equal(homeAddress.userId, null, 'old saved children have their fks cleared');
+        assert.equal(homeAddress[otherIdAccessor], null, 'old saved children have their fks cleared');
       }
     });
   });
 
-});
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-].forEach(state => {
+  if (/^savedParent/.test(scenario.state)) {
+    test(`updating associationIds to a list of saved children ids updates the child's fk, with ${scenario.title}`, function(assert) {
 
-  test(`updating a ${state} associationIds to a list of saved children ids updates the child's fk`, function(assert) {
-    var [user] = this.helper[state]();
-    var savedHomeAddress = this.helper.savedChild();
+      var { parent: user, helper, idsAccessor, otherIdAccessor } = scenario.go();
+      var savedHomeAddress = helper.savedChild();
 
-    user.homeAddressIds = [savedHomeAddress.id];
-    savedHomeAddress.reload();
+      user[idsAccessor] = [savedHomeAddress.id];
+      savedHomeAddress.reload();
 
-    assert.equal(savedHomeAddress.userId, user.id, `the child's fk was set`);
-  });
+      assert.equal(savedHomeAddress[otherIdAccessor], user.id, `the child's fk was set`);
+    });
+  }
 
-});
+  test(`${scenario.title} can update its associationIds to an empty list`, function(assert) {
+    let { parent: user, children: homeAddresses, idsAccessor, accessor, otherIdAccessor } = scenario.go();
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
+    user[idsAccessor] = [];
 
-  test(`a ${state} can update its associationIds to an empty list`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
-
-    user.homeAddressIds = [];
-
-    assert.equal(user.homeAddresses.length, 0);
+    assert.equal(user[accessor].length, 0);
     homeAddresses.forEach(function(homeAddress) {
       if (homeAddress.isSaved()) {
         homeAddress.reload();
-        assert.equal(homeAddress.userId, null, 'old saved children have their fks cleared');
+        assert.equal(homeAddress[otherIdAccessor], null, 'old saved children have their fks cleared');
       }
     });
   });

--- a/tests/integration/schema/has-many/set-association-test.js
+++ b/tests/integration/schema/has-many/set-association-test.js
@@ -7,185 +7,117 @@ module('Integration | Schema | hasMany #setAssociation', {
   }
 });
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
+HasManyHelper.forEachScenario(scenario => {
+  test(`${scenario.title} can update its association to a list of saved children`, function(assert) {
+    let { parent: user, children: homeAddresses, helper, accessor, otherIdAccessor } = scenario.go();
+    var savedHomeAddress = helper.savedChild();
 
-  test(`a ${state} can update its association to a list of saved children`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
-    var savedHomeAddress = this.helper.savedChild();
-
-    user.homeAddresses = [savedHomeAddress];
+    user[accessor] = [savedHomeAddress];
     savedHomeAddress.reload();
 
-    assert.deepEqual(user.homeAddresses[0], savedHomeAddress);
+    assert.deepEqual(user[accessor][0], savedHomeAddress);
     homeAddresses.forEach(function(address) {
       if (address.isSaved()) {
         address.reload();
-        assert.equal(address.userId, null, 'old saved children have their fks cleared');
+        assert.equal(address[otherIdAccessor], null, 'old saved children have their fks cleared');
       }
     });
   });
 
-});
+  if (/^savedParent/.test(scenario.state)) {
+    test(`updating an association to a list of saved children updates the child's fk when ${scenario.title}`, function(assert) {
+      let { parent: user, helper, accessor, otherIdAccessor } = scenario.go();
+      var savedHomeAddress = helper.savedChild();
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-].forEach(state => {
+      user[accessor] = [savedHomeAddress];
+      savedHomeAddress.reload();
 
-  test(`updating a ${state} association to a list of saved children updates the child's fk`, function(assert) {
-    var [user] = this.helper[state]();
-    var savedHomeAddress = this.helper.savedChild();
+      assert.equal(savedHomeAddress[otherIdAccessor], user.id, `the child's fk was set`);
+    });
+  }
 
-    user.homeAddresses = [savedHomeAddress];
-    savedHomeAddress.reload();
+  test(`${scenario.title} can update its association to a list of new children`, function(assert) {
+    let { parent: user, children: homeAddresses, helper, accessor, otherIdAccessor } = scenario.go();
+    var address = helper.newChild();
 
-    assert.equal(savedHomeAddress.userId, user.id, `the child's fk was set`);
-  });
-
-});
-
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
-
-  test(`a ${state} can update its association to a list of new children`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
-    var address = this.helper.newChild();
-
-    user.homeAddresses = [address];
+    user[accessor] = [address];
     // The address is saved if the user is a saved user. In that case, we need to reload.
     if (user.isSaved()) {
       address.reload();
     }
 
-    assert.deepEqual(user.homeAddresses[0], address);
+    assert.deepEqual(user[accessor][0], address);
     homeAddresses.forEach(function(address) {
       if (address.isSaved()) {
         address.reload();
-        assert.equal(address.userId, null, 'old saved children have their fks cleared');
+        assert.equal(address[otherIdAccessor], null, 'old saved children have their fks cleared');
       }
     });
   });
 
-});
+  if (/^savedParent/.test(scenario.state)) {
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-].forEach(state => {
+    test(`updating an association to a list of new children saves the children and updates their fks when ${scenario.title}`, function(assert) {
+      let { parent: user, helper, accessor, otherIdAccessor } = scenario.go();
+      var address = helper.newChild();
 
-  test(`updating a ${state} association to a list of new children saves the children and updates their fks`, function(assert) {
-    var [user] = this.helper[state]();
-    var address = this.helper.newChild();
+      user[accessor] = [address];
+      address.reload();
 
-    user.homeAddresses = [address];
-    address.reload();
+      assert.ok(address.isSaved(), 'the new child was saved');
+      assert.equal(address[otherIdAccessor], user.id, `the child's fk was set`);
+    });
+  }
 
-    assert.ok(address.isSaved(), 'the new child was saved');
-    assert.equal(address.userId, user.id, `the child's fk was set`);
-  });
+  test(`${scenario.title} can update its association to a list of mixed children`, function(assert) {
+    let { parent: user, children: homeAddresses, helper, accessor, otherIdAccessor } = scenario.go();
+    var savedHomeAddress = helper.savedChild();
+    var newAddress = helper.newChild();
 
-});
-
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
-
-  test(`a ${state} can update its association to a list of mixed children`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
-    var savedHomeAddress = this.helper.savedChild();
-    var newAddress = this.helper.newChild();
-
-    user.homeAddresses = [savedHomeAddress, newAddress];
+    user[accessor] = [savedHomeAddress, newAddress];
     savedHomeAddress.reload();
     // The new address is saved if the user is a saved user. In that case, we need to reload.
     if (user.isSaved()) {
       newAddress.reload();
     }
 
-    assert.deepEqual(user.homeAddresses[0], savedHomeAddress);
-    assert.deepEqual(user.homeAddresses[1], newAddress);
+    assert.deepEqual(user[accessor][0], savedHomeAddress);
+    assert.deepEqual(user[accessor][1], newAddress);
     homeAddresses.forEach(function(address) {
       if (address.isSaved()) {
         address.reload();
-        assert.equal(address.userId, null, 'old saved children have their fks cleared');
+        assert.equal(address[otherIdAccessor], null, 'old saved children have their fks cleared');
       }
     });
   });
 
-});
+  if (/^savedParent/.test(scenario.state)) {
+    test(`updating an association to a list of mixed children saves the new children and updates all children's fks when ${scenario.title}`, function(assert) {
+      let { parent: user, helper, accessor, otherIdAccessor } = scenario.go();
+      var savedHomeAddress = helper.savedChild();
+      var newHomeAddress = helper.newChild();
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-].forEach(state => {
+      user[accessor] = [savedHomeAddress, newHomeAddress];
+      savedHomeAddress.reload();
+      newHomeAddress.reload();
 
-  test(`updating a ${state} association to a list of mixed children saves the new children and updates all children's fks`, function(assert) {
-    var [user] = this.helper[state]();
-    var savedHomeAddress = this.helper.savedChild();
-    var newHomeAddress = this.helper.newChild();
+      assert.ok(newHomeAddress.isSaved(), 'the new child was saved');
+      assert.equal(savedHomeAddress[otherIdAccessor], user.id, `the saved child's fk was set`);
+      assert.equal(newHomeAddress[otherIdAccessor], user.id, `the new child's fk was set`);
+    });
+  }
 
-    user.homeAddresses = [savedHomeAddress, newHomeAddress];
-    savedHomeAddress.reload();
-    newHomeAddress.reload();
 
-    assert.ok(newHomeAddress.isSaved(), 'the new child was saved');
-    assert.equal(savedHomeAddress.userId, user.id, `the saved child's fk was set`);
-    assert.equal(newHomeAddress.userId, user.id, `the new child's fk was set`);
-  });
+  test(`${scenario.title} can update its association to an empty list`, function(assert) {
+    let { parent: user, children: homeAddresses, accessor, otherIdAccessor } = scenario.go();
 
-});
+    user[accessor] = [];
 
-[
-  'savedParentNoChildren',
-  'savedParentNewChildren',
-  'savedParentSavedChildren',
-  'savedParentMixedChildren',
-  'newParentNoChildren',
-  'newParentNewChildren',
-  'newParentSavedChildren',
-  'newParentMixedChildren',
-].forEach(state => {
-
-  test(`a ${state} can update its association to an empty list`, function(assert) {
-    var [user, homeAddresses] = this.helper[state]();
-
-    user.homeAddresses = [];
-
-    assert.equal(user.homeAddresses.length, 0);
+    assert.equal(user[accessor].length, 0);
     homeAddresses.forEach(function(address) {
       if (address.isSaved()) {
         address.reload();
-        assert.equal(address.userId, null, 'old saved children have their fks cleared');
+        assert.equal(address[otherIdAccessor], null, 'old saved children have their fks cleared');
       }
     });
   });


### PR DESCRIPTION
This adds an optional `inverseOf` option on `hasMany` associations so that you can correctly map relationships in which the child model has a non-default association key.

I also expanded test scenario coverage of all the tests that use the HasManyHelper so that they also include every permutation of default and non-default keys for the hasMany association and its inverse.

Note that I fixed what I would consider to be a bug, which is that the `newFoo` and `createFoo` methods were being named based on the destination model name and not the local key. That makes multiple associations to the same model type impossible to use unambiguously.