### PR TITLE
update links to v0.2.x docs

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -45,7 +45,7 @@ export default class BaseRouteHandler {
 
     assert(
       json.data && (json.data.attributes || json.data.relationships),
-      `You're using a shorthand or #normalizedRequestAttrs, but your serializer's normalize function did not return a valid JSON:API document. http://www.ember-cli-mirage.com/docs/v0.2.0-beta.9/serializers/#normalizejson`
+      `You're using a shorthand or #normalizedRequestAttrs, but your serializer's normalize function did not return a valid JSON:API document. http://www.ember-cli-mirage.com/docs/v0.2.x/serializers/#normalizejson`
     );
 
     if (json.data.attributes) {

--- a/blueprints/ember-cli-mirage/files/__root__/config.js
+++ b/blueprints/ember-cli-mirage/files/__root__/config.js
@@ -21,6 +21,6 @@ export default function() {
     this.put('/posts/:id'); // or this.patch
     this.del('/posts/:id');
 
-    http://www.ember-cli-mirage.com/docs/v0.2.0-beta.7/shorthands/
+    http://www.ember-cli-mirage.com/docs/v0.2.x/shorthands/
   */
 }


### PR DESCRIPTION
after 0.2.0 final dropped, I found some links in blueprint and in route-handler which links to 0.2.0.beta versions.