### PR TITLE
Index Route Passthroughs

### DIFF
--- a/tests/integration/passthrough-test.js
+++ b/tests/integration/passthrough-test.js
@@ -176,8 +176,8 @@ test('passthrough without args allows all paths on the current domain to passthr
   $.ajax({
     method: "GET",
     url: "/addresses",
-    error: function(/* reason */) {
-      assert.ok(true);
+    error: function(reason) {
+      assert.equal(reason.status, 404);
       done2();
     }
   });

--- a/tests/integration/passthrough-test.js
+++ b/tests/integration/passthrough-test.js
@@ -183,6 +183,38 @@ test('passthrough without args allows all paths on the current domain to passthr
   });
 });
 
+test('passthrough without args allows index route on current domain to passthrough', function(assert) {
+  assert.expect(2);
+  var done1 = assert.async();
+  var done2 = assert.async();
+  var server = this.server;
+
+  server.loadConfig(function() {
+    this.get('/contacts', function() {
+      return 123;
+    });
+    this.passthrough();
+  });
+
+  $.ajax({
+    method: "GET",
+    url: "/contacts",
+    success: function(data) {
+      assert.equal(data, 123);
+      done1();
+    }
+  });
+
+  $.ajax({
+    method: "GET",
+    url: "/",
+    error: function(reason) {
+      assert.equal(reason.status, 404);
+      done2();
+    }
+  });
+});
+
 test('it can passthrough other-origin hosts', function(assert) {
   assert.expect(1);
   var done1 = assert.async();


### PR DESCRIPTION
Here's a failing test for passthroughs catching the index route.

I tried removing the leading `/`, but it didn't work. 

Maybe including the naked `/` in the list of paths when the `path.length === 0`?