### PR TITLE
Added ms dependancy to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "ember-cli-babel": "^5.1.5",
     "ember-inflector": "^1.9.2",
     "ember-lodash": "0.0.9",
-    "exists-sync": "0.0.3"
+    "exists-sync": "0.0.3",
+    "ms": "^0.7.1"
   }
 }


### PR DESCRIPTION
When setuping up the development env for ember-cli-mirage I had to install ms using npm