### PR TITLE
Include intermediate dot-path relationships

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -3,6 +3,7 @@ import { dasherize, pluralize, camelize } from '../utils/inflector';
 import Model from 'ember-cli-mirage/orm/model';
 import Collection from 'ember-cli-mirage/orm/collection';
 import _assign from 'lodash/object/assign';
+import _flatten from 'lodash/array/flatten';
 import _get from 'lodash/object/get';
 import _trim from 'lodash/string/trim';
 import _isString from 'lodash/lang/isString';
@@ -211,7 +212,12 @@ class JsonApiSerializer {
 
     if (_isString(requestRelationships)) {
       if(requestRelationships.length) {
-        return requestRelationships.split(',').map(_trim);
+        const relationships = requestRelationships
+          .split(',')
+          .map(_trim)
+          .map((r) => r.split('.').map((_, index, elements) => elements.slice(0, index + 1).join('.')));
+
+        return _flatten(relationships);
       }
       return [];
     }

--- a/tests/integration/serializers/json-api-serializer/associations/included-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/included-test.js
@@ -324,6 +324,95 @@ test(`dot-paths in include query params include query param`, function(assert) {
     },
     included: [
       {
+        type: 'bars',
+        id: '1',
+        attributes: {},
+        relationships: {
+          'baz': {
+            data: {type: 'bazs', id: '1'}
+          }
+        },
+      },
+      {
+        type: 'bazs',
+        id: '1',
+        attributes: {},
+        relationships: {
+          'quuxes': {
+            data: [
+              {type: 'quuxes', id: '1'},
+              {type: 'quuxes', id: '2'}
+            ]
+          }
+        },
+      },
+      {
+        type: 'quuxes',
+        id: '1',
+        attributes: {},
+        relationships: {
+          'zomgs': {
+            data: [
+              {type: 'zomgs', id: '1'},
+              {type: 'zomgs', id: '2'}
+            ]
+          }
+        },
+      },
+      {
+        type: 'quuxes',
+        id: '2',
+        attributes: {},
+        relationships: {
+          'zomgs': {
+            data: [
+              {type: 'zomgs', id: '3'},
+              {type: 'zomgs', id: '4'}
+            ]
+          }
+        },
+      },
+      {
+        type: 'zomgs',
+        id: '1',
+        attributes: {},
+        relationships: {
+          'lol': {
+            data: {type: 'lols', id: '1'}
+          }
+        },
+      },
+      {
+        type: 'zomgs',
+        id: '2',
+        attributes: {},
+        relationships: {
+          'lol': {
+            data: {type: 'lols', id: '2'}
+          }
+        },
+      },
+      {
+        type: 'zomgs',
+        id: '3',
+        attributes: {},
+        relationships: {
+          'lol': {
+            data: {type: 'lols', id: '3'}
+          }
+        },
+      },
+      {
+        type: 'zomgs',
+        id: '4',
+        attributes: {},
+        relationships: {
+          'lol': {
+            data: {type: 'lols', id: '4'}
+          }
+        },
+      },
+      {
         type: 'lols',
         id: '1',
         attributes: {},


### PR DESCRIPTION
Recently started using ember-cli-mirage. Was very happy when I found out it already supported the `include` query param for the JSON::API adapter!

However, per the JSON::API spec, when a dot-path relationship is included, all intermediate relationships should be included as well (see the second text box of the [Inclusion of Related Resources](http://jsonapi.org/format/#fetching-includes) section). This PR should make mirage comply with that.