### PR TITLE
[DOCS] Advise user to shutdown pretender servers

### DIFF
--- a/docs/v0.2.x/manually-starting-mirage.md
+++ b/docs/v0.2.x/manually-starting-mirage.md
@@ -5,27 +5,19 @@ version: v0.2.x
 
 Currently, Mirage's server boots up in an Ember initializer. This means it will not automatically start in unit or integration tests, since there's no Ember app running.
 
-Eventually we'll extract Mirage's initializer, but for now you can use this workaround. To run your Mirage server during a unit or integration test, first create a helper:
-
-```js
-// tests/helpers/setup-mirage-for-integration.js
-import mirageInitializer from '../../initializers/ember-cli-mirage';
-
-export default function startMirage(container) {
-  mirageInitializer.initialize(container);
-}
-```
-
-Then, add the following to any test where you want Mirage to initialize:
+Eventually we'll extract Mirage's initializer, but for now you can use this workaround. Add the following to any test where you want Mirage to initialize:
 
 ```js
 // tests/integration/components/your-test.js
-import startMirage from '../../../helpers/setup-mirage-for-integration';
+import { startMirage } from 'yourapp/initializers/ember-cli-mirage';
 
 moduleForComponent('your-component', 'Integration | Component | your component', {
   integration: true,
-  setup() {
-    startMirage(this.container);
+  beforeEach() {
+    this.server = startMirage();
+  },
+  afterEach() {
+    this.server.shutdown();
   }
 });
 ```


### PR DESCRIPTION
Updating old documentation.  I'm not sure why the original docs advised running the initializer method; the startMirage function should work just fine—no helper file should be necessary.

Closes #915 (not automatically, though)