### PR TITLE
Update upgrading.md

### DIFF
--- a/docs/v0.2.x/upgrading.md
+++ b/docs/v0.2.x/upgrading.md
@@ -33,7 +33,7 @@ If you're upgrading your Mirage server from v0.1.x to v0.2.x, here's what you ne
     mv app/mirage mirage
     ```
 
-    from the root of your project. Mirage's directory is also [customizable](../configuration/#directory), so you can also set an option and leave it under `/app`, if you'd like.
+    from the root of your project. Mirage's directory is also [customizable](../configuration/#directory) (Although you should move it from the `/app` directory or else it will not be removed from the build in production mode).
 
   - **All multiword filenames are dasherized.** In Mirage 0.1.x, database collection names were taken from filenames. The idea was, if your API returned snake_case collection keys (e.g. `blog_posts: []`), just name your file `fixtures/blog_posts.js`. This approach turned out to be insufficiently flexib-- what am I saying, it was just a bad idea :P.
 


### PR DESCRIPTION
Noticed that the mirage folder wasn't being removed from our production build after upgrading to 0.2.x because we were using the `directory` feature to point it at the old `/app/mirage` directory.