### PR TITLE
JSONAPIAdapter shorthand routes need to include empty relationship values by default

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -127,11 +127,11 @@ class JsonApiSerializer {
       let relationship = model[camelizedType];
       let relationshipKey = this.keyForRelationship(camelizedType);
 
-      if (isCollection(relationship)) {
-        if (!obj.relationships) {
-          obj.relationships = {};
-        }
+      if (!obj.relationships) {
+        obj.relationships = {};
+      }
 
+      if (isCollection(relationship)) {
         obj.relationships[relationshipKey] = {
           data: relationship.models.map(model => {
             return {
@@ -141,15 +141,15 @@ class JsonApiSerializer {
           })
         };
       } else if (relationship) {
-        if (!obj.relationships) {
-          obj.relationships = {};
-        }
-
         obj.relationships[relationshipKey] = {
           data: {
             type: this.typeKeyForModel(relationship),
             id: relationship.id
           }
+        };
+      } else {
+        obj.relationships[relationshipKey] = {
+          data: null
         };
       }
 

--- a/tests/integration/serializers/json-api-serializer/associations/included-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/included-test.js
@@ -253,6 +253,9 @@ test(`collection: it can include relationships specified by the include query pa
         id: '2',
         attributes: {},
         relationships: {
+          'word-smith': {
+            data: null
+          },
           'fine-comments': {
             data: []
           }

--- a/tests/integration/serializers/json-api-serializer/associations/model-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/model-test.js
@@ -264,6 +264,9 @@ test(`it gracefully handles null belongs-to relationship`, function(assert) {
       relationships: {
         'fine-comments': {
           data: []
+        },
+        'word-smith': {
+          data: null
         }
       }
     }


### PR DESCRIPTION
Looks like the tests were setup sufficiently to cover this. Did modify a couple tests to reflect the new behavior.

Closes #821