### PR TITLE
handle hasMany relationships in _getAttrsForRequest

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -59,7 +59,9 @@ export default class BaseRouteHandler {
       Object.keys(json.data.relationships).forEach((key) => {
         let relationship = json.data.relationships[key];
 
-        if (!_isArray(relationship.data)) {
+        if (_isArray(relationship.data)) {
+          attrs[`${camelize(singularize(key))}Ids`] = relationship.data.map(obj => obj.id);
+        } else {
           attrs[`${camelize(key)}Id`] = relationship.data && relationship.data.id;
         }
       }, {});

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -73,6 +73,18 @@ test('_getAttrsForRequest works with attributes and relationships', function(ass
         },
         'many-things': {
           'data': []
+        },
+        'articles': {
+          'data': [
+            {
+              'id': '10',
+              'type': 'articles'
+            },
+            {
+              'id': '20',
+              'type': 'articles'
+            }
+          ]
         }
       },
       'type': 'github-account'
@@ -92,7 +104,9 @@ test('_getAttrsForRequest works with attributes and relationships', function(ass
       doesMirage: true,
       companyId: '1',
       githubAccountId: '1',
-      somethingId: null
+      somethingId: null,
+      manyThingIds: [],
+      articleIds: ['10', '20']
     },
     'it normalizes data correctly.'
   );


### PR DESCRIPTION
Currently `hasMany` relationship are not handled in `_getAttrsForRequest`, only `belongsTo` are.  This PR makes both relationship types work.