### PR TITLE
add :resource helper for handling generic CRUD

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -294,13 +294,13 @@ export default class Server {
     }
   }
 
-  resource(resourcePath) {
-    this.get(resourcePath);
-    this.get(`${resourcePath}/:id`);
-    this.post(resourcePath);
-    this.put(`${resourcePath}/:id`);
-    this.patch(`${resourcePath}/:id`);
-    this.del(`${resourcePath}/:id`);
+  resource(resourceName) {
+    this.get(`/${resourceName}`);
+    this.get(`/${resourceName}/:id`);
+    this.post(`/${resourceName}`);
+    this.put(`/${resourceName}/:id`);
+    this.patch(`/${resourceName}/:id`);
+    this.del(`/${resourceName}/:id`);
   }
 
   _defineRouteHandlerHelpers() {

--- a/addon/server.js
+++ b/addon/server.js
@@ -294,6 +294,15 @@ export default class Server {
     }
   }
 
+  resource(resourcePath) {
+    this.get(resourcePath);
+    this.get(`${resourcePath}/:id`);
+    this.post(resourcePath);
+    this.put(`${resourcePath}/:id`);
+    this.patch(`${resourcePath}/:id`);
+    this.del(`${resourcePath}/:id`);
+  }
+
   _defineRouteHandlerHelpers() {
     [['get'], ['post'], ['put'], ['delete', 'del'], ['patch'], ['head']].forEach(([verb, alias]) => {
       this[verb] = (path, ...args) => {

--- a/addon/server.js
+++ b/addon/server.js
@@ -312,7 +312,7 @@ export default class Server {
 
     let allActions = Object.keys(actionsMethodsAndsPathsMappings);
     let actions = only.length > 0 && only ||
-                  except.length > 0 && allActions.filter(action => !except.includes(action)) ||
+                  except.length > 0 && allActions.filter(action => (except.indexOf(action) === -1)) ||
                   allActions;
 
     actions.forEach((action) => {

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Resolver from './resolver';
-import loadInitializers from 'ember/load-initializers';
+import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 let App;

--- a/tests/integration/http-verbs-test.js
+++ b/tests/integration/http-verbs-test.js
@@ -107,7 +107,7 @@ test('mirage responds to resource', function(assert) {
   assert.expect(0);
   let done = assert.async();
 
-  this.server.resource('/contacts');
+  this.server.resource('contacts');
 
   $.ajax({
     method: 'GET',

--- a/tests/integration/http-verbs-test.js
+++ b/tests/integration/http-verbs-test.js
@@ -1,10 +1,14 @@
 import {module, test} from 'qunit';
 import Server from 'ember-cli-mirage/server';
+import { Model } from 'ember-cli-mirage';
 
 module('Integration | HTTP Verbs', {
   beforeEach() {
     this.server = new Server({
-      environment: 'development'
+      environment: 'development',
+      models: {
+        contact: Model
+      }
     });
     this.server.timing = 0;
     this.server.logging = false;
@@ -95,6 +99,20 @@ test('mirage responds to patch', function(assert) {
     url: '/contacts'
   }).done(function(res) {
     assert.equal(res, true);
+    done();
+  });
+});
+
+test('mirage responds to resource', function(assert) {
+  assert.expect(0);
+  let done = assert.async();
+
+  this.server.resource('/contacts');
+
+  $.ajax({
+    method: 'GET',
+    url: '/contacts'
+  }).done(function() {
     done();
   });
 });

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -217,7 +217,7 @@ test('resource does not generate shorthands which are not whitelisted with :only
     method: 'GET',
     url: '/contacts/1'
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to GET '/contacts/1'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to GET '/contacts/1'") !== -1);
     doneForShow();
   });
 
@@ -232,7 +232,7 @@ test('resource does not generate shorthands which are not whitelisted with :only
       }
     })
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to POST '/contacts'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to POST '/contacts'") !== -1);
     doneForCreate();
   });
 
@@ -247,7 +247,7 @@ test('resource does not generate shorthands which are not whitelisted with :only
       }
     })
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to PUT '/contacts/1'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to PUT '/contacts/1'") !== -1);
     doneForPut();
   });
 
@@ -262,7 +262,7 @@ test('resource does not generate shorthands which are not whitelisted with :only
       }
     })
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to PATCH '/contacts/1'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to PATCH '/contacts/1'") !== -1);
     doneForPatch();
   });
 
@@ -272,7 +272,7 @@ test('resource does not generate shorthands which are not whitelisted with :only
     method: 'DELETE',
     url: '/contacts/1'
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to DELETE '/contacts/1'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to DELETE '/contacts/1'") !== -1);
     doneForDelete();
   });
 });
@@ -333,7 +333,7 @@ test('resource does not generate shorthands which are blacklisted by :except opt
       }
     })
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to POST '/contacts'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to POST '/contacts'") !== -1);
     doneForCreate();
   });
 
@@ -348,7 +348,7 @@ test('resource does not generate shorthands which are blacklisted by :except opt
       }
     })
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to PUT '/contacts/1'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to PUT '/contacts/1'") !== -1);
     doneForPut();
   });
 
