### PR TITLE
Update serializers.md

### DIFF
--- a/docs/v0.2.0-beta.9/serializers.md
+++ b/docs/v0.2.0-beta.9/serializers.md
@@ -15,7 +15,7 @@ Mirage ships with three named serializers:
 
   ```js
   // mirage/serializers/application.js
-  import JSONAPISerializer from 'ember-cli-mirage';
+  import { JSONAPISerializer } from 'ember-cli-mirage';
 
   export default JSONAPISerializer;
   ```


### PR DESCRIPTION
Fixed JSONAPISerializer import statement. I don't know if this is applicable to line 26 (ActiveModelSerializer) as well. Fixes https://github.com/samselikoff/ember-cli-mirage/issues/750