### PR TITLE
Update faker version specified in afterInstall hook

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -54,7 +54,7 @@ module.exports = {
 
     return this.addBowerPackagesToProject([
       { name: 'pretender', target: '~0.12.0' },
-      { name: 'Faker', target: '~3.0.0' }
+      { name: 'Faker', target: '~3.1.0' }
     ]);
   }
 };


### PR DESCRIPTION
This is a follow-up to #694. 

The version of `Faker` that clients will consume is controlled by `addBowerPackagesToProject` in the default blueprint's `afterInstall` hook. I was missing some of the supercool randomization functions that @bgentry was alluding to until I made the change there. 