### PR TITLE
Pull third-party dependencies from npm instead of Bower

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -54,13 +54,5 @@ module.exports = {
         )
       );
     }
-
-    return this.addBowerPackagesToProject([{
-      name: 'pretender',
-      target: '~1.1.0'
-    }, {
-      name: 'Faker',
-      target: '~3.1.0'
-    }]);
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -6,8 +6,6 @@
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "pretender": "~1.1.0",
-    "Faker": "~3.1.0",
     "sinonjs": "~1.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,8 +69,13 @@
     "broccoli-unwatched-tree": "^0.1.1",
     "chalk": "^1.1.1",
     "ember-cli-babel": "^5.1.5",
+    "ember-cli-node-assets": "^0.1.4",
     "ember-inflector": "^1.9.2",
     "ember-lodash": "0.0.9",
-    "exists-sync": "0.0.3"
+    "exists-sync": "0.0.3",
+    "fake-xml-http-request": "^1.4.0",
+    "faker": "^3.1.0",
+    "pretender": "^1.1.0",
+    "route-recognizer": "^0.1.11"
   }
 }

--- a/tests/unit/import-files-test-node.js
+++ b/tests/unit/import-files-test-node.js
@@ -17,9 +17,10 @@ describe('import files', function() {
     var addon = new EmberAddon();
 
     expect(_.values(addon._scriptOutputFiles)[0]).to.not.include.members([
-      addon.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js',
-      addon.bowerDirectory + '/route-recognizer/dist/route-recognizer.js',
-      addon.bowerDirectory + '/pretender/pretender.js',
+      'vendor/fake-xml-http-request/fake_xml_http_request.js',
+      'vendor/route-recognizer/dist/route-recognizer.js',
+      'vendor/pretender/pretender.js',
+      'vendor/faker/build/build/faker.js',
       'vendor/ember-cli-mirage/pretender-shim.js'
     ]);
   });
@@ -30,9 +31,10 @@ describe('import files', function() {
       var addon = new EmberAddon();
 
       expect(_.values(addon._scriptOutputFiles)[0]).to.include.members([
-        addon.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js',
-        addon.bowerDirectory + '/route-recognizer/dist/route-recognizer.js',
-        addon.bowerDirectory + '/pretender/pretender.js',
+        'vendor/fake-xml-http-request/fake_xml_http_request.js',
+        'vendor/route-recognizer/dist/route-recognizer.js',
+        'vendor/pretender/pretender.js',
+        'vendor/faker/build/build/faker.js',
         'vendor/ember-cli-mirage/pretender-shim.js'
       ]);
     });
@@ -43,9 +45,10 @@ describe('import files', function() {
     var addon = new EmberAddon({ configPath: 'tests/fixtures/config/environment-production-enabled' });
 
     expect(_.values(addon._scriptOutputFiles)[0]).to.include.members([
-      addon.bowerDirectory + '/FakeXMLHttpRequest/fake_xml_http_request.js',
-      addon.bowerDirectory + '/route-recognizer/dist/route-recognizer.js',
-      addon.bowerDirectory + '/pretender/pretender.js',
+      'vendor/fake-xml-http-request/fake_xml_http_request.js',
+      'vendor/route-recognizer/dist/route-recognizer.js',
+      'vendor/pretender/pretender.js',
+      'vendor/faker/build/build/faker.js',
       'vendor/ember-cli-mirage/pretender-shim.js'
     ]);
   });


### PR DESCRIPTION
I'm on a quest to remove Bower dependencies from our apps and addons where possible in the ultimate hope that once [Ember itself moves to npm](https://github.com/ember-cli/ember-cli/issues/4546) we'll be able stop using Bower entirely.

This changes switches over Faker, Pretender and friends over to come from npm, and eliminates the installation of those two packages via Bower in the default blueprint.