### PR TITLE
[FIX] Bump pretender to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-mirage",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A client-side HTTP server to develop, test and demo your Ember app",
   "directories": {
     "doc": "doc",
@@ -75,7 +75,7 @@
     "exists-sync": "0.0.3",
     "fake-xml-http-request": "^1.4.0",
     "faker": "3.0.1",
-    "pretender": "^1.2.0",
+    "pretender": "git://github.com/mariogintili/pretender.git#nfr/replace-error-with-warning",
     "route-recognizer": "^0.1.11"
   }
 }


### PR DESCRIPTION
Hello!

Following from what I read on #915 and pretenderjs/pretender#178 I decided to commit a small version bump on [pretender(and hope its accepted)](https://github.com/pretenderjs/pretender/pull/187) that changes throwing an error for a soft assertion 

I don't know if this is the best way moving forwards for both projects but it does unblock my team for the time being 😄 happy to make any changes to this or any work I've submitted to Pretender

P.S: I know this is only aiming to a branch on my fork, will change accordingly if Pretender responds 😄 