### PR TITLE
adds YUIDoc comments to addon/db-collection

### DIFF
--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -102,17 +102,17 @@ class DbCollection {
     `query` and optional `attributesForCreate`.
     @method firstOrCreate
     @param query
-    @param attributesForNew
+    @param attributesForCreate
     @public
   */
-  firstOrCreate(query, attributesForNew={}) {
+  firstOrCreate(query, attributesForCreate={}) {
     let queryResult = this.where(query);
     let [ record ] = queryResult;
 
     if (record) {
       return record;
     } else {
-      let mergedAttributes = _assign(attributesForNew, query);
+      let mergedAttributes = _assign(attributesForCreate, query);
       let createdRecord = this.insert(mergedAttributes);
 
       return createdRecord;

--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -15,8 +15,10 @@ function isNumber(n) {
   return (+n).toString() === n.toString();
 }
 
-/*
+/**
   A collection of db records i.e. a database table.
+  @class DbCollection
+  @constructor
 */
 class DbCollection {
 
@@ -29,13 +31,23 @@ class DbCollection {
       this.insert(initialData);
     }
   }
-  /*
+
+  /**
     Returns a copy of the data, to prevent inadvertent data manipulation.
+    @method all
+    @public
   */
   all() {
     return duplicate(this._records);
   }
 
+  /**
+    Inserts `data` into the collection. `data` can be a single object
+    or an array of objects. Returns the inserted record.
+    @method insert
+    @param data
+    @public
+  */
   insert(data) {
     if (!_isArray(data)) {
       return this._insertRecord(data);
@@ -45,6 +57,15 @@ class DbCollection {
     }
   }
 
+  /**
+    Returns a single record from the `collection` if `ids` is a single
+    id, or an array of records if `ids` is an array of ids. Note
+    each id can be an int or a string, but integer ids as strings
+    (e.g. the string “1”) will be treated as integers.
+    @method find
+    @param ids
+    @public
+  */
   find(ids) {
     if (_isArray(ids)) {
       let records = this._findRecords(ids)
@@ -63,10 +84,27 @@ class DbCollection {
     }
   }
 
+  /**
+    Returns an array of models from `collection` that match the
+    key-value pairs in the `query` object. Note that a string
+    comparison is used. `query` is a POJO.
+    @method where
+    @param query
+    @public
+  */
   where(query) {
     return this._findRecordsWhere(query).map(duplicate);
   }
 
+  /**
+    Finds the first record matching the provided query in
+    `collection`, or creates a new record using a merge of the
+    `query` and optional `attributesForCreate`.
+    @method firstOrCreate
+    @param query
+    @param attributesForNew
+    @public
+  */
   firstOrCreate(query, attributesForNew={}) {
     let queryResult = this.where(query);
     let [ record ] = queryResult;
@@ -81,6 +119,21 @@ class DbCollection {
     }
   }
 
+  /**
+    Updates one or more records in collection.
+    If attrs is the only arg present, updates all records
+    in the collection according to the key-value pairs in attrs.
+    If target is present, restricts updates to those that
+    match target. If target is a number or string, finds a
+    single record whose id is target to update. If target is
+    a POJO, queries collection for records that match the
+    key-value pairs in target, and updates their attrs.
+    Returns the updated record or records.
+    @method update
+    @param target
+    @param attrs
+    @public
+  */
   update(target, attrs) {
     let records;
 
@@ -130,6 +183,18 @@ class DbCollection {
     }
   }
 
+  /**
+    Removes one or more records in `collection`.
+    If `target` is undefined, removes all records.
+    If `target` is a number or string, removes a
+    single record using `target` as id. If `target` is
+    a POJO, queries `collection` for records that
+    match the key-value pairs in `target`, and
+    removes them from the collection.
+    @method remove
+    @param target
+    @public
+  */
   remove(target) {
     let records;
 
@@ -165,6 +230,11 @@ class DbCollection {
     API query methods return copies.
   */
 
+  /**
+    @method _findRecord
+    @param id
+    @private
+  */
   _findRecord(id) {
     id = id.toString();
 
@@ -173,10 +243,20 @@ class DbCollection {
     return record;
   }
 
+  /**
+    @method _findRecords
+    @param ids
+    @private
+  */
   _findRecords(ids) {
     return ids.map(this._findRecord, this);
   }
 
+  /**
+    @method _findRecordsWhere
+    @param query
+    @private
+  */
   _findRecordsWhere(query) {
     let records = this._records;
 
@@ -193,6 +273,11 @@ class DbCollection {
     return records.filter(queryFunction);
   }
 
+  /**
+    @method _insertRecord
+    @param data
+    @private
+  */
   _insertRecord(data) {
     let attrs = duplicate(data);
 
@@ -209,6 +294,12 @@ class DbCollection {
     return duplicate(attrs);
   }
 
+  /**
+    @method _updateRecord
+    @param record
+    @param attrs
+    @private
+  */
   _updateRecord(record, attrs) {
     let targetId = (attrs && attrs.hasOwnProperty('id')) ? attrs.id.toString() : null;
     let currentId = record.id;


### PR DESCRIPTION
For issue #658 

I noticed that for `firstOrCreate` the documentation lists the second param as `attributesForCreate` while the code uses `attributesForNew`. Do you have a preference as to which should be referenced in the YUIDoc comments?

Also wasn't sure if I should document the `IdentityManager` methods at all. I didn't on this pass, but if I should, just let me know!