### PR TITLE
Add findBy(query) method to db / schema

### DIFF
--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -86,6 +86,24 @@ class DbCollection {
   }
 
   /**
+   * Returns the first model from `collection` that matches the
+   * key-value pairs in the `query` object. Note that a string
+   * comparison is used. `query` is a POJO.
+   * @method find
+   * @param query
+   * @public
+   */
+  findBy(query) {
+    let record = this._findRecordBy(query);
+    if (!record) {
+      return null;
+    }
+
+    // Return a copy
+    return duplicate(record);
+  }
+
+  /**
    * Returns an array of models from `collection` that match the
    * key-value pairs in the `query` object. Note that a string
    * comparison is used. `query` is a POJO.
@@ -242,6 +260,15 @@ class DbCollection {
     let [ record ] = this._records.filter((obj) => obj.id === id);
 
     return record;
+  }
+
+  /**
+   * @method _findRecordBy
+   * @param query
+   * @private
+   */
+  _findRecordBy(query) {
+    return this._findRecordsWhere(query)[0];
   }
 
   /**

--- a/addon/db.js
+++ b/addon/db.js
@@ -41,7 +41,7 @@ class Db {
         get() {
           let recordsCopy = newCollection.all();
 
-          ['insert', 'find', 'where', 'update', 'remove', 'firstOrCreate']
+          ['insert', 'find', 'findBy', 'where', 'update', 'remove', 'firstOrCreate']
             .forEach(function(method) {
               recordsCopy[method] = function() {
                 return newCollection[method](...arguments);

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -85,6 +85,7 @@ export default class Schema {
       create: (attrs) => this.create(camelizedModelName, attrs),
       all: (attrs) => this.all(camelizedModelName, attrs),
       find: (attrs) => this.find(camelizedModelName, attrs),
+      findBy: (attrs) => this.findBy(camelizedModelName, attrs),
       where: (attrs) => this.where(camelizedModelName, attrs),
       first: (attrs) => this.first(camelizedModelName, attrs)
     };
@@ -141,6 +142,23 @@ export default class Schema {
     }
 
     return this._hydrate(records, dasherize(type));
+  }
+
+  /**
+   * @method findBy
+   * @param type
+   * @param attributeName
+   * @public
+   */
+  findBy(type, query) {
+    let collection = this._collectionForType(type);
+    let records = collection.where(query);
+
+    if (records.length === 0) {
+      return this._hydrate(records, dasherize(type));
+    }
+
+    return this._hydrate(records[0], dasherize(type));
   }
 
   /**

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -152,13 +152,9 @@ export default class Schema {
    */
   findBy(type, query) {
     let collection = this._collectionForType(type);
-    let records = collection.where(query);
+    let records = collection.findBy(query);
 
-    if (records.length === 0) {
-      return this._hydrate(records, dasherize(type));
-    }
-
-    return this._hydrate(records[0], dasherize(type));
+    return this._hydrate(records, dasherize(type));
   }
 
   /**

--- a/tests/unit/db-test.js
+++ b/tests/unit/db-test.js
@@ -212,6 +212,57 @@ test('tracks the correct IDs being used', function(assert) {
   assert.equal(db.contacts.length, 2);
 });
 
+module('Unit | Db #findBy', {
+  beforeEach() {
+    db = new Db();
+    db.createCollection('contacts');
+    db.contacts.insert([
+      { name: 'Zelda' },
+      { name: 'Link' },
+      { name: 'Epona', race: 'Horse' },
+      { name: 'Epona', race: 'Centaur' },
+      { id: 'abc', name: 'Ganon' }
+    ]);
+  },
+  afterEach() {
+    db.emptyData();
+  }
+});
+
+test('returns a record that matches the given name', function(assert) {
+  let contact = db.contacts.findBy({ 'name': 'Link' });
+
+  assert.deepEqual(contact, { id: '2', name: 'Link' });
+});
+
+test('returns a copy not a reference', function(assert) {
+  let contact = db.contacts.findBy({ 'name': 'Link' });
+
+  contact.name = 'blah';
+
+  assert.deepEqual(db.contacts.find(2), { id: '2', name: 'Link' });
+});
+
+test('returns the first record matching the criteria', function(assert) {
+  let contact = db.contacts.findBy({ 'name': 'Epona' });
+
+  console.log(contact);
+  assert.deepEqual(contact, { id: '3', name: 'Epona', race: 'Horse' });
+});
+
+test('returns a record only matching multiple criteria', function(assert) {
+  let contact = db.contacts.findBy({ 'name': 'Epona', 'race': 'Centaur' });
+
+  console.log(contact);
+  assert.deepEqual(contact, { id: '4', name: 'Epona', race: 'Centaur' });
+});
+
+test('returns null when no record is found', function(assert) {
+  let contact = db.contacts.findBy({ 'name': 'Fi' });
+
+  assert.equal(contact, null);
+});
+
 module('Unit | Db #find', {
   beforeEach() {
     db = new Db();


### PR DESCRIPTION
Hey Sam,

I want to add a finder method that takes a multiple attribute query (like `where`), but always returns 0 or 1 results (like `find`).
This method does exactly that.

My particular use case was for finding by slug instead of id in route handlers, like so:

````
let slug = request.params.id;

return schema.contacts.findBy({ slug: slug });
````

Please let me know if this is acceptable, and I'll write the docs for the site.