### PR TITLE
Add `sort` to orm/collection

### DIFF
--- a/addon/orm/collection.js
+++ b/addon/orm/collection.js
@@ -82,6 +82,18 @@ export default class Collection {
   }
 
   /**
+   * @method sort
+   * @param f
+   * @return {Collection}
+   * @public
+   */
+  sort(f) {
+    let sortedModels = this.models.concat().sort(f);
+
+    return new Collection(this.modelName, sortedModels);
+  }
+
+  /**
    * @method mergeCollection
    * @param collection
    * @return this

--- a/tests/integration/orm/collection-test.js
+++ b/tests/integration/orm/collection-test.js
@@ -50,6 +50,19 @@ test('a collection can filter its models', function(assert) {
   assert.equal(newCollection.models.length, 2);
 });
 
+test('a collection can sort its models', function(assert) {
+  let collection = this.schema.users.all();
+  assert.deepEqual(collection.models.map(m => m.name), ['Link', 'Zelda', 'Ganon']);
+
+  let newCollection = collection.sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  });
+
+  assert.ok(newCollection instanceof Collection);
+  assert.equal(newCollection.modelName, 'user', 'the sorted collection has the right type');
+  assert.deepEqual(newCollection.models.map(m => m.name), ['Ganon', 'Link', 'Zelda']);
+});
+
 test('a collection can merge with another collection', function(assert) {
   let goodGuys = this.schema.users.where(user => user.good);
   let badGuys = this.schema.users.where(user => !user.good);


### PR DESCRIPTION
`sort` returns a new collection with models sorted according to the function as an argument to the method.

@samselikoff Should docs be in a separate commit?