### PR TITLE
Remove the term mock on the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A client-side server to develop, test and prototype your Ember CLI app.
 
 Are you tired of
 
-- Writing one set of mocks for your tests, and another for development?
+- Writing one set of fixtures for your tests, and another for development?
 - Wiring up tests for each of your apps manually, from scratch?
 - Changing lots of files/tests when your API changes?
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-mirage",
   "version": "0.2.0-beta.8",
-  "description": "A client-side mock HTTP server to develop, test and demo your Ember app",
+  "description": "A client-side HTTP server to develop, test and demo your Ember app",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
To address #669 

* Changed the description in package.json
* Update the README

In the readme I think "fixtures" is a little better. I often seen people
turn to stubbing with fixtures first when trying to test against an API.
Using "mocks" outside of a testing context doesn't make sense.