### PR TITLE
Adds Delete to Identity Manager

### DIFF
--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -207,12 +207,13 @@ class DbCollection {
       let record = this._findRecord(target);
       let index = this._records.indexOf(record);
       this._records.splice(index, 1);
-
+      this.identityManager.delete(record.id);
     } else if (_isArray(target)) {
       records = this._findRecords(target);
       records.forEach((record) =>  {
         let index = this._records.indexOf(record);
         this._records.splice(index, 1);
+        this.identityManager.delete(record.id);
       });
 
     } else if (typeof target === 'object') {
@@ -220,6 +221,7 @@ class DbCollection {
       records.forEach((record) =>  {
         let index = this._records.indexOf(record);
         this._records.splice(index, 1);
+        this.identityManager.delete(record.id);
       });
     }
   }
@@ -357,6 +359,12 @@ class IdentityManager {
     this.inc();
 
     return id.toString();
+  }
+
+  delete(id) {
+    if (id && this._ids[id]) {
+      this._ids[id] = false;
+    }
   }
 
   reset() {

--- a/tests/unit/db-test.js
+++ b/tests/unit/db-test.js
@@ -2,7 +2,7 @@ import Db from 'ember-cli-mirage/db';
 
 import {module, test} from 'qunit';
 
-let db;
+let db, collection, identityManager;
 module('Unit | Db');
 
 test('it can be instantiated', function(assert) {
@@ -450,6 +450,8 @@ module('Unit | Db #remove', {
       { name: 'Ganon', evil: true },
       { id: '123-abc', name: 'Epona', evil: false }
     ]);
+    collection = db._collections[0];
+    identityManager = collection.identityManager;
   },
 
   afterEach() {
@@ -471,6 +473,13 @@ test('it can remove a single record by id', function(assert) {
     { id: '2', name: 'Zelda', evil: false },
     { id: '3', name: 'Ganon', evil: true }
   ]);
+
+  assert.deepEqual(identityManager._ids, {
+    '1': false,
+    '2': true,
+    '3': true,
+    '123-abc': true
+  });
 });
 
 test('it can remove a single record when the id is a string', function(assert) {
@@ -481,6 +490,13 @@ test('it can remove a single record when the id is a string', function(assert) {
     { id: '2', name: 'Zelda', evil: false },
     { id: '3', name: 'Ganon', evil: true }
   ]);
+
+  assert.deepEqual(identityManager._ids, {
+    '1': true,
+    '2': true,
+    '3': true,
+    '123-abc': false
+  });
 });
 
 test('it can remove multiple records by ids', function(assert) {
@@ -490,6 +506,13 @@ test('it can remove multiple records by ids', function(assert) {
     { id: '123-abc', name: 'Epona', evil: false },
     { id: '3', name: 'Ganon', evil: true }
   ]);
+
+  assert.deepEqual(identityManager._ids, {
+    '1': false,
+    '2': false,
+    '3': true,
+    '123-abc': true
+  });
 });
 
 test('it can remove multiple records by query', function(assert) {
@@ -498,6 +521,13 @@ test('it can remove multiple records by query', function(assert) {
   assert.deepEqual(db.contacts, [
     { id: '3', name: 'Ganon', evil: true }
   ]);
+
+  assert.deepEqual(identityManager._ids, {
+    '1': false,
+    '2': false,
+    '3': true,
+    '123-abc': false
+  });
 });
 
 test('it can add a record after removing all records', function(assert) {
@@ -508,6 +538,43 @@ test('it can add a record after removing all records', function(assert) {
   assert.deepEqual(db.contacts, [
     { id: '1', name: 'Foo' }
   ]);
+
+  assert.deepEqual(identityManager._ids, {
+    '1': true
+  });
+});
+
+test('it can remove a record and then re-create with same id', function(assert) {
+  db.contacts.remove(1);
+
+  assert.deepEqual(db.contacts, [
+    { id: '123-abc', name: 'Epona', evil: false },
+    { id: '2', name: 'Zelda', evil: false },
+    { id: '3', name: 'Ganon', evil: true }
+  ]);
+
+  assert.deepEqual(identityManager._ids, {
+    '1': false,
+    '2': true,
+    '3': true,
+    '123-abc': true
+  });
+
+  db.contacts.insert({ id: 1, name: 'Link', evil: false });
+
+  assert.deepEqual(db.contacts, [
+    { id: '123-abc', name: 'Epona', evil: false },
+    { id: '2', name: 'Zelda', evil: false },
+    { id: '3', name: 'Ganon', evil: true },
+    { id: '1', name: 'Link', evil: false }
+  ]);
+
+  assert.deepEqual(identityManager._ids, {
+    '1': true,
+    '2': true,
+    '3': true,
+    '123-abc': true
+  });
 });
 
 module('Unit | Db #firstOrCreate', {

--- a/tests/unit/db/identity-manager-test.js
+++ b/tests/unit/db/identity-manager-test.js
@@ -76,6 +76,24 @@ test(`a string value that doesn't parse as an int passed into set doesn't affect
   assert.equal(manager.fetch(), 2);
 });
 
+test(`deletes id from the manager`, function(assert) {
+  let manager = new IdentityManager();
+
+  assert.equal(manager.fetch(), 1);
+  assert.equal(manager.fetch(), 2);
+  assert.deepEqual(manager._ids, {
+    1: true,
+    2: true
+  });
+
+  manager.delete(1);
+
+  assert.deepEqual(manager._ids, {
+    1: false,
+    2: true
+  });
+});
+
 test(`reset clears the managers memory`, function(assert) {
   let manager = new IdentityManager();
   manager.set('abc');


### PR DESCRIPTION
When a record is removed, the identity manager currently retains the id with a value of true. When trying to revive the record, mirage gives an error like: `Attempting to use the ID 1, but it's already been used`. I'd like the ability to reinstate the object that was deleted (via undo or some action) and use the same id.
