### PR TITLE
Allow for nesting ember-cli-mirage addon in another addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,13 @@ module.exports = {
   name: 'ember-cli-mirage',
 
   included: function included(app) {
+    this._super.included.apply(this, arguments);
+
+    // see: https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
+
     this.app = app;
     this.addonConfig = this.app.project.config(app.env)['ember-cli-mirage'] || {};
     this.addonBuildConfig = this.app.options['ember-cli-mirage'] || {};


### PR DESCRIPTION
This fix allow nesting ember-cli-mirage as an addon dependency of another addon.  

As described on the ember-cli docs here:
http://ember-cli.com/extending/#addons-depending-on-other-addons

The implementation has been discussed at length here:
https://github.com/ember-cli/ember-cli/issues/3718