@@ -363,7 +363,7 @@ test('resource does not generate shorthands which are blacklisted by :except opt
       }
     })
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to PATCH '/contacts/1'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to PATCH '/contacts/1'") !== -1);
     doneForPatch();
   });
 
@@ -373,7 +373,7 @@ test('resource does not generate shorthands which are blacklisted by :except opt
     method: 'DELETE',
     url: '/contacts/1'
   }).fail((xhr, textStatus, error) => {
-    assert.ok(error.message.includes("Mirage: Your Ember app tried to DELETE '/contacts/1'"));
+    assert.ok(error.message.indexOf("Mirage: Your Ember app tried to DELETE '/contacts/1'") !== -1);
     doneForDelete();
   });
 });

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -32,7 +32,7 @@ test('resource generates get shorthand for index action', function(assert) {
     ]
   });
 
-  this.server.resource('/contacts');
+  this.server.resource('contacts');
 
   $.ajax({
     method: 'GET',
@@ -55,7 +55,7 @@ test('resource generates get shorthand for show action', function(assert) {
     ]
   });
 
-  this.server.resource('/contacts');
+  this.server.resource('contacts');
 
   $.ajax({
     method: 'GET',
@@ -72,7 +72,7 @@ test('resource generates post shorthand', function(assert) {
   assert.expect(2);
   let done = assert.async();
 
-  server.resource('/contacts');
+  server.resource('contacts');
 
   $.ajax({
     method: 'POST',
@@ -100,7 +100,7 @@ test('resource generates put shorthand', function(assert) {
     ]
   });
 
-  server.resource('/contacts');
+  server.resource('contacts');
 
   $.ajax({
     method: 'PUT',
@@ -128,7 +128,7 @@ test('resource generates patch shorthand', function(assert) {
     ]
   });
 
-  server.resource('/contacts');
+  server.resource('contacts');
 
   $.ajax({
     method: 'PATCH',
@@ -156,7 +156,7 @@ test('resource generates delete shorthand works', function(assert) {
     ]
   });
 
-  server.resource('/contacts');
+  server.resource('contacts');
 
   $.ajax({
     method: 'DELETE',

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -1,0 +1,169 @@
+import {module, test} from 'qunit';
+import { Model, ActiveModelSerializer } from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+
+module('Integration | Server | Resource shorthand', {
+  beforeEach() {
+    this.server = new Server({
+      environment: 'test',
+      models: {
+        contact: Model
+      },
+      serializers: {
+        application: ActiveModelSerializer
+      }
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+  },
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+test('resource generates get shorthand for index action', function(assert) {
+  assert.expect(2);
+  let done = assert.async();
+
+  this.server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' },
+      { id: 2, name: 'Zelda' }
+    ]
+  });
+
+  this.server.resource('/contacts');
+
+  $.ajax({
+    method: 'GET',
+    url: '/contacts'
+  }).done(function(res, status, xhr) {
+    assert.equal(xhr.status, 200);
+    assert.deepEqual(res, { contacts: [{ id: '1', name: 'Link' }, { id: '2', name: 'Zelda' }] });
+    done();
+  });
+});
+
+test('resource generates get shorthand for show action', function(assert) {
+  assert.expect(2);
+  let done = assert.async();
+
+  this.server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' },
+      { id: 2, name: 'Zelda' }
+    ]
+  });
+
+  this.server.resource('/contacts');
+
+  $.ajax({
+    method: 'GET',
+    url: '/contacts/2'
+  }).done(function(res, status, xhr) {
+    assert.equal(xhr.status, 200);
+    assert.deepEqual(res, { contact: { id: '2', name: 'Zelda' } });
+    done();
+  });
+});
+
+test('resource generates post shorthand', function(assert) {
+  let { server } = this;
+  assert.expect(2);
+  let done = assert.async();
+
+  server.resource('/contacts');
+
+  $.ajax({
+    method: 'POST',
+    url: '/contacts',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).done((res, status, xhr) => {
+    assert.equal(xhr.status, 201);
+    assert.equal(server.db.contacts.length, 1);
+    done();
+  });
+});
+
+test('resource generates put shorthand', function(assert) {
+  let { server } = this;
+  assert.expect(2);
+  let done = assert.async();
+
+  this.server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' }
+    ]
+  });
+
+  server.resource('/contacts');
+
+  $.ajax({
+    method: 'PUT',
+    url: '/contacts/1',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).done((res, status, xhr) => {
+    assert.equal(xhr.status, 200);
+    assert.equal(server.db.contacts[0].name, 'Zelda');
+    done();
+  });
+});
+
+test('resource generates patch shorthand', function(assert) {
+  let { server } = this;
+  assert.expect(2);
+  let done = assert.async();
+
+  this.server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' }
+    ]
+  });
+
+  server.resource('/contacts');
+
+  $.ajax({
+    method: 'PATCH',
+    url: '/contacts/1',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).done((res, status, xhr) => {
+    assert.equal(xhr.status, 200);
+    assert.equal(server.db.contacts[0].name, 'Zelda');
+    done();
+  });
+});
+
+test('resource generates delete shorthand works', function(assert) {
+  let { server } = this;
+  assert.expect(2);
+  let done = assert.async();
+
+  this.server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' }
+    ]
+  });
+
+  server.resource('/contacts');
+
+  $.ajax({
+    method: 'DELETE',
+    url: '/contacts/1'
+  }).done((res, status, xhr) => {
+    assert.equal(xhr.status, 204);
+    assert.equal(server.db.contacts.length, 0);
+    done();
+  });
+});

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -167,3 +167,213 @@ test('resource generates delete shorthand works', function(assert) {
     done();
   });
 });
