### PR TITLE
support aliases for --proxy flag (-pr, -pxy)

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 
 function usingProxy() {
   var usingProxyArg = !!process.argv.filter(function (arg) {
-    return arg.indexOf('--proxy') === 0;
+    return arg.indexOf('--proxy') === 0 || arg.indexOf('-pr') === 0 || arg.indexOf('-pxy') === 0;
   }).length;
 
   var hasGeneratedProxies = false;


### PR DESCRIPTION
The current `usingProxy` implementation only accounts for the long form of the `--proxy` flag. Added checks for `-pr` and `-pxy` aliases.