### PR TITLE
Include function documentation

### DIFF
--- a/docs/v0.2.x/serializers.md
+++ b/docs/v0.2.x/serializers.md
@@ -165,6 +165,21 @@ GET /authors/1
 }
 ```
 
+You can also define `include` as a function so it can be determined dynamically:
+
+```js
+// mirage/serializers/author.js
+export default Serializer.extend({
+  include: function(request) {
+    if (request.queryParams.posts) {
+      return ['blogPosts'];
+    } else {
+      return [];
+    }
+  }
+});
+```
+
 ## include query param
 
 *Note: This is only available when using the JSONAPISerializer.*

--- a/docs/v0.2.x/serializers.md
+++ b/docs/v0.2.x/serializers.md
@@ -141,7 +141,7 @@ export default Model.extend({
 and you wanted to sideload these, specify so in the `include` key:
 
 ```js
-// mirage/serializers/authors.j
+// mirage/serializers/author.js
 export default Serializer.extend({
   include: ['blogPosts']
 });


### PR DESCRIPTION
You mentioned this to me at Wicked Good Ember but it’s not documented. This example is maybe not the best, I can update it if you have a better suggestion.

Also, I threw in a commit to fix what looks to me to be a typo. If you’d prefer that to be in a separate PR, let me know.

I think this won’t help with my situation, which involves serialising a related model that [may or may not be present](https://github.com/travis-ci/travis-web/blob/a11090ad28459b3b01b409579dc6e9d366263352/mirage/serializers/build.js):

```
  serialize(object, request) {
    const response = object.attrs;

    if (object.commit) {
      response.commit = this.serializerFor('commit').serialize(object.commit, request);
    }

    return response;
  }
```

I’d ideally be able to use `includes: ['commit']` and ignore it if there’s no related commit, but I don’t think the `include` function would help because it only receives the `request`, not the object being serialised. But this custom `serialize` method isn’t outrageous.