### PR TITLE
Update version of resource helper to 0.2.2

### DIFF
--- a/docs/v0.2.x/shorthands.md
+++ b/docs/v0.2.x/shorthands.md
@@ -183,7 +183,7 @@ this.del('/contacts/:id', ({ contacts }, request) => {
 
 ## Resource helper
 
-For handling generic CRUD, you can use *resource* helper which will take care of defining all shorthands. The following examples are equivalent:
+For handling generic CRUD, you can use *resource* helper since mirage 0.2.2 which will take care of defining all shorthands. The following examples are equivalent:
 
 {% capture resource %}
 {% highlight js %}

--- a/docs/v0.2.x/shorthands.md
+++ b/docs/v0.2.x/shorthands.md
@@ -183,11 +183,11 @@ this.del('/contacts/:id', ({ contacts }, request) => {
 
 ## Resource helper
 
-For handling generic CRUD, you can use *resource* helper since mirage 0.2.2 which will take care of defining all shorthands. The following examples are equivalent:
+For handling generic CRUD, you can use *resource* helper which will take care of defining all shorthands. The following examples are equivalent:
 
 {% capture resource %}
 {% highlight js %}
-this.resource('contacts');
+this.resource('contacts'); // available since mirage 0.2.2 
 {% endhighlight %}
 {% endcapture %}
 

--- a/docs/v0.2.x/shorthands.md
+++ b/docs/v0.2.x/shorthands.md
@@ -187,7 +187,7 @@ For handling generic CRUD, you can use *resource* helper which will take care of
 
 {% capture resource %}
 {% highlight js %}
-this.resource('contacts'); // available since mirage 0.2.2 
+this.resource('contacts'); // available in 0.2.2+
 {% endhighlight %}
 {% endcapture %}
 


### PR DESCRIPTION
I've stumbled at using this.resource, as it was not clarified what version it was added to mirage (still using 0.2.1)