### PR TITLE
implement association helper

### DIFF
--- a/addon/association.js
+++ b/addon/association.js
@@ -1,0 +1,10 @@
+let association = function(nameOverride, ...traitsAndOverrides) {
+  let __isAssociation__ = true;
+  return {
+    nameOverride,
+    __isAssociation__,
+    traitsAndOverrides
+  };
+};
+
+export default association;

--- a/addon/association.js
+++ b/addon/association.js
@@ -1,7 +1,6 @@
-let association = function(nameOverride, ...traitsAndOverrides) {
+let association = function(...traitsAndOverrides) {
   let __isAssociation__ = true;
   return {
-    nameOverride,
     __isAssociation__,
     traitsAndOverrides
   };

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,6 @@
 import Factory from './factory';
 import trait from './trait';
+import association from './association';
 import Response from './response';
 import faker from './faker';
 import Model from './orm/model';
@@ -21,6 +22,7 @@ function belongsTo(...args) {
 export {
   Factory,
   trait,
+  association,
   Response,
   faker,
   Model,

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -288,5 +288,8 @@ class Model {
 }
 
 Model.extend = extend;
+Model.findBelongsToAssociation = function(associationType) {
+  return this.prototype.belongsToAssociations[associationType];
+};
 
 export default Model;

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -105,6 +105,15 @@ export default class Schema {
   }
 
   /**
+   * @method modelFor
+   * @param type
+   * @public
+   */
+  modelFor(type) {
+    return this._registry[type];
+  }
+
+  /**
    * @method new
    * @param type
    * @param attrs

--- a/addon/server.js
+++ b/addon/server.js
@@ -2,7 +2,11 @@
 
 import { pluralize, camelize } from './utils/inflector';
 import { toCollectionName } from 'ember-cli-mirage/utils/normalize-name';
+<<<<<<< HEAD
 import Ember from 'ember';
+=======
+import isAssociation from 'ember-cli-mirage/utils/is-association';
+>>>>>>> implement association helper
 import Pretender from 'pretender';
 import Db from './db';
 import Schema from './orm/schema';
@@ -242,22 +246,11 @@ export default class Server {
 
     let OriginalFactory = this.factoryFor(type);
     if (OriginalFactory) {
-      let { attrs } = OriginalFactory;
-
-      traits.forEach((traitName) => {
-        if (!OriginalFactory.isTrait(traitName)) {
-          throw new Error(`'${traitName}' trait is not registered in '${type}' factory`);
-        }
-      });
-
-      let allExtensions = traits.map((traitName) => {
-        // throw error if not registered
-        return attrs[traitName].extension;
-      });
-      allExtensions.push(overrides || {});
-      let mergedExtensions = allExtensions.reduce((accum, extension) => {
-        return _assign(accum, extension);
-      }, {});
+      let attrs = OriginalFactory.attrs || {};
+      this._validateTraits(traits, OriginalFactory, type);
+      let mergedExtensions = this._mergeExtensions(attrs, traits, overrides);
+      this._mapAssociationsFromAttributes(attrs);
+      this._mapAssociationsFromAttributes(mergedExtensions);
 
       let Factory = OriginalFactory.extend(mergedExtensions);
       let factory = new Factory();
@@ -454,6 +447,36 @@ export default class Server {
   _configureDefaultPassthroughs() {
     defaultPassthroughs.forEach(passthroughUrl => {
       this.passthrough(passthroughUrl);
+    });
+  }
+
+  _validateTraits(traits, factory, type) {
+    traits.forEach((traitName) => {
+      if (!factory.isTrait(traitName)) {
+        throw new Error(`'${traitName}' trait is not registered in '${type}' factory`);
+      }
+    });
+  }
+
+  _mergeExtensions(attrs, traits, overrides) {
+    let allExtensions = traits.map((traitName) => {
+      return attrs[traitName].extension;
+    });
+    allExtensions.push(overrides || {});
+    return allExtensions.reduce((accum, extension) => {
+      return _assign(accum, extension);
+    }, {});
+  }
+
+  _mapAssociationsFromAttributes(attributes) {
+    Object.keys(attributes).filter((attr) => {
+      return isAssociation(attributes[attr]);
+    }).forEach((attr) => {
+      let association = attributes[attr];
+      let associationName = association.nameOverride || camelize(attr);
+      let foreignKey = `${camelize(attr)}Id`;
+      attributes[foreignKey] = this.create(associationName, ...association.traitsAndOverrides).id;
+      delete attributes[attr];
     });
   }
 }

--- a/addon/utils/is-association.js
+++ b/addon/utils/is-association.js
@@ -1,0 +1,5 @@
+import _isPlainObject from 'lodash/lang/isPlainObject';
+
+export default function(object) {
+  return _isPlainObject(object) && object.__isAssociation__ === true;
+}

--- a/tests/integration/factories/helpers-test.js
+++ b/tests/integration/factories/helpers-test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import { Model, Factory, belongsTo, hasMany, trait, association } from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+
+module('Integration | Server | Factories | helpers', {
+  beforeEach() {
+    this.server = new Server({
+      environment: 'test',
+      models: {
+        author: Model.extend({
+          posts: hasMany()
+        }),
+        category: Model.extend({
+          posts: hasMany('post', { inverse: 'kind' })
+        }),
+        post: Model.extend({
+          author: belongsTo(),
+          kind: belongsTo('category')
+        })
+      },
+      factories: {
+        author: Factory.extend({
+          name: 'Sam'
+        }),
+        category: Factory.extend({
+          name: 'awesome software'
+        }),
+        post: Factory.extend({
+          title: 'Lorem ipsum',
+
+          author: association(),
+
+          withCategory: trait({
+            kind: association('category')
+          })
+        })
+      }
+    });
+  },
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+test('it creates associations with "association" helper combininig with traits', function(assert) {
+  this.server.create('post', 'withCategory');
+
+  assert.equal(this.server.db.posts.length, 1);
+  assert.deepEqual(
+    this.server.db.posts[0],
+    { id: '1', title: 'Lorem ipsum', authorId: '1', kindId: '1' }
+  );
+  assert.deepEqual(
+    this.server.schema.posts.find(1).author.attrs,
+    { id: '1', name: 'Sam' }
+  );
+  assert.deepEqual(
+    this.server.schema.posts.find(1).kind.attrs,
+    { id: '1', name: 'awesome software' }
+  );
+
+  assert.equal(this.server.db.authors.length, 1);
+  assert.deepEqual(
+    this.server.db.authors[0],
+    { id: '1', name: 'Sam' }
+  );
+  assert.equal(this.server.schema.authors.find(1).posts.models.length, 1);
+  assert.deepEqual(
+    this.server.schema.authors.find(1).posts.models[0].attrs,
+    { id: '1', title: 'Lorem ipsum', authorId: '1', kindId: '1' }
+  );
+
+  assert.equal(this.server.db.categories.length, 1);
+  assert.deepEqual(
+    this.server.db.categories[0],
+    { id: '1', name: 'awesome software' }
+  );
+  assert.equal(this.server.schema.categories.find(1).posts.models.length, 1);
+  assert.deepEqual(
+    this.server.schema.categories.find(1).posts.models[0].attrs,
+    { id: '1', title: 'Lorem ipsum', authorId: '1', kindId: '1' }
+  );
+});

--- a/tests/integration/factories/helpers-test.js
+++ b/tests/integration/factories/helpers-test.js
@@ -31,7 +31,7 @@ module('Integration | Server | Factories | helpers', {
           author: association(),
 
           withCategory: trait({
-            kind: association('category')
+            kind: association()
           })
         })
       }

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -4,7 +4,7 @@ import {module, test} from 'qunit';
 module('Unit | Model');
 
 test('it can be instantiated', function(assert) {
-  let  model = new Model({}, 'user');
+  let model = new Model({}, 'user');
   assert.ok(model);
 });
 
@@ -18,4 +18,15 @@ test('it cannot be instantiated without a modelName', function(assert) {
   assert.throws(function() {
     new Model({});
   }, /requires a modelName/);
+});
+
+test('findBelongsToAssociation returns association for given type if defined', function(assert) {
+  let ModelClass = Model.extend();
+  let authorAssociationMock = {};
+  ModelClass.prototype.belongsToAssociations = {
+    author: authorAssociationMock
+  };
+
+  assert.equal(ModelClass.findBelongsToAssociation('article'), null);
+  assert.deepEqual(ModelClass.findBelongsToAssociation('author'), authorAssociationMock);
 });

--- a/tests/unit/schema-test.js
+++ b/tests/unit/schema-test.js
@@ -1,4 +1,6 @@
 import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+import { Model, belongsTo } from 'ember-cli-mirage';
 import {module, test} from 'qunit';
 
 module('Unit | Schema');
@@ -13,4 +15,22 @@ test('it cannot be instantiated without a db', function(assert) {
   assert.throws(function() {
     new Schema();
   }, /requires a db/);
+});
+
+test('modelFor returns model for given type if registered', function(assert) {
+  let db = new Db();
+  let schema = new Schema(db);
+
+  assert.equal(schema.modelFor('article'), null);
+
+  let authorModel = Model.extend({
+  });
+  let articleModel = Model.extend({
+    author: belongsTo()
+  });
+  schema.registerModel('article', articleModel);
+  schema.registerModel('author', authorModel);
+
+  assert.deepEqual(schema.modelFor('article').foreignKeys, ['authorId']);
+  assert.deepEqual(schema.modelFor('author').foreignKeys, []);
 });

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -1,7 +1,7 @@
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers, disallowMultipleVarDecl
 import Server, { defaultPassthroughs } from 'ember-cli-mirage/server';
 import {module, test} from 'qunit';
-import { Model, Factory, trait } from 'ember-cli-mirage';
+import { Model, Factory, trait, association } from 'ember-cli-mirage';
 
 module('Unit | Server');
 
@@ -465,6 +465,77 @@ test('create throws errors when using trait that is not defined and distinquishe
   server.shutdown();
 });
 
+test('create allows to create objects with associations', function(assert) {
+  let AuthorFactory = Factory.extend({
+    name: 'Sam'
+  });
+  let CategoryFactory = Factory.extend({
+    name: 'splendid software'
+  });
+  let ArticleFactory = Factory.extend({
+    title: 'Lorem ipsum',
+
+    withCategory: trait({
+      awesomeCategory: association('category')
+    }),
+
+    someOtherTrait: trait({
+      user: association()
+    }),
+
+    author: association()
+  });
+
+  let server = new Server({
+    environment: 'test',
+    factories: {
+      article: ArticleFactory,
+      author: AuthorFactory,
+      category: CategoryFactory
+    }
+  });
+
+  let article = server.create('article', 'withCategory');
+
+  assert.deepEqual(article, { title: 'Lorem ipsum', id: '1', authorId: '1', awesomeCategoryId: '1' });
+  assert.equal(server.db.authors.length, 1);
+  assert.equal(server.db.categories.length, 1);
+});
+
+test('create allows to create objects with associations with traits and overrides for associations', function(assert) {
+  let CategoryFactory = Factory.extend({
+    name: 'splendid software',
+
+    published: trait({
+      isPublished: true,
+      publishedAt: '2014-01-01 10:00:00'
+    })
+  });
+  let ArticleFactory = Factory.extend({
+    title: 'Lorem ipsum',
+
+    withCategory: trait({
+      category: association('category', 'published', { publishedAt: '2016-01-01 12:00:00' })
+    })
+  });
+
+  let server = new Server({
+    environment: 'test',
+    factories: {
+      article: ArticleFactory,
+      category: CategoryFactory
+    }
+  });
+
+  let article = server.create('article', 'withCategory');
+  assert.deepEqual(article, { title: 'Lorem ipsum', id: '1', categoryId: '1' });
+  assert.equal(server.db.categories.length, 1);
+  assert.deepEqual(
+    server.db.categories[0],
+    { name: 'splendid software', id: '1', isPublished: true, publishedAt: '2016-01-01 12:00:00' }
+  );
+});
+
 module('Unit | Server #createList', {
   beforeEach() {
     this.server = new Server({ environment: 'test' });
@@ -800,6 +871,74 @@ test('build allows to extend with multiple traits and to apply attr overrides', 
 
   assert.deepEqual(publishedArticleWithContent, { title: 'Lorem ipsum', isPublished: true,
     publishedAt: '2012-01-01 10:00:00', content: 'content' });
+});
+
+test('build allows to build objects with associations', function(assert) {
+  let AuthorFactory = Factory.extend({
+    name: 'Yehuda'
+  });
+  let CategoryFactory = Factory.extend({
+    name: 'splendid software'
+  });
+  let ArticleFactory = Factory.extend({
+    title: 'Lorem ipsum',
+
+    withCategory: trait({
+      awesomeCategory: association('category')
+    }),
+
+    someOtherTrait: trait({
+      user: association()
+    }),
+
+    author: association()
+  });
+
+  this.server.loadFactories({
+    article: ArticleFactory,
+    author: AuthorFactory,
+    category: CategoryFactory
+  });
+
+  let article = this.server.build('article', 'withCategory');
+
+  assert.deepEqual(article, { title: 'Lorem ipsum', authorId: '1', awesomeCategoryId: '1' });
+  assert.equal(server.db.authors.length, 1);
+  assert.equal(server.db.categories.length, 1);
+});
+
+test('build allows to build objects with associations with traits and overrides for associations', function(assert) {
+  let CategoryFactory = Factory.extend({
+    name: 'splendid software',
+
+    published: trait({
+      isPublished: true,
+      publishedAt: '2014-01-01 10:00:00'
+    })
+  });
+  let ArticleFactory = Factory.extend({
+    title: 'Lorem ipsum',
+
+    withCategory: trait({
+      category: association('category', 'published', { publishedAt: '2016-01-01 12:00:00' })
+    })
+  });
+
+  let server = new Server({
+    environment: 'test',
+    factories: {
+      article: ArticleFactory,
+      category: CategoryFactory
+    }
+  });
+
+  let article = server.build('article', 'withCategory');
+  assert.deepEqual(article, { title: 'Lorem ipsum', categoryId: '1' });
+  assert.equal(server.db.categories.length, 1);
+  assert.deepEqual(
+    server.db.categories[0],
+    { name: 'splendid software', id: '1', isPublished: true, publishedAt: '2016-01-01 12:00:00' }
+  );
 });
 
 test('build throws errors when using trait that is not defined and distinquishes between traits and non-traits', function(assert) {


### PR DESCRIPTION
Another feature I was happy to see in the roadmap as it's super useful :). Works with name override, traits and attribute overrrides.

I think traits / association handling may need some refactoring, the responsibilites are a bit split betweem the factory itself and the server and it's not really clear what should happen where (e.g. some attributes are deleted in factory, others in server). And the building / creating could be actually delegated to some other object so that there's no so much logic directly in the server. But that's probably out of the scope of this PR.
