### PR TITLE
reuse getForeignKey in getForeignKeyArray method in BelongsTo class

### DIFF
--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -10,7 +10,7 @@ class BelongsTo extends Association {
     The belongsTo association adds a fk to the owner of the association
   */
   getForeignKeyArray() {
-    return [camelize(this.ownerModelName), `${camelize(this.key)}Id`];
+    return [camelize(this.ownerModelName), this.getForeignKey()];
   }
 
   getForeignKey() {


### PR DESCRIPTION
Not a big thing, but I think it looks more expressive this way besides being DRY. 