### PR TITLE
Pass schema to serializer

### DIFF
--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -24,7 +24,7 @@ export default class SerializerRegistry {
     if (this._isModelOrCollection(response)) {
       let serializer = this.serializerFor(response.modelName);
 
-      return serializer.serialize(response, request);
+      return serializer.serialize(response, request, this.schema);
     } else if (_isArray(response) && response.filter(this._isCollection).length) {
       return response.reduce((json, collection) => {
         let serializer = this.serializerFor(collection.modelName);


### PR DESCRIPTION
Currently, the docs state that a good place to add metadata to a response is when overriding the `Serializer.serialize()` method. One common piece of metadata is the total number of records when making a filtered or paginated request.

Except the recommended `.serialize()` method is only given the response and the request as arguments, so it can't get a reference to the schema/server/db objects to get a total count.

This is one approach to solving that problem - just pass the schema into the serialize method.

---

However, I'm not sure this is the best long term solution. Metadata can be tricky - if I make a request that is both paginated **and** filtered, perhaps the metadata's `total: 42` indicates that there are a total of 42 records **that match that filter**, rather than 42 records of that type overall. 

If that's the case, mocking that behavior in Mirage would require calculating metadata in the route handler (where the filtering is happening), which this PR doesn't solve. But I figured I'd at least offer some kind of solution to start the conversation :wink:. One idea: perhaps you could return a Mirage.Response object that allows arbitrary metadata payloads but still triggers the serializer layer? Then that Response object could be read out in the serializer to populate the appropriate JSON payload structure.
