### PR TITLE
Feature/add seed data builder

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,8 @@
     "document",
     "window",
     "-Promise",
-    "faker"
+    "faker",
+    "server"
   ],
   "browser": true,
   "boss": true,

--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -3,6 +3,7 @@ import _assign from 'lodash/object/assign';
 import { capitalize, camelize } from 'ember-cli-mirage/utils/inflector';
 import { toCollectionName } from 'ember-cli-mirage/utils/normalize-name';
 import assert from 'ember-cli-mirage/assert';
+import Ember from 'ember';
 
 class BelongsTo extends Association {
 
@@ -76,13 +77,20 @@ class BelongsTo extends Association {
           - sets the associated parent (via model)
       */
       set(newModel) {
-        if (newModel && newModel.isNew()) {
+        if (!Ember.isEmpty(newModel) && typeof newModel === 'object' && typeof newModel.isNew === 'function' && newModel.isNew()) {
+          // newModel is a model
           this[foreignKey] = null;
           association._tempParent = newModel;
-        } else if (newModel) {
+        } else if (!Ember.isEmpty(newModel) && typeof newModel === 'object' && !Ember.isEmpty(newModel.id)) {
+          // newModel is a simple object with id property
           association._tempParent = null;
           this[foreignKey] = newModel.id;
+        } else if (!Ember.isEmpty(newModel)) {
+          // newModel is an id
+          association._tempParent = null;
+          this[foreignKey] = newModel;
         } else {
+          // newModel is not present
           association._tempParent = null;
           this[foreignKey] = null;
         }

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -79,7 +79,7 @@ class Model {
     }
 
     Object.keys(attrs).forEach(function(attr) {
-      this[attr] = attrs[attr];
+      this.attrs[attr] = this[attr] = attrs[attr];
     }, this);
 
     this.save();

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -25,9 +25,9 @@ class Model {
     this.modelName = modelName;
     this.fks = fks || [];
     attrs = attrs || {};
-    attrs.childrenAssociations = attrs.childrenAssociations || [];
     this._setupAttrs(attrs);
     this._setupRelationships(attrs);
+    this.childrenAssociations = this.childrenAssociations || [];
     // the associations in this list will be destroyed in beforeDestroy
     // TODO: define cleaner hasOne / belongsToMany relationships
 
@@ -109,11 +109,8 @@ class Model {
     * @public
     */
    _beforeDestroy() {
-     console.log('beforeDestroy', this.modelName, this.associationKeys);
      this.associationKeys.forEach((relName) => {
-       console.log('beforeDestroy 2', this.modelName, this.childrenAssociations, relName);
-       if (this.childrenAssociations.contains(relName)) {
-         console.log('hasNo beforeDestroy', this.modelName, relName);
+       if (this.childrenAssociations.indexOf(relName) > -1) {
          this.hasNo(relName);
        }
      });
@@ -126,7 +123,6 @@ class Model {
   */
 
   destroy() {
-    console.log('destroy', this.modelName);
     this._beforeDestroy();
     let collection = toCollectionName(this.modelName);
     this._schema.db[collection].remove(this.attrs.id);

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -25,13 +25,29 @@ class Model {
     this.modelName = modelName;
     this.fks = fks || [];
     attrs = attrs || {};
-
+    attrs.childrenAssociations = attrs.childrenAssociations || [];
     this._setupAttrs(attrs);
     this._setupRelationships(attrs);
+    // the associations in this list will be destroyed in beforeDestroy
+    // TODO: define cleaner hasOne / belongsToMany relationships
 
     return this;
   }
 
+  default() {
+    // override in model to setup when instantiated
+  }
+
+  typeOf(relName) {
+    let relNames = relName.pluralize();
+    return this[relNames] ? 'hasMany' : 'belongsTo';
+  }
+
+  updateAttrs(hash) {
+    this.update(hash);
+    // https://github.com/samselikoff/ember-cli-mirage/issues/719
+    return this;
+  }
   /**
    * Creates or saves the model.
    * @method save
@@ -40,13 +56,13 @@ class Model {
    */
   save() {
     let collection = toCollectionName(this.modelName);
-
     if (this.isNew()) {
       // Update the attrs with the db response
       this.attrs = this._schema.db[collection].insert(this.attrs);
 
       // Ensure the id getter/setter is set
       this._definePlainAttribute('id');
+      this.default();
 
     } else {
       this._schema.db[collection].update(this.attrs.id, this.attrs);
@@ -66,33 +82,52 @@ class Model {
    * @return this
    * @public
    */
-  update(key, val) {
-    let attrs;
-    if (key == null) {
-      return this;
-    }
+  update(key, val) { // https://github.com/samselikoff/ember-cli-mirage/pull/846
+     let attrs;
+     if (key == null) {
+       return this;
+     }
 
-    if (typeof key === 'object') {
-      attrs = key;
-    } else {
-      (attrs = {})[key] = val;
-    }
+     if (typeof key === 'object') {
+       attrs = key;
+     } else {
+       (attrs = {})[key] = val;
+     }
 
-    Object.keys(attrs).forEach(function(attr) {
-      this.attrs[attr] = this[attr] = attrs[attr];
-    }, this);
+     Object.keys(attrs).forEach(function(attr) {
+       this.attrs[attr] = this[attr] = attrs[attr];
+     }, this);
 
-    this.save();
+     this.save();
 
-    return this;
-  }
+     return this;
+   }
 
-  /**
-   * Destroys the db record
-   * @method destroy
-   * @public
-   */
+   /**
+    * Destroys the children associations before destroying the model
+    * @method destroy
+    * @public
+    */
+   _beforeDestroy() {
+     console.log('beforeDestroy', this.modelName, this.associationKeys);
+     this.associationKeys.forEach((relName) => {
+       console.log('beforeDestroy 2', this.modelName, this.childrenAssociations, relName);
+       if (this.childrenAssociations.contains(relName)) {
+         console.log('hasNo beforeDestroy', this.modelName, relName);
+         this.hasNo(relName);
+       }
+     });
+   }
+
+ /**
+  * Destroys the db record
+  * @method destroy
+  * @public
+  */
+
   destroy() {
+    console.log('destroy', this.modelName);
+    this._beforeDestroy();
     let collection = toCollectionName(this.modelName);
     this._schema.db[collection].remove(this.attrs.id);
   }
@@ -280,6 +315,96 @@ class Model {
    */
   toString() {
     return `model:${this.modelName}(${this.id})`;
+  }
+
+  hasNo(relName) {
+    relName = relName.singularize();
+    return this.typeOf(relName) === 'hasMany' ?
+    this.hasNoOfMany(relName) :
+    this.hasNoOfOne(relName);
+  }
+  hasNoOfOne(relName) {
+    relName = relName.singularize();
+    let rel = this[relName];
+    if (rel) {
+      rel.destroy();
+    }
+    this[relName] = null;
+    return this;
+  }
+  hasNoOfMany(relName) {
+    relName = relName.singularize();
+    // TODO: create a general deleteXX method for hasMany
+    let rels = this[`${relName}s`].models;
+    this[`${relName}s`] = [];
+    rels.forEach((rel) => {
+      rel.destroy();
+    });
+    return this;
+  }
+
+  hasMulti(relName) { // exactly two
+    relName = relName.singularize();
+    let rels = this[`${relName}s`].models;
+    let initialNumber = rels.length;
+    for (let i = initialNumber; i < 2; i++) {
+      // let rel = this[`create${relName.capitalize()}`]();
+      let assoc = this.hasManyAssociations[relName.pluralize()];
+      let { modelName } = assoc;
+      let inverseRelName = assoc.opts.inverse || this.modelName;
+      let hash = {};
+      hash[`${inverseRelName.camelize()}Id`] = this.id;
+      server.create(modelName, hash);
+    }
+    return this[`${relName}s`].models;
+  }
+
+  hasOne(relName, attrs) { // exactly one
+    relName = relName.singularize();
+    let model = this.typeOf(relName) === 'hasMany' ?
+    this.hasOneOfMany(relName) :
+    this.hasOneOfOne(relName);
+    if (attrs) {
+      return model.updateAttrs(attrs);
+    } else {
+      return model;
+    }
+  }
+  hasOneOfMany(relName) {
+    relName = relName.singularize();
+    // TODO: create a general deleteXX method for hasMany
+    let rels = this[`${relName}s`].models;
+    let rel;
+    let { length } = rels;
+    if (length) {
+      rel = rels[0];
+      for (let i = 1; i < length; i++) {
+        rels[i].destroy();
+      }
+      if (length > 1) {
+        this[`${relName}s`] = [rel];
+      }
+    } else {
+      let assoc = this.hasManyAssociations[relName.pluralize()];
+      let { modelName } = assoc;
+      let inverseRelName = assoc.opts.inverse || this.modelName;
+      let hash = {};
+      hash[`${inverseRelName.camelize()}Id`] = this.id;
+      rel = server.create(modelName, hash);
+    }
+    return rel;
+  }
+  hasOneOfOne(relName) {
+    relName = relName.singularize();
+    let rel = this[relName];
+    if (!rel) {
+      let hash = {};
+      hash[`${this.modelName.camelize()}Id`] = this.id;
+      let { modelName } = this.belongsToAssociations[relName];
+      rel = server.create(modelName, hash);
+      this.update(`${relName}Id`, rel.id);
+    }
+    return rel;
   }
 }
 

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -31,6 +31,7 @@ class Serializer {
    * @public
    */
   serialize(response, request={}) {
+    // console.log('serialize mirage', this, this.embed);
     if (this.embed) {
       let json;
 
@@ -53,6 +54,7 @@ class Serializer {
   }
 
   oldSerialize(response, request) {
+    // console.log('oldSerialize', response, response instanceof Model);
     if (response instanceof Model) {
       return this._oldAttrsForModel(response);
     } else {
@@ -285,6 +287,7 @@ class Serializer {
    * @private
    */
   _serializeSideloadedModelOrCollection(modelOrCollection, request) {
+    // console.log('_serializeSideloadedModelOrCollection');
     if (this.isModel(modelOrCollection)) {
       return this._serializeSideloadedModelResponse(modelOrCollection, request);
     } else if (modelOrCollection.models && modelOrCollection.models.length) {
@@ -309,6 +312,7 @@ class Serializer {
    * @private
    */
   _serializeSideloadedModelResponse(model, request, topLevelIsArray = false, allAttrs = {}, root = null) {
+    // console.log('_serializeSideloadedModelResponse', model, this, this._hasBeenSerialized(model));
     if (this._hasBeenSerialized(model)) {
       return allAttrs;
     }

--- a/addon/server.js
+++ b/addon/server.js
@@ -131,8 +131,9 @@ export default class Server {
       if (options.testConfig) {
         this.loadConfig(options.testConfig);
       }
-
-      window.server = this; // TODO: Better way to inject server into test env
+      window.server = this;
+    } else if (!this.isTest() && hasDefaultScenario) {
+      window.server = this; // TODO: Better way to inject server into env
     }
 
     if (this.isTest() && hasFactories) {
@@ -151,6 +152,11 @@ export default class Server {
 
   isTest() {
     return this.environment === 'test';
+  }
+
+  isTestOrDev() {
+    return this.environment === 'test' ||
+    this.environment === 'development';
   }
 
   shouldLog() {

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "sinonjs": "~1.17.1"
+    "sinonjs": "~1.17.1",
+    "Faker": "3.0.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ var unwatchedTree = require('broccoli-unwatched-tree');
 
 module.exports = {
   name: 'ember-cli-mirage',
-
+  isDevelopingAddon: function () {
+    return true;
+  },
   options: {
     nodeAssets: {
       'route-recognizer': npmAsset({

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ember-lodash": "0.0.9",
     "exists-sync": "0.0.3",
     "fake-xml-http-request": "^1.4.0",
-    "faker": "^3.1.0",
+    "faker": "3.0.1",
     "pretender": "^1.1.0",
     "route-recognizer": "^0.1.11"
   }


### PR DESCRIPTION
This PR adds to models the ability to create flexible seed data for their relationships.

This is a powerful way to create seed data by combining this with mirage factories / routes:

Example of seed data (a customer has many premises, a premise has many energyAccounts and servicesAccounts).

`````
 server.create('customer')
  .anySeedFunctionDefinedInTheCustomerModel() // <= defined on customer, returns customer
  .hasOne('premise', { // 
    status: hasPassedScreening || null
  }) // <= defined on customer, returns premise
  .hasNo('servicesAccount') // <= defined on premise, returns premise
  .hasOne('energyAccount') // <= defined on premise, returns energyAccount
  .isJointInvoiced() // <= defined on energyAccount, returns energyAccount
  .anySeedFunctionDefinedInTheEnergyAccountModel(); <= defined on energyAccount, returns energyAccount
`````

Each model has default seed data defined in Model.default()

We made `server` available as a global in the `development` environment to make it accessible inside Mirage models (was only a global in `test` before).

Haven't added tests yet but could do if you want to merge the PR.