### PR TITLE
refactoring getAttrsForRequest to allow relationship updates

### DIFF
--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -63,16 +63,19 @@ export default class BaseShorthandRouteHandler {
   _getAttrsForRequest(request, modelName) {
     let json = this._getJsonApiDocForRequest(request, modelName);
     let id = this._getIdForRequest(request, json);
+    let attrs = {};
 
     assert(
-      json.data && json.data.attributes,
+      json.data && (json.data.attributes || json.data.relationships),
       `You're using a shorthand but your serializer's normalize function did not return a valid JSON:API document. http://www.ember-cli-mirage.com/docs/v0.2.x/serializers/#normalizejson`
     );
 
-    let attrs = Object.keys(json.data.attributes).reduce((sum, key) => {
-      sum[camelize(key)] = json.data.attributes[key];
-      return sum;
-    }, {});
+    if (json.data.attributes) {
+      attrs = Object.keys(json.data.attributes).reduce((sum, key) => {
+        sum[camelize(key)] = json.data.attributes[key];
+        return sum;
+      }, {});
+    }
 
     if (json.data.relationships) {
       Object.keys(json.data.relationships).forEach((key) => {

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -48,7 +48,7 @@ test('it can read the id from the request body', function(assert) {
   assert.equal(this.handler._getIdForRequest(request, jsonApiDoc), 'jsonapi-id', 'it returns id from json api data.');
 });
 
-test('_getAttrsForRequest works', function(assert) {
+test('_getAttrsForRequest works with attributes and relationships', function(assert) {
   var payload = {
     'data': {
       'attributes': {
@@ -94,6 +94,37 @@ test('_getAttrsForRequest works', function(assert) {
       companyId: '1',
       githubAccountId: '1',
       somethingId: null
+    },
+    'it normalizes data correctly.'
+  );
+});
+
+test('_getAttrsForRequest works with just relationships', function(assert) {
+  var payload = {
+    'data': {
+      'relationships': {
+        'company': {
+          'data': {
+            'id': '1',
+            'type': 'companies'
+          }
+        }
+      },
+      'type': 'github-account'
+    }
+  };
+
+  this.handler._getJsonApiDocForRequest = function(request, modelName) {
+    return payload;
+  };
+
+  var attrs = this.handler._getAttrsForRequest(this.request, 'user');
+
+  assert.deepEqual(
+    attrs,
+    {
+      id: undefined,
+      companyId: '1',
     },
     'it normalizes data correctly.'
   );


### PR DESCRIPTION
Previously, this method assumed that the request body contained an `attributes` property which is fine when you are actually updating properties of a model (e.g. changing the name of a user or the content of a post).

My changes allow updating model relationships without modifying the existing models (e.g. changing a post's author to another user).