### PR TITLE
Corrects the meaning for the definition of `isNew()`

### DIFF
--- a/docs/v0.2.0-beta.7/models.md
+++ b/docs/v0.2.0-beta.7/models.md
@@ -155,7 +155,7 @@ post.destroy(); // removed from the db
 
 ### isNew()
 
-Boolean, true if the model has been persisted to the db.
+Boolean, true if the model has not been persisted yet to the db.
 
 ```js
 let post = blogPost.new({title: 'Lorem ipsum'});


### PR DESCRIPTION
The `isNew()` instance method for the `mirage-model` is supposed to return true only when the model hasn't been persisted yet to the mirage db.
Added the word `not` :)