### PR TITLE
Allow models to be updated by mirage created via a factory

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -210,13 +210,14 @@ class Model {
    * @private
    */
   _definePlainAttribute(attr) {
-    if (this[attr] !== undefined) {
+    let descriptor = Object.getOwnPropertyDescriptor(this, attr);
+    if (descriptor != null) {
       return;
     }
 
     // Ensure the attribute is on the attrs hash
     if (!this.attrs.hasOwnProperty(attr)) {
-      this.attrs[attr] = null;
+      this.attrs[attr] = this[attr] || null;
     }
 
     // Define the getter/setter


### PR DESCRIPTION
We were seeing consistently a case where creating a new model, then
updating via the UI wouldn't persist changes to mirage's db.

I tracked this down to `this.save()` being called with `this.attrs`.
There were missing Object descriptors on the model due to mirage
skipping properties that were not undefined, even though there were
no descriptors for them.

To fix this, I used Object.getDescriptors() to introspect on the model
which properties have been defined. This fixes the issue and allows
for updates to pass through smoothly.
