### PR TITLE
Remove "mock" references in documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,8 +9,8 @@ kramdown:
 
 # Setup
 title: Ember CLI Mirage
-tagline: 'Easy API mocking for your Ember app'
-description: 'A client-side mock server to develop, test and prototype your Ember CLI app'
+tagline: 'Develop and test your Ember app against a client-side server'
+description: 'A client-side server to develop, test and prototype your Ember CLI app'
 url: https://github.com/samselikoff/ember-cli-mirage
 baseurl: ''
 destination: jekyll-tmp/

--- a/about/index.html
+++ b/about/index.html
@@ -4,13 +4,13 @@ title: About
 ---
 
 <div class="About">
-  
+
   <div class='About__section'>
     <h1 class='About__heading'>About Mirage</h1>
     <div class='About__content'>
-      <p>Mirage was created to let you easily mock out your JSON API. It's built on existing libraries, but brings along conventions to make setting up your mock server quick and painless.</p>
-      <p>One primary goal of the project is maintainability. New developers should be able to jump into an existing Ember project that uses Mirage and understand the API endpoints the app expects, be able to create mock data for tests, add new routes, and more, without having to understand a custom mocking setup.</p>
-      <p>Additionally, an Ember test suite that uses Mirage can run anywhere a normal test suite can, since Mirage runs completely in the client. Many existing mocking solutions rely on a node server, which can make CI integration cumbersome.</p>
+      <p>Mirage was created to let you easily fake your JSON API. It's built on existing libraries, but brings along conventions to make setting up your fake server quick and painless.</p>
+      <p>One primary goal of the project is maintainability. New developers should be able to jump into an existing Ember project that uses Mirage and understand the API endpoints the app expects, be able to create data for tests, add new routes, and more, without having to understand a custom setup.</p>
+      <p>Additionally, an Ember test suite that uses Mirage can run anywhere a normal test suite can, since Mirage runs completely in the client. Many existing solutions rely on a node server, which can make CI integration cumbersome.</p>
     </div>
   </div>
 
@@ -29,12 +29,12 @@ title: About
       <p>Yes! This is a great use case for Mirage. Simply <a href="{{ site.baseurl }}/docs/{{site.default_version}}/server-configuration/#enabled">enable Mirage in production</a>, and everything will work just like it does in development.</p>
       <p><strong>This project seems complex. Is it a good idea?</strong></p>
       <p>Mirage tries to do a lot so you don't have to. Mirage server definitions end up being straightforward, which is especially important for long-lived projects with multiple developers.</p>
-      <p>As long as people are mocking out JSON APIs for testing and development, we should try to build on each other's knowledge, and establish some conventions.</p>
+      <p>As long as people are faking JSON APIs for testing and development, we should try to build on each other's knowledge, and establish some conventions.</p>
       <p><strong>What's on the roadmap?</strong></p>
       <p>Several things:</p>
       <ul>
         <li><a href="https://github.com/samselikoff/ember-cli-mirage/issues/69">An ORM</a>, to simplify CRUD operations on associations</li>
-        <li><a href="https://github.com/samselikoff/ember-cli-mirage/issues/24">Websocket mocking</a></li>
+        <li><a href="https://github.com/samselikoff/ember-cli-mirage/issues/24">Simulating websockets</a></li>
         <li><a href="https://github.com/samselikoff/ember-cli-mirage/issues/28">Factory relationships</a></li>
         <li><a href="https://github.com/samselikoff/ember-cli-mirage/issues/2">Serializers</a></li>
       </ul>

--- a/docs/v0.2.0-beta.7/acceptance-testing.md
+++ b/docs/v0.2.0-beta.7/acceptance-testing.md
@@ -90,7 +90,7 @@ We override `title` in the second test since it's relevant there, but we stick w
 
 ## Asserting a server call was made in a test
 
