### PR TITLE
Allow a namespace of / to be used

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -360,13 +360,11 @@ export default class Server {
         fullPath += urlPrefix[urlPrefix.length - 1] === '/' ? urlPrefix : `${urlPrefix}/`;
       }
 
-      // if a namespace has been configured, add it before the path
-      if (!!namespace.length) {
-        fullPath += namespace ? `${namespace}/` : namespace;
-      }
+      // add the namespace to the path
+      fullPath += namespace;
 
-      // we're at the root, ensure a leading /
-      if (!urlPrefix.length && !namespace.length) {
+      // add a trailing slash to the path if it doesn't already contain one
+      if (fullPath[fullPath.length - 1] !== '/') {
         fullPath += '/';
       }
 

--- a/tests/integration/server-config-test.js
+++ b/tests/integration/server-config-test.js
@@ -120,3 +120,84 @@ test('urlPrefix/namespace are ignored when fully qualified domain names are used
     done();
   });
 });
+
+test('blank urlPrefix and namespace ends up as /', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  let contacts = [
+    { id: '1', name: 'Link' },
+    { id: '2', name: 'Zelda' }
+  ];
+  this.server.db.loadData({
+    contacts
+  });
+  this.server.namespace = '';
+  this.server.urlPrefix = '';
+  this.server.get('contacts');
+
+  $.getJSON('/contacts', function(data) {
+    assert.deepEqual(data, { contacts });
+    done();
+  });
+});
+
+test('namespace with no slash gets one', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  let contacts = [
+    { id: '1', name: 'Link' },
+    { id: '2', name: 'Zelda' }
+  ];
+  this.server.db.loadData({
+    contacts
+  });
+  this.server.namespace = 'api';
+  this.server.get('contacts');
+
+  $.getJSON('/api/contacts', function(data) {
+    assert.deepEqual(data, { contacts });
+    done();
+  });
+});
+
+test('urlPrefix with no slash gets one', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  let contacts = [
+    { id: '1', name: 'Link' },
+    { id: '2', name: 'Zelda' }
+  ];
+  this.server.db.loadData({
+    contacts
+  });
+  this.server.urlPrefix = 'pre';
+  this.server.get('contacts');
+
+  $.getJSON('/pre/contacts', function(data) {
+    assert.deepEqual(data, { contacts });
+    done();
+  });
+});
+
+test('namespace of / works', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  let contacts = [
+    { id: '1', name: 'Link' },
+    { id: '2', name: 'Zelda' }
+  ];
+  this.server.db.loadData({
+    contacts
+  });
+  this.server.namespace = '/';
+  this.server.get('contacts');
+
+  $.getJSON('/contacts', function(data) {
+    assert.deepEqual(data, { contacts });
+    done();
+  });
+});


### PR DESCRIPTION
If / is passed as the namespace it shouldn't end up as //

This is my attempt at a workaround for #826 it allows me to send `/` as my namespace and then tests work again.  I don't necessarily understand what all of these options do and what the default behavior should be, so please don't hesitate to tell me this is a mess.