### PR TITLE
Add optional links to JSONAPI response

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -122,9 +122,39 @@ class JsonApiSerializer {
           }
         };
       }
+
+      this._addLinkData(obj, model, relationshipKey);
     });
 
     return obj;
+  }
+
+  _addLinkData(json, model, relationshipKey) {
+    let serializer = this._serializerFor(model);
+
+    if (serializer && serializer.links) {
+      let linkData = serializer.links(model);
+
+      for (let key in linkData) {
+        if (linkData[key]) {
+          if (!json.relationships[relationshipKey]) { json.relationships[relationshipKey] = {}; }
+
+          // ember-data will not use links if data is present
+          delete json.relationships[relationshipKey].data;
+          json.relationships[relationshipKey].links = {};
+
+          let selfLink = linkData[key]['self'];
+          if (selfLink) {
+            json.relationships[relationshipKey].links.self = { href: selfLink };
+          }
+
+          let relatedLink = linkData[key]['related'];
+          if (relatedLink) {
+            json.relationships[relationshipKey].links.related = { href: relatedLink };
+          }
+        }
+      }
+    }
   }
 
   keyForAttribute(attr) {

--- a/tests/integration/serializers/json-api-serializer/associations/links-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/links-test.js
@@ -1,0 +1,62 @@
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+import JsonApiSerializer from 'ember-cli-mirage/serializers/json-api-serializer';
+import schemaHelper from '../../schema-helper';
+import { module, test } from 'qunit';
+
+module('Integration | Serializers | JSON API Serializer | Associations | Links', {
+  beforeEach: function() {
+    this.schema = schemaHelper.setup();
+
+    let link = this.schema.wordSmith.create({firstName: 'Link'});
+    let blogPost = link.createBlogPost({title: 'Lorem'});
+    blogPost.createFineComment({text: 'pwned'});
+
+    link.createBlogPost({title: 'Ipsum'});
+
+    this.schema.wordSmith.create({name: 'Zelda'});
+  },
+  afterEach() {
+    this.schema.db.emptyData();
+  }
+});
+
+test(`it can link to relationships, omitting 'data'`, function(assert) {
+  let registry = new SerializerRegistry(this.schema, {
+    application: JsonApiSerializer,
+    wordSmith: JsonApiSerializer.extend({
+      links(model) {
+        return {
+          'blogPosts': {
+            related: `/api/blog_posts?word_smith_id=${model.id}`,
+            self: `/api/word_smiths/${model.id}/relationships/blog_posts`
+          }
+        };
+      }
+    })
+  });
+
+  let wordSmith = this.schema.wordSmith.find(1);
+  let result = registry.serialize(wordSmith);
+
+  assert.deepEqual(result, {
+    data: {
+      type: 'word-smiths',
+      id: '1',
+      attributes: {
+        'first-name': 'Link',
+      },
+      relationships: {
+        'blog-posts': {
+          links: {
+            related: {
+              href: `/api/blog_posts?word_smith_id=${wordSmith.id}`
+            },
+            self: {
+              href: `/api/word_smiths/${wordSmith.id}/relationships/blog_posts`
+            }
+          }
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
This is helpful for async relationships that are driven by links in the
response, instead of relationship IDs.

JSONAPI Links spec: http://jsonapi.org/format/#document-links

Usage:

```es6
import ApplicationSerializer from './application';

export default ApplicationSerializer.extend({
  links: {
    comments: {
      related: function(model) { return `/api/comments?post_id=${model.id}`; },
      self: function(model) { return `/api/posts/${model.id}/comments`; }
   }
});
```