-Often you'll write tests against your application's UI, which will verify that the proper data from Mirage was returned. However, because Mirage gives you a full mock server, you can gain more confidence from your tests by asserting against Mirage's server state, in addition to testing your Ember app's UI.
+Often you'll write tests against your application's UI, which will verify that the proper data from Mirage was returned. However, because Mirage gives you a full client-side server, you can gain more confidence from your tests by asserting against Mirage's server state, in addition to testing your Ember app's UI.
 
 There are two general approaches to this. First, you can assert directly against Mirage's database:
 
@@ -162,4 +162,4 @@ This route handler definition is only in effect for the duration of this test, s
 
 ---
 
-You should now know enough to mock out your API and test your app using Mirage!
+You should now know enough to fake your production API and test your app using Mirage!

--- a/docs/v0.2.0-beta.7/defining-routes.md
+++ b/docs/v0.2.0-beta.7/defining-routes.md
@@ -114,7 +114,7 @@ As long as all your Mirage routes read from and write to the database, user inte
 ## Dynamic paths and query params
 
 The request object that's injected into your route handlers contains any dynamic route segments and query params.
- 
+
 To define a route that has a dynamic segment, use colon syntax (`:segment`) in your path. The dynamic piece will be available via `request.params.[segment]`:
 
 ```js
@@ -154,7 +154,7 @@ which infers the collection name from the last part of the URL. Returning a sing
 this.get('/authors/:id');
 ```
 
-Similarly, we wrote a mock by hand to deal with creating an author
+Similarly, we wrote a route handler by hand to deal with creating an author
 
 ```js
 this.post('/authors', (schema, request) => {
@@ -177,7 +177,7 @@ View the [full reference](../shorthands) to see all available shorthands.
 
 When you return a model or a collection from a route handler, Mirage *serializes* it into a JSON payload, and then responds to your Ember app with that payload. It uses an object called a Serializer to do this, which you can customize. Having a single object that's responsible for this formatting logic helps keep your route handlers simple. In particular, a bit of customization in the serializer layer often lets you use shorthands when you otherwise wouldn't be able to.
 
-Mirage ships with two named serializers, JsonApiSerializer (used to mock servers implementing [JSON:API](http://jsonapi.org/)) and ActiveModelSerializer (used to mock Rails servers using ActiveModel::Serializers). You should use these if your app's backend will be built to conform to either standard.
+Mirage ships with two named serializers, JsonApiSerializer (used to implement [JSON:API](http://jsonapi.org/)) and ActiveModelSerializer (used to simulate Rails servers using ActiveModel::Serializers). You should use these if your app's backend will be built to conform to either standard.
 
 Additionally, there's a basic Serializer class that you can use and customize. By default, it takes all the attributes of your model, and returns them under a root key of the model type. Suppose you had the following author in your database:
 
@@ -221,7 +221,7 @@ import Ember from 'ember';
 const { dasherize } = Ember.String;
 
 export default Serializer.extend({
-  
+
   keyForAttribute(key) {
     return dasherize(key);
   }
@@ -251,8 +251,8 @@ Just like in Ember, the `application/serializer.js` file will apply to all your 
 import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
-  
-  attributes: ['firstName'] 
+
+  attributes: ['firstName']
 
 });
 ```
