### PR TITLE
hasMany association cache issue

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -368,15 +368,19 @@ export default class Server {
 
   _resetHasManyAssociations() {
     Object.keys(this.schema._registry).forEach((modelKey)=> {
-      if (this.schema._registry[modelKey].class) {
-        this._removeCachedChildren(this.schema._registry[modelKey].class.prototype.hasManyAssociations);
+      let modelClass = this.schema._registry[modelKey].class;
+      if (Ember.isPresent(modelClass)) {
+        this._removeCachedChildren(modelClass.prototype.hasManyAssociations);
       }
     });
   }
 
   _removeCachedChildren(hasManyAssociations) {
     Object.keys(hasManyAssociations).forEach((hasMany)=> {
-      hasManyAssociations[hasMany]._cachedChildren = null;
+      if (Ember.get(hasManyAssociations[hasMany], '_cachedChildren.models')) {
+        hasManyAssociations[hasMany]._cachedChildren.models = [];
+      }
+    });
   }
 
   _defineRouteHandlerHelpers() {

--- a/addon/server.js
+++ b/addon/server.js
@@ -333,6 +333,7 @@ export default class Server {
   shutdown() {
     this.pretender.shutdown();
     if (this.environment === 'test') {
+      this._resetHasManyAssociations();
       window.server = undefined;
     }
   }
@@ -363,6 +364,19 @@ export default class Server {
 
       methodsWithPath.methods.forEach(method => this[method](methodsWithPath.path));
     });
+  }
+
+  _resetHasManyAssociations() {
+    Object.keys(this.schema._registry).forEach((modelKey)=> {
+      if (this.schema._registry[modelKey].class) {
+        this._removeCachedChildren(this.schema._registry[modelKey].class.prototype.hasManyAssociations);
+      }
+    });
+  }
+
+  _removeCachedChildren(hasManyAssociations) {
+    Object.keys(hasManyAssociations).forEach((hasMany)=> {
+      hasManyAssociations[hasMany]._cachedChildren = null;
   }
 
   _defineRouteHandlerHelpers() {

--- a/tests/acceptance/shutdown-test.js
+++ b/tests/acceptance/shutdown-test.js
@@ -1,0 +1,38 @@
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+import { test } from 'qunit';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+moduleForAcceptance('Acceptance | Shutdown | Test Environment', {
+  beforeEach() {
+    this.store = this.application.__container__.lookup('service:store');
+  }
+});
+
+test('Upon shutdown deletes cached hasMany on models', function(assert) {
+  let blogPosts = server.createList('blog-post', 10);
+  let wordSmith = server.create('word-smith', { blogPostIds: blogPosts.map((blogPost) => blogPost.id) });
+
+  visit(`/word-smiths/${wordSmith.id}`);
+
+  andThen(() => {
+    let registry = server.schema._registry;
+    let wordSmithClass = registry.wordSmith.class;
+
+    let wordSmithStore = this.store.peekRecord('word-smith', wordSmith.id);
+    assert.equal(wordSmithStore.get('blogPosts.length'), 10);
+
+    // Cached blog posts association on wordSmithClass hasManyAssociations on prototype level
+    assert.equal(wordSmithClass.prototype.hasManyAssociations.blogPosts._cachedChildren.models.length, 10, '10 cached blogPosts');
+
+    // destroyApp calls server.shutdown()
+    destroyApp(this.application);
+
+    // Cached children removed
+    assert.equal(wordSmithClass.prototype.hasManyAssociations.blogPosts._cachedChildren.models.length, 0);
+
+    // For destroyApp on moduleForAcceptance afterEach
+    this.application = startApp();
+  });
+});
+


### PR DESCRIPTION
Not sure why `_cachedChildren` is set on the `ModelClass.prototype` level, but this causes hasMany model factories that were created from the a test to be part of the schema of the model throughout all the test.

To make sure every data is wiped clean after each test, added a method in `server.js` to go through every `ModelClass` to remove `_cachedChildren`.
