### PR TITLE
adds helper method to normalize form data requests

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -90,5 +90,4 @@ export default class BaseRouteHandler {
 
     return attrs;
   }
-
 }

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -71,4 +71,21 @@ export default class BaseRouteHandler {
     return attrs;
   }
 
+  _getAttrsForFormRequest({ requestBody }) {
+    let attrs;
+
+    assert(
+      requestBody && typeof requestBody === 'string',
+      `You're using the helper method #normalizedFormData, but the request body is empty or not a valid url encoded string.`
+    );
+
+    attrs = requestBody.split('&').reduce((a, b) => {
+      let [ key, value ] = b.split('=');
+      a[key] = value;
+      return a;
+    }, {});
+
+    return attrs;
+  }
+
 }

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -73,15 +73,18 @@ export default class BaseRouteHandler {
 
   _getAttrsForFormRequest({ requestBody }) {
     let attrs;
+    let urlEncodedParts = [];
 
     assert(
       requestBody && typeof requestBody === 'string',
       `You're using the helper method #normalizedFormData, but the request body is empty or not a valid url encoded string.`
     );
 
-    attrs = requestBody.split('&').reduce((a, b) => {
-      let [ key, value ] = b.split('=');
-      a[key] = value;
+    urlEncodedParts = requestBody.split('&');
+
+    attrs = urlEncodedParts.reduce((a, urlEncodedPart) => {
+      let [key, value] = urlEncodedPart.split('=');
+      a[key] = decodeURIComponent(value.replace(/\+/g,  ' '));
       return a;
     }, {});
 

--- a/addon/route-handlers/function.js
+++ b/addon/route-handlers/function.js
@@ -35,4 +35,8 @@ export default class FunctionRouteHandler extends BaseRouteHandler {
     return this._getAttrsForRequest(this.request, modelName);
   }
 
+  normalizedFormData() {
+    return this._getAttrsForFormRequest(this.request);
+  }
+
 }

--- a/addon/route-handlers/function.js
+++ b/addon/route-handlers/function.js
@@ -30,13 +30,17 @@ export default class FunctionRouteHandler extends BaseRouteHandler {
   }
 
   normalizedRequestAttrs() {
-    let modelName = this.getModelClassFromPath(this.request.url);
+    let {
+      request,
+      request: { url, requestHeaders }
+    } = this;
 
-    return this._getAttrsForRequest(this.request, modelName);
+    let modelName = this.getModelClassFromPath(url);
+
+    if (/x-www-form-urlencoded/.test(requestHeaders['Content-Type'])) {
+      return this._getAttrsForFormRequest(request);
+    } else {
+      return this._getAttrsForRequest(request, modelName);
+    }
   }
-
-  normalizedFormData() {
-    return this._getAttrsForFormRequest(this.request);
-  }
-
 }

--- a/tests/integration/server/custom-function-handler-test.js
+++ b/tests/integration/server/custom-function-handler-test.js
@@ -43,7 +43,7 @@ test(`a POJA of models defaults to responding with an array of each model's attr
   });
 });
 
-test(`#normalizedRequestAttrs returns the an object with the primary resource's attrs and belongsTo keys camelized`, function(assert) {
+test(`#normalizedRequestAttrs returns an object with the primary resource's attrs and belongsTo keys camelized`, function(assert) {
   assert.expect(1);
   let done = assert.async();
   let { server } = this;
@@ -70,6 +70,32 @@ test(`#normalizedRequestAttrs returns the an object with the primary resource's 
         team_id: 1
       }
     })
+  }).done(() => {
+    done();
+  });
+});
+
+test(`#normalizedFormData parses a x-www-form-urlencoded request and returns a POJO`, function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+  let { server } = this;
+
+  server.post('/form-test', function() {
+    let attrs = this.normalizedFormData();
+
+    assert.deepEqual(attrs, {
+      firstName: 'Sam',
+      lastName: 'Selikoff',
+      teamId: '1'
+    });
+
+    return {};
+  });
+
+  $.ajax({
+    method: 'POST',
+    url: '/form-test',
+    data: 'firstName=Sam&lastName=Selikoff&teamId=1'
   }).done(() => {
     done();
   });

--- a/tests/integration/server/custom-function-handler-test.js
+++ b/tests/integration/server/custom-function-handler-test.js
@@ -84,9 +84,9 @@ test(`#normalizedFormData parses a x-www-form-urlencoded request and returns a P
     let attrs = this.normalizedFormData();
 
     assert.deepEqual(attrs, {
-      firstName: 'Sam',
-      lastName: 'Selikoff',
-      teamId: '1'
+      name: 'Sam Selikoff',
+      company: 'TED',
+      email: 'sam.selikoff@gmail.com'
     });
 
     return {};
@@ -95,7 +95,7 @@ test(`#normalizedFormData parses a x-www-form-urlencoded request and returns a P
   $.ajax({
     method: 'POST',
     url: '/form-test',
-    data: 'firstName=Sam&lastName=Selikoff&teamId=1'
+    data: 'name=Sam+Selikoff&company=TED&email=sam.selikoff@gmail.com'
   }).done(() => {
     done();
   });

--- a/tests/integration/server/custom-function-handler-test.js
+++ b/tests/integration/server/custom-function-handler-test.js
@@ -63,6 +63,7 @@ test(`#normalizedRequestAttrs returns an object with the primary resource's attr
   $.ajax({
     method: 'POST',
     url: '/contacts',
+    contentType: 'application/json',
     data: JSON.stringify({
       contact: {
         first_name: 'Sam',
@@ -75,19 +76,19 @@ test(`#normalizedRequestAttrs returns an object with the primary resource's attr
   });
 });
 
-test(`#normalizedFormData parses a x-www-form-urlencoded request and returns a POJO`, function(assert) {
+test(`#normalizedRequestAttrs parses a x-www-form-urlencoded request and returns a POJO`, function(assert) {
   assert.expect(1);
   let done = assert.async();
   let { server } = this;
 
   server.post('/form-test', function() {
-    let attrs = this.normalizedFormData();
+    let attrs = this.normalizedRequestAttrs();
 
     assert.deepEqual(attrs, {
       name: 'Sam Selikoff',
       company: 'TED',
       email: 'sam.selikoff@gmail.com'
-    });
+    }, '#normalizedRequestAttrs successfully returned the parsed x-www-form-urlencoded request body');
 
     return {};
   });


### PR DESCRIPTION
Adds a helper method to parse a request sent using `formData`. Currently just supports simple key/value url encoded strings, does not support `multipart/form-data`.

Related to https://github.com/samselikoff/ember-cli-mirage/issues/753
