### PR TITLE
Add support for promises in route functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "exists-sync": "0.0.3",
     "fake-xml-http-request": "^1.4.0",
     "faker": "3.0.1",
-    "pretender": "^1.2.0",
+    "pretender": "^1.4.1",
     "route-recognizer": "^0.1.11"
   }
 }


### PR DESCRIPTION
This enables users to work with promises in route function handlers, e.g.:

```js
this.get('/users', () => {
  return new Promise(resolve => {
    resolve(new Response(200, { 'Content-Type': 'text/csv' }, 'firstname,lastname\nbob,dylan'));
  });
});
```