### PR TITLE
Remove styles for highlighting syntax errors

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -170,3 +170,7 @@ th {
 .highlight pre {
   margin-bottom: 0;
 }
+/* Rouge doesn't like newer ES2016 syntax */
+.highlight .err {
+  color: inherit; background-color: transparent;
+}


### PR DESCRIPTION
@samselikoff I think this is the best course of action. By adjusting the styles we don't need to open code fences in markdown with the `text` type and we still get to keep _some_ highlighting for those blocks. The downside is that if a code block does have real errors we rely on only a keen eye.