### PR TITLE
Fix a capitalization typo for `JSONAPISerializer`

### DIFF
--- a/docs/v0.2.0-beta.9/serializers.md
+++ b/docs/v0.2.0-beta.9/serializers.md
@@ -17,7 +17,7 @@ Mirage ships with three named serializers:
   // mirage/serializers/application.js
   import JSONAPISerializer from 'ember-cli-mirage';
 
-  export default JsonApiSerializer;
+  export default JSONAPISerializer;
   ```
 
 - **ActiveModelSerializer**, to fake Rails backends that use AMS-style responses:


### PR DESCRIPTION
Fix the incorrect capitalization of the imported `JSONAPISerializer` which causes ReferenceError in run-time.