### PR TITLE
add @public to block comment in addon/utils/db-collection.js to fix JSCS

### DIFF
--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -18,6 +18,7 @@ function isNumber(n) {
 /**
   A collection of db records i.e. a database table.
   @class DbCollection
+  @public
   @constructor
 */
 class DbCollection {


### PR DESCRIPTION
I’m seeing a single test error — both locally with Node@4.2.4/phantomJS@2.1.1 — and in Travis after a fresh clone/build of the project:

```
not ok 3 PhantomJS 2.0 - JSCS - modules/ember-cli-mirage: modules/ember-cli-mirage/db-collection.js should pass jscs
    ---
        actual: >
            false
        expected: >
            true
        stack: >
                at http://localhost:7357/assets/test-support.js:4039:17
                at http://localhost:7357/assets/dummy.js:66:7
                at runTest (http://localhost:7357/assets/test-support.js:2688:32)
                at run (http://localhost:7357/assets/test-support.js:2673:11)
                at http://localhost:7357/assets/test-support.js:2815:14
                at process (http://localhost:7357/assets/test-support.js:2474:24)
                at begin (http://localhost:7357/assets/test-support.js:2456:9)
                at http://localhost:7357/assets/test-support.js:2516:9
        message: >
            modules/ember-cli-mirage/db-collection.js should pass jscs.
            requireCommentsToIncludeAccess: You must supply `@public`, `@private`, or `@protected` for block comments. at modules/ember-cli-mirage/db-collection.js :
                16 |}
                17 |
                18 |/**
            --------^
                19 |  A collection of db records i.e. a database table.
                20 |  @class DbCollection
```
This can be [seen right now on the currently-failing build for my other PR](https://github.com/samselikoff/ember-cli-mirage/pull/702), which only introduces a small change to a file completely separate than `addon/utils/db-collection`.

I'm not quite sure how master is still green while this is occurring, but in any case, this change appears to solve the issue.