### PR TITLE
Fix typo in handledRequest string interp.

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -23,7 +23,7 @@ function createPretender(server) {
 
     this.handledRequest = function(verb, path, request) {
       if (server.shouldLog()) {
-        console.log(`Successful request: ${verb.toUpperCase()} $[request.url}`);
+        console.log(`Successful request: ${verb.toUpperCase()} ${request.url}`);
         let { responseText } = request;
         let loggedResponse;
 


### PR DESCRIPTION
On master was seeing this in the output:
```
Successful request: GET $[request.url}
```
Subtle typo causing this problem.