### PR TITLE
Fix serializing embedded collection keys

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -418,7 +418,11 @@ class Serializer {
       let relatedAttrs = serializer._serializeModelOrCollection(modelOrCollection, request);
 
       if (relatedAttrs) {
-        attrs[camelize(key)] = relatedAttrs;
+        if (this.isModel(modelOrCollection)) {
+          attrs[this.keyForModel(key)] = relatedAttrs;
+        } else {
+          attrs[this.keyForRelationship(key)] = relatedAttrs;
+        }
       }
 
       return attrs;

--- a/tests/integration/serializers/active-model-serializer-test.js
+++ b/tests/integration/serializers/active-model-serializer-test.js
@@ -17,6 +17,12 @@ module('Integration | Serializer | ActiveModelSerializer', {
       }),
       blogPost: Model.extend({
         wordSmith: belongsTo()
+      }),
+      user: Model.extend({
+        contactInfos: hasMany()
+      }),
+      contactInfo: Model.extend({
+        user: belongsTo()
       })
     });
 
@@ -26,11 +32,22 @@ module('Integration | Serializer | ActiveModelSerializer', {
 
     this.schema.wordSmiths.create({ name: 'Zelda', age: 230 });
 
+    let user = this.schema.users.create({ name: 'John Peach', age: 123 });
+    user.createContactInfo({ email: 'peach@bb.me' });
+    user.createContactInfo({ email: 'john3000@mail.com' });
+
+    this.schema.users.create({ name: 'Pine Apple', age: 230 });
+
     this.registry = new SerializerRegistry(this.schema, {
       application: ActiveModelSerializer,
       wordSmith: ActiveModelSerializer.extend({
         attrs: ['id', 'name'],
         include: ['blogPosts']
+      }),
+      user: ActiveModelSerializer.extend({
+        attrs: ['id', 'name'],
+        include: ['ContactInfos'],
+        embed: true
       })
     });
   },
@@ -92,6 +109,37 @@ test('it sideloads associations and snake-cases relationships and attributes cor
         id: '2',
         title: 'Ipsum',
         word_smith_id: '1'
+      }
+    ]
+  });
+});
+
+test('it embeds associations and snake-cases relationships and attributes correctly for a collection', function(assert) {
+  let users = this.schema.users.all();
+  let result = this.registry.serialize(users);
+
+  assert.deepEqual(result, {
+    users: [
+      {
+        id: '1',
+        name: 'John Peach',
+        contact_infos: [
+          {
+            id: '1',
+            email: 'peach@bb.me',
+            user_id: '1'
+          },
+          {
+            id: '2',
+            email: 'john3000@mail.com',
+            user_id: '1'
+          }
+        ]
+      },
+      {
+        id: '2',
+        name: 'Pine Apple',
+        contact_infos: []
       }
     ]
   });


### PR DESCRIPTION
I was trying to serialize a model that has a multiple hasMany() relationships with the standard ActiveModelSerializer plus `include` of these relationships with `embed: true`.

Although the regular fields are serialized fine as `underscore`, the embedded relationship keys were still in camelcase.

As it turned out, `camelize` was still hard-coded instead of `keyForRelationship`, so I fixed it and added a test. All existing tests still pass.