+
+test('resource does not accept both :all and :except options', function(assert) {
+  let { server } = this;
+
+  assert.throws(() => {
+    server.resource('contacts', { only: ['index'], except: ['create'] });
+  }, 'cannot use both :only and :except options');
+});
+
+test('resource generates shorthands which are whitelisted by :only option', function(assert) {
+  let { server } = this;
+  assert.expect(1);
+  let done = assert.async();
+
+  server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' },
+      { id: 2, name: 'Zelda' }
+    ]
+  });
+
+  server.resource('contacts', { only: ['index'] });
+
+  $.ajax({
+    method: 'GET',
+    url: '/contacts'
+  }).done((res, status, xhr) => {
+    assert.equal(xhr.status, 200);
+    done();
+  });
+});
+
+test('resource does not generate shorthands which are not whitelisted with :only option', function(assert) {
+  let { server } = this;
+  assert.expect(5);
+
+  server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' }
+    ]
+  });
+
+  server.resource('contacts', { only: ['index'] });
+
+  let doneForShow = assert.async();
+
+  $.ajax({
+    method: 'GET',
+    url: '/contacts/1'
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to GET '/contacts/1'"));
+    doneForShow();
+  });
+
+  let doneForCreate = assert.async();
+
+  $.ajax({
+    method: 'POST',
+    url: '/contacts',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to POST '/contacts'"));
+    doneForCreate();
+  });
+
+  let doneForPut = assert.async();
+
+  $.ajax({
+    method: 'PUT',
+    url: '/contacts/1',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to PUT '/contacts/1'"));
+    doneForPut();
+  });
+
+  let doneForPatch = assert.async();
+
+  $.ajax({
+    method: 'PATCH',
+    url: '/contacts/1',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to PATCH '/contacts/1'"));
+    doneForPatch();
+  });
+
+  let doneForDelete = assert.async();
+
+  $.ajax({
+    method: 'DELETE',
+    url: '/contacts/1'
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to DELETE '/contacts/1'"));
+    doneForDelete();
+  });
+});
+
+test('resource generates shorthands which are not blacklisted by :except option', function(assert) {
+  let { server } = this;
+  assert.expect(2);
+
+  server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' }
+    ]
+  });
+
+  server.resource('contacts', { except: ['create', 'update', 'delete'] });
+
+  let doneForIndex = assert.async();
+
+  $.ajax({
+    method: 'GET',
+    url: '/contacts'
+  }).done((res, status, xhr) => {
+    assert.equal(xhr.status, 200);
+    doneForIndex();
+  });
+
+  let doneForShow = assert.async();
+
+  $.ajax({
+    method: 'GET',
+    url: '/contacts'
+  }).done((res, status, xhr) => {
+    assert.equal(xhr.status, 200);
+    doneForShow();
+  });
+});
+
+test('resource does not generate shorthands which are blacklisted by :except option', function(assert) {
+  let { server } = this;
+  assert.expect(4);
+
+  server.db.loadData({
+    contacts: [
+      { id: 1, name: 'Link' }
+    ]
+  });
+
+  server.resource('contacts', { except: ['create', 'update', 'delete'] });
+
+  let doneForCreate = assert.async();
+
+  $.ajax({
+    method: 'POST',
+    url: '/contacts',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to POST '/contacts'"));
+    doneForCreate();
+  });
+
+  let doneForPut = assert.async();
+
+  $.ajax({
+    method: 'PUT',
+    url: '/contacts/1',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to PUT '/contacts/1'"));
+    doneForPut();
+  });
+
+  let doneForPatch = assert.async();
+
+  $.ajax({
+    method: 'PATCH',
+    url: '/contacts/1',
+    data: JSON.stringify({
+      contact: {
+        name: 'Zelda'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to PATCH '/contacts/1'"));
+    doneForPatch();
+  });
+
+  let doneForDelete = assert.async();
+
+  $.ajax({
+    method: 'DELETE',
+    url: '/contacts/1'
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(error.message.includes("Mirage: Your Ember app tried to DELETE '/contacts/1'"));
+    doneForDelete();
+  });
+});


### PR DESCRIPTION
Shorthands are super useful, but for very generic CRUD it might be a bit tedious to define a route handler for every endpoint, so I thought that Rails-like `resource` helper would help with that. 