@@ -310,7 +310,7 @@ GET /authors/1
 {
   author: {
     id: 1,
-    name: 'Link' 
+    name: 'Link'
   },
   posts: [
     {id: 1, authorId: 1, title: "The Beauty of Hyrule"},
@@ -330,7 +330,7 @@ Mirage's database uses camelcase for all model attributes, including foreign key
 ## Dynamic status codes and HTTP headers
 
 By default, Mirage sets the HTTP code of a response based on the verb being used:
-  
+
   - `get`, `put` and `del` are 200
   - `post` is 201
 
@@ -359,7 +359,7 @@ export default function() {
 
 ## Fully qualified URLs
 
-Route handlers for paths without a domain (e.g. `this.get('/authors')`) work for requests that target the current domain. To mock out other-origin requests, specify the fully qualified URL for your route handler:
+Route handlers for paths without a domain (e.g. `this.get('/authors')`) work for requests that target the current domain. To simulate other-origin requests, specify the fully qualified URL for your route handler:
 
 ```js
 this.get('https://api.github.com/users/samselikoff/events', () => {

--- a/docs/v0.2.0-beta.7/index.md
+++ b/docs/v0.2.0-beta.7/index.md
@@ -9,9 +9,9 @@ Nearly all Ember apps interact with an API. When you reach the point during deve
   2. Use a library like [Pretender](https://github.com/trek/pretender) or [jQuery mockjax](https://github.com/jakerella/jquery-mockjax) to write a custom script that intercepts your requests in the client
   3. Use Ember CLI's HTTP mocks
 
-Option 1 can work if you already have the API - but often that isn't the case. Option 2 is flexible, but requires you to start from scratch in each project, leaving it up to you to enforce conventions across your apps. Option 3 has a bit more structure, but requires a node server to be running, and doesn't allow you to use your mocks in a CI environment.
+Option 1 can work if you already have the API - but often that isn't the case. Option 2 is flexible, but requires you to start from scratch in each project, leaving it up to you to enforce conventions across your apps. Option 3 has a bit more structure, but requires a node server to be running, and doesn't allow you to use your fake server in a CI environment.
 
-Mirage was built to solve these problems. It's a mock server that runs in the client, and can be used in both development and testing. It brings along enough conventions to quickly get you up and running.
+Mirage was built to solve these problems. It's a fake server that runs in the client, and can be used in both development and testing. It brings along enough conventions to quickly get you up and running.
 
 Mirage borrows concepts from typical backend systems like
 

--- a/docs/v0.2.0-beta.7/quickstart.md
+++ b/docs/v0.2.0-beta.7/quickstart.md
@@ -3,7 +3,7 @@ title: Quickstart
 version: v0.2.0-beta.7
 ---
 
-Mirage is all about faking your API server. You define *route handlers* to respond to your Ember app's AJAX requests.
+Mirage is all about simulating your API server. You define *route handlers* to respond to your Ember app's AJAX requests.
 
 Here's a simple example of a handler:
 
@@ -28,7 +28,7 @@ Now whenever your Ember app makes a GET request to `/api/authors`, Mirage will r
 
 ## Dynamic data
 
-This works, and is a common way to isolate tests from a real HTTP server - but hard-coded responses like this have a few problems:
+This works, and is a common way to simulate HTTP responses - but hard-coded responses like this have a few problems:
 
    - *They're inflexible*. What if you want to change this route's response data in your tests?
    - *They contain formatting logic*. Logic that formats the shape of your JSON payload (e.g., including the root `authors` key) is now duplicated across all your route handlers.
@@ -51,7 +51,7 @@ import { Model } from 'ember-cli-mirage';
 export default Model;
 ```
 
-The model will create an `authors` table in Mirage's *in-memory database*. The database makes our route handlers dynamic&mdash;we can change the returned data without rewriting the handler. In this way, we can share a single implementation for a route in both development and testing, while still having control over the response data.
+The model will create an `authors` table in Mirage's *in-memory database*. The database makes our route handlers dynamic&mdash;we can change the returned data without rewriting the handler. In this way, we can share the same route definitions in both development and testing, while still having control over their response data.
 
 Let's update our route handler to be dynamic:
 
@@ -253,7 +253,7 @@ Shorthands make writing your server definition concise, so you should use them w
 
 ## Passthrough
 
-Mirage is a great tool to use even if you don't want to fake your entire API. By default, Mirage throws an error if your Ember app makes a request that doesn't have a corresponding route handler defined. To avoid this, tell Mirage to let unhandled requests pass through:
+Mirage is a great tool to use even if you're working on an existing app, or if you don't want to fake your entire API. By default, Mirage throws an error if your Ember app makes a request that doesn't have a corresponding route handler defined. To avoid this, tell Mirage to let unhandled requests pass through:
 
 ```js
 // mirage/config.js

--- a/docs/v0.2.0-beta.7/quickstart.md
+++ b/docs/v0.2.0-beta.7/quickstart.md
@@ -3,7 +3,7 @@ title: Quickstart
 version: v0.2.0-beta.7
 ---
 
-Mirage is all about mocking out your API server. You define *route handlers* to respond to your Ember app's AJAX requests.
+Mirage is all about faking your API server. You define *route handlers* to respond to your Ember app's AJAX requests.
 
 Here's a simple example of a handler:
 
@@ -26,15 +26,15 @@ export default function() {
 
 Now whenever your Ember app makes a GET request to `/api/authors`, Mirage will respond with this data.
 
-## Dynamic mocks
+## Dynamic data
 
-This works, and is traditionally how HTTP mocking is done - but hard-coded responses like this have a few problems:
+This works, and is a common way to isolate tests from a real HTTP server - but hard-coded responses like this have a few problems:
 
    - *They're inflexible*. What if you want to change this route's response data in your tests?
-   - *They contain formatting logic*. Logic that formats the shape of your JSON payload (e.g., including the root `authors` key) is now duplicated across all your mock routes.
-   - *They're too basic.* Inevitably, when your mocks need to deal with more complex things like relationships, these simple ad hoc responses start to break down.
+   - *They contain formatting logic*. Logic that formats the shape of your JSON payload (e.g., including the root `authors` key) is now duplicated across all your route handlers.
+   - *They're too basic.* Inevitably, when your fake server needs to deal with more complex things like relationships, these simple ad hoc responses start to break down.
 
-Mirage provides some primitives that let you write more flexible, powerful mocks. Let's see how they work by replacing our basic mock above.
+Mirage provides primitives that let you write a more flexible server implementation. Let's see how they work by replacing our basic stub data above.
 
 First, create an `author` model by running the following in your terminal:
 
@@ -51,11 +51,11 @@ import { Model } from 'ember-cli-mirage';
 export default Model;
 ```
 
-The model will create an `authors` table in Mirage's *in-memory database*. The database enables our mocks to be dynamic, and lets us change the return data without rewriting the entire mock. In this way, we can share a single set of mock routes in both development and testing, while still having control over the response data.
+The model will create an `authors` table in Mirage's *in-memory database*. The database makes our route handlers dynamic&mdash;we can change the returned data without rewriting the handler. In this way, we can share a single implementation for a route in both development and testing, while still having control over the response data.
 
 Let's update our route handler to be dynamic:
 
-```js 
+```js
 this.get('/api/authors', (schema, request) => {
   return schema.author.all();
 });
@@ -137,11 +137,11 @@ test("I can view the authors", function() {
 });
 ```
 
-You now have a simple way to set up your mock server's initial data, both during development and on a per-test basis.
+You now have a simple way to set up your fake server's initial data, both during development and on a per-test basis.
 
 ## Associations and serializers
 
-Dealing with associations is always tricky, and mocking endpoints that deal with associations is no exception. Fortunately, Mirage ships with an ORM to help keep your mocks clean.
+Dealing with associations is always tricky, and faking endpoints that deal with associations is no exception. Fortunately, Mirage ships with an ORM to help keep your routes clean.
 
 Let's say your author has many blog-posts. You can declare this relationship in your model:
 
@@ -169,7 +169,7 @@ this.get('/authors/:id/blog-posts', (schema, request) => {
 });
 ```
 
-Mirage's serializer layer is also aware of your relationships, which helps when mocking endpoints that sideload or embed related data. Models and collections that are returned from a route handler pass through the serializer layer, where you can customize which attributes and associations to include, as well as override other formatting options:
+Mirage's serializer layer is also aware of your relationships, which helps when faking endpoints that sideload or embed related data. Models and collections that are returned from a route handler pass through the serializer layer, where you can customize which attributes and associations to include, as well as override other formatting options:
 
 ```js
 // mirage/serializers/application.js
@@ -253,16 +253,16 @@ Shorthands make writing your server definition concise, so you should use them w
 
 ## Passthrough
 
-Mirage is a great tool to use even if you're working on an existing app that doesn't have any mocks. By default, Mirage throws an error if your Ember app makes a request that doesn't have a corresponding mock defined. To avoid this, tell Mirage to let unhandled requests pass through:
+Mirage is a great tool to use even if you don't want to fake your entire API. By default, Mirage throws an error if your Ember app makes a request that doesn't have a corresponding route handler defined. To avoid this, tell Mirage to let unhandled requests pass through:
 
 ```js
 // mirage/config.js
 this.passthrough();
 ```
 
-Now you can develop as you normally would, for example against an existing API. 
+Now you can develop as you normally would, for example against an existing API.
 
-When it comes time to build a new feature, you don't have to wait for the API to be updated. Just mock out the new route that you need
+When it comes time to build a new feature, you don't have to wait for the API to be updated. Just define the new route that you need
 
 ```js
 // mirage/config.js
@@ -271,7 +271,7 @@ this.get('/comments');
 this.passthrough();
 ```
 
-and you can fully develop and test the feature. In this way you can build up your mock server piece by piece - adding some solid acceptance tests along the way.
+and you can fully develop and test the feature. In this way you can build up your fake server piece by piece - adding some solid acceptance tests along the way.
 
 ---
 

--- a/docs/v0.2.0-beta.7/route-handlers.md
+++ b/docs/v0.2.0-beta.7/route-handlers.md
@@ -117,17 +117,17 @@ this.post('/api/messages', ({message}, request) => {
 });
 ```
 
-If you return a string, it will not be `JSON.stringified`, so you can mock out responses other than JSON.
+If you return a string, it will not be `JSON.stringified`, so you can return responses other than JSON.
 
 ## External origins
 
-You can use Mirage to mock out other-origin requests. By default, a mock like
+You can use Mirage to simulate other-origin requests. By default, a route like
 
 ```js
 this.get('/contacts', ...)
 ```
 
-will hit the same origin that's serving your Ember app. To mock out a different origin, add the fully qualified domain name to your mock:
+will hit the same origin that's serving your Ember app. To handle a different origin, use the fully qualified domain name:
 
 ```js
 this.get('http://api.twitter.com/v1', ...)
@@ -139,6 +139,6 @@ If your entire Ember app uses an external (other-origin) API, you can globally c
 // mirage/config.js
 this.urlPrefix = 'https://my.api.com';
 
-// This mock will handle requests to https://my.api.com/contacts
+// This route will handle requests to https://my.api.com/contacts
 this.get('/contacts', ...)
 ```

--- a/docs/v0.2.0-beta.7/seeding-your-database.md
+++ b/docs/v0.2.0-beta.7/seeding-your-database.md
@@ -5,7 +5,7 @@ version: v0.2.0-beta.7
 redirect_from: "/docs/latest/seeding-your-database/"
 ---
 
-Once you've defined your server's routes, you'll probably want to seed your database with some initial data. You can use factories or fixtures, or both. 
+Once you've defined your server's routes, you'll probably want to seed your database with some initial data. You can use factories or fixtures, or both.
 
 In general Mirage recommends that you use factories, for a few reasons:
 
@@ -54,7 +54,7 @@ and so on.
   <p>View the full <a href="../factories#using-fakerjs">faker guide</a>.</p>
 </aside>
 
-Mirage also includes the Faker.js library, which pairs nicely with your factories to make your mock data more realistic:
+Mirage also includes the Faker.js library, which pairs nicely with your factories to make your data more realistic:
 
 ```js
 // mirage/factories/author.js
@@ -207,4 +207,4 @@ export default [
 
 ---
 
-You should now know how to seed your database with data, both during development and testing! Let's wrap up with a look at how to use your shiny new mock server to write some acceptance tests for your Ember app.
+You should now know how to seed your database with data, both during development and testing! Let's wrap up with a look at how to use your shiny new client-side server to write some acceptance tests for your Ember app.

--- a/docs/v0.2.0-beta.7/serializers.md
+++ b/docs/v0.2.0-beta.7/serializers.md
@@ -9,7 +9,7 @@ The application serializer (`/mirage/serializers/application.js`) will apply to 
 
 Any Model or Collection returned from a route handler will pass through the serializer layer. Highest priority will be given to a model-specific serializer, then the application serializer, then the default serializer.
 
-Mirage ships with two named serializers. Use **JsonApiSerializer** to mock out JSON:API compliant servers:
+Mirage ships with two named serializers. Use **JsonApiSerializer** to simulate JSON:API compliant servers:
 
 ```js
 // mirage/serializers/application.js
@@ -18,7 +18,7 @@ import JsonApiSerializer from 'ember-cli-mirage/serializers/json-api-serializer'
 export default JsonApiSerializer;
 ```
 
-Use **ActiveModelSerializer** to mock out Rails backends that use AMS-style responses:
+Use **ActiveModelSerializer** to fake Rails backends that use AMS-style responses:
 
 ```js
 // mirage/serializers/application.js
@@ -179,7 +179,7 @@ Setting `root` to false disables this:
 ```js
 // mirage/serializers/application.js
 export default Serializer.extend({
-  root: false 
+  root: false
 });
 ```
 
@@ -224,7 +224,7 @@ Setting `embed` to true will embed related records:
 ```js
 // mirage/serializers/application.js
 export default Serializer.extend({
-  embed: true 
+  embed: true
 });
 ```
 

--- a/docs/v0.2.0-beta.7/upgrading.md
+++ b/docs/v0.2.0-beta.7/upgrading.md
@@ -34,7 +34,7 @@ If you're upgrading your Mirage server from v0.1.x to v0.2 (currently in Beta), 
     ```
 
     from the root of your project. Mirage's directory is also [customizable](http://localhost:4000/docs/v0.2.0-beta.7/configuration/#directory), so you can also set an option and leave it under `/app`, if you'd like.
-  
+
   - **All multiword filenames are dasherized.** In Mirage 0.1.x, database collection names were taken from filenames. The idea was, if your API returned snake_case collection keys (e.g. `blog_posts: []`), just name your file `fixtures/blog_posts.js`. This approach turned out to be insufficiently flexib-- what am I saying, it was just a bad idea :P.
 
     In Mirage 0.2.x, we follow Ember CLI's conventions of dasherized filenames. So, you'll just need to go through and change
@@ -54,7 +54,7 @@ If you're upgrading your Mirage server from v0.1.x to v0.2 (currently in Beta), 
 
     You will then use the [new Serializer layer](../serializers) to do things like format keys in your json payloads (or Mirage will do it for you).
 
-  - **All JavaScript properties are camelCased.** Similar to the previous change, factory properties and database collection names followed the format of your API in Mirage 0.1.x. If you were mocking an ActiveModelSerializer backend, multiword keys used snake_case throughout your Mirage code. So, your database table might be `db.blog_posts`, and your factory keys might be `first_name() {..}`. Looks pretty cool right?
+  - **All JavaScript properties are camelCased.** Similar to the previous change, factory properties and database collection names followed the format of your API in Mirage 0.1.x. If you were faking an ActiveModelSerializer backend, multiword keys used snake_case throughout your Mirage code. So, your database table might be `db.blog_posts`, and your factory keys might be `first_name() {..}`. Looks pretty cool right?
 
     Wrong. We're JavaScript developers here, people. It's time to start using camelCase.
 
@@ -64,7 +64,7 @@ If you're upgrading your Mirage server from v0.1.x to v0.2 (currently in Beta), 
     let posts = db.blog_posts.filter(p => p.author_id === 1);
     ```
 
-    to 
+    to
 
     ```js
     let posts = db.blogPosts.filter(p => p.authorId === 1);
@@ -122,7 +122,7 @@ If you're upgrading your Mirage server from v0.1.x to v0.2 (currently in Beta), 
 
     Having that file sets up the `db.blogPosts` collection, allows you to use the JSON:API serializer, and more. You can still define factories and fixtures - but only if you need them. <!-- not yet! in 0.6.0 For instance, given the model above, `server.create('blog-post')` would create a blank `blog-post` model. You could then make a factory for models that need more customization. --> Models, factories and fixtures all work together, but now you won't be making blank factory or fixture files just to set up your database. The models themselves serve as the source of truth.
 
-    We needed to add models for [association support](../models/#associations) (which currently exists) and factory relationships (the first feature to come after the 0.2 release). Read through the [models guide](../models) and [serializers guide](../serializers) to see how having models can simplify your mock server.
+    We needed to add models for [association support](../models/#associations) (which currently exists) and factory relationships (the first feature to come after the 0.2 release). Read through the [models guide](../models) and [serializers guide](../serializers) to see how having models can simplify your Mirage server.
 
     We also have a plan to make a separate addon that could ascertain your model definitions and their relationships from your Ember Data models. Adding the ORM paves the way for this important future addition.
 

--- a/index.html
+++ b/index.html
@@ -4,20 +4,20 @@ title: Home
 ---
 
 <div class="Home-page">
-  <p class="Home-page__tagline">Build, test and demo your app <span class='u-desktop'><br /></span> using a single mock server</h1>
+  <p class="Home-page__tagline">Build, test and demo your app <span class='u-desktop'><br /></span> using a client-side server</h1>
 
   <div class="Home-page__features Grid Grid--gutters Grid--full small-Grid--fit">
     <div class="Grid-cell">
       <h2 class='Home-page__feature-heading'>Productive</h2>
-      <p class='Home-page__feature-section'>Spend less time wiring up HTTP mocks, and get back to developing your app.</p>
+      <p class='Home-page__feature-section'>Spend less time wiring up HTTP stubs, and get back to developing your app.</p>
     </div>
     <div class="Grid-cell">
       <h2 class='Home-page__feature-heading'>Test-worthy</h2>
-      <p class='Home-page__feature-section'>Use factories to define your server's state per test. Acceptance testing just got a whole lot easier.</p> 
+      <p class='Home-page__feature-section'>Use factories to define your server's state per test. Acceptance testing just got a whole lot easier.</p>
     </div>
     <div class="Grid-cell">
       <h2 class='Home-page__feature-heading'>Shareable</h2>
-      <p class='Home-page__feature-section'>Share a functional prototype of your app that runs entirely in the client - before writing a single line of your API.</p> 
+      <p class='Home-page__feature-section'>Share a functional prototype of your app that runs entirely in the client - before writing a single line of your API.</p>
     </div>
   </div>
 


### PR DESCRIPTION
To address #669 on the gh-pages branch.

I audited the gh-pages brach for use of the word "mock". This is not a simple find/replace and needs some review before merging.

For the docs, I only changed the v0.2.0-beta.7 version.

Beyond my own pedantic hangups about terminology, I think this is a nice improvement. The work "mock" was used generally to mean:

* noun - "a mock" - a route handler
* noun - "a mock" - data returned from a route handler or stub data
* verb - "mock" or "mock out" - simulate a real API or implement a route handler
* adjective - "mock server" - fake server

Instead I replaced these uses with "fake", "simulate", "data", "stub", "route handlers", "Mirage" or anything else that seemed to convey the original intent.
