### PR TITLE
Serialize models on the relation key instead of the modelName

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -118,10 +118,14 @@ class Serializer {
             return [...acc, ...resources];
           }
 
-          return [
-            ...acc,
-            { key: this.keyForModel(key), resource: resource[key] }
-          ];
+          if (resource[key]) {
+            return [
+              ...acc,
+              { key: this.keyForModel(key), resource: resource[key] }
+            ];
+          }
+
+          return acc;
         }, []))
         .uniq(({ resource }) => resource.toString())
         .value();

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -110,12 +110,18 @@ class Serializer {
         .reduce((acc, key)=> {
           if (this.isCollection(resource)) {
             let { models } = resource;
-            let resources = models.filter(m => !m[key]).map(r => ({ key, r: resource }));
+            let resources = models.filter(m => m[key]).map(r => ({
+              key: this.keyForCollection(key),
+              resource: r[key]
+            }));
 
             return [...acc, ...resources];
           }
 
-          return [...acc, { key, resource: resource[key] }];
+          return [
+            ...acc,
+            { key: this.keyForModel(key), resource: resource[key] }
+          ];
         }, []))
         .uniq(({ resource }) => resource.toString())
         .value();

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -50,15 +50,15 @@ class Serializer {
       return this.buildPayload(undefined, newIncludes, newDidSerialize, resourceHash);
 
     } else {
-      let nextIncludedResource = toInclude.shift();
-      let [ resourceHash, newIncludes ] = this.getHashForIncludedResource(nextIncludedResource);
+      let { key, resource } = toInclude.shift();
+      let [ resourceHash, newIncludes ] = this.getHashForIncludedResource(key, resource);
 
       let newToInclude = newIncludes
-        .filter(resource => {
+        .filter(({ resource }) => {
           return !_includes(didSerialize.map(m => m.toString()), resource.toString());
         })
         .concat(toInclude);
-      let newDidSerialize = (this.isCollection(nextIncludedResource) ? nextIncludedResource.models : [ nextIncludedResource ])
+      let newDidSerialize = (this.isCollection(resource) ? resource.models : [ resource ])
         .concat(didSerialize);
       let newJson = this.mergePayloads(json, resourceHash);
 
@@ -72,7 +72,7 @@ class Serializer {
 
     if (this.root) {
       let serializer = this.serializerFor(resource.modelName);
-      let rootKey = serializer.keyForResource(resource);
+      let rootKey = serializer.keyForResource(resource.modelName, resource);
       hashWithRoot = { [rootKey]: hash };
     } else {
       hashWithRoot = hash;
@@ -81,13 +81,13 @@ class Serializer {
     return [ hashWithRoot, addToIncludes ];
   }
 
-  getHashForIncludedResource(resource) {
+  getHashForIncludedResource(key, resource) {
+    let pluralKey = pluralize(key);
     let serializer = this.serializerFor(resource.modelName);
     let [ hash, addToIncludes ] = serializer.getHashForResource(resource);
 
     // Included resources always have a root, and are always pushed to an array.
-    let rootKey = serializer.keyForRelationship(resource.modelName);
-    let hashWithRoot = _isArray(hash) ? { [rootKey]: hash } : { [rootKey]: [ hash ] };
+    let hashWithRoot = _isArray(hash) ? { [pluralKey]: hash } : { [pluralKey]: [ hash ] };
 
     return [ hashWithRoot, addToIncludes ];
   }
@@ -106,17 +106,18 @@ class Serializer {
       return [ hash ];
 
     } else {
-      let addToIncludes = _(serializer.getKeysForIncluded())
-        .map(key => {
+      let addToIncludes = _(serializer.getKeysForIncluded()
+        .reduce((acc, key)=> {
           if (this.isCollection(resource)) {
-            return resource.models.map(m => m[key]);
-          } else {
-            return resource[key];
+            let { models } = resource;
+            let resources = models.filter(m => !m[key]).map(r => ({ key, r: resource }));
+
+            return [...acc, ...resources];
           }
-        })
-        .flatten()
-        .compact()
-        .uniq(m => m.toString())
+
+          return [...acc, { key, resource: resource[key] }];
+        }, []))
+        .uniq(({ resource }) => resource.toString())
         .value();
 
       return [ hash, addToIncludes ];
@@ -167,9 +168,8 @@ class Serializer {
     return newJson;
   }
 
-  keyForResource(resource) {
-    let { modelName } = resource;
-    return this.isModel(resource) ? this.keyForModel(modelName) : this.keyForCollection(modelName);
+  keyForResource(key, resource) {
+    return this.isModel(resource) ? this.keyForModel(key) : this.keyForCollection(key);
   }
 
   /**
@@ -213,11 +213,12 @@ class Serializer {
         let associatedResource = model[key];
         if (!_get(newDidSerialize, `${associatedResource.modelName}.${associatedResource.id}`)) {
           let [ associatedResourceHash ] = this.getHashForResource(associatedResource, true, newDidSerialize, true);
-          let formattedKey = this.keyForResource(associatedResource);
+          let formattedKey = this.keyForResource(key, associatedResource);
+
           attrs[formattedKey] = associatedResourceHash;
 
           if (this.isModel(associatedResource)) {
-            let fk = `${camelize(associatedResource.modelName)}Id`;
+            let fk = `${camelize(key)}Id`;
             delete attrs[fk];
           }
         }

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -111,7 +111,7 @@ export default Serializer.extend({
     return includes;
   },
 
-  _getModelsToAdd (key, resource) {
+  _getModelsToAdd(key, resource) {
     if (this.isModel(resource)) {
       return [{ key, resource }];
     } else if (this.isCollection(resource)) {

--- a/tests/integration/serializers/base/associations/custom-key-collection-test.js
+++ b/tests/integration/serializers/base/associations/custom-key-collection-test.js
@@ -1,0 +1,157 @@
+// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+import Serializer from 'ember-cli-mirage/serializer';
+import { hasMany, belongsTo } from 'ember-cli-mirage';
+import Schema from 'ember-cli-mirage/orm/schema';
+import Model from 'ember-cli-mirage/orm/model';
+import Db from 'ember-cli-mirage/db';
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+import { module, test } from 'qunit';
+
+module('Integration | Serializers | Base | Associations | Custom Key', {
+  beforeEach() {
+    let db = new Db();
+    this.schema = new Schema(db);
+    this.schema.registerModels({
+      wordSmith: Model.extend({
+        draftBlogPosts: hasMany('blogPost', { inverse: 'wordSmithee' })
+      }),
+      blogPost: Model.extend({
+        wordSmithee: belongsTo('wordSmith')
+      }),
+    });
+
+    let link = this.schema.wordSmiths.create({ name: 'Link', age: 123 });
+    link.createDraftBlogPost({ title: 'Lorem' });
+    link.createDraftBlogPost({ title: 'Ipsum' });
+
+    this.schema.wordSmiths.create({ name: 'Zelda', age: 230 });
+  },
+
+  afterEach() {
+    this.schema.db.emptyData();
+  }
+});
+
+test(`it can embed a model with a belongs-to relationship with a custom key`, function (assert) {
+  let BaseSerializer = Serializer.extend({ embed: true });
+
+  let registry = new SerializerRegistry(this.schema, {
+    application: BaseSerializer,
+    blogPost: BaseSerializer.extend({
+      embed: true,
+      include: ['wordSmithee']
+    })
+  });
+
+  let blogPost = this.schema.blogPosts.find(1);
+  let result = registry.serialize(blogPost);
+
+  assert.deepEqual(result, {
+    blogPost: {
+      id: '1',
+      title: 'Lorem',
+      wordSmithee: {
+        age: 123,
+        id: '1',
+        name: 'Link'
+      }
+    }
+  });
+});
+
+test(`it can sideload a model with a belongs-to relationship with a custom key`, function(assert) {
+  let BaseSerializer = Serializer.extend({ embed: false });
+
+  let registry = new SerializerRegistry(this.schema, {
+    application: BaseSerializer,
+    blogPost: BaseSerializer.extend({
+      include: ['wordSmithee']
+    })
+  });
+
+  let blogPost = this.schema.blogPosts.find(1);
+  let result = registry.serialize(blogPost);
+
+  assert.deepEqual(result, {
+    blogPost: {
+      id: '1',
+      title: 'Lorem',
+      wordSmitheeId: '1'
+    },
+    wordSmithees: [
+      {
+        id: '1',
+        name: 'Link',
+        age: 123 }
+    ]
+  });
+});
+
+test('it can embed a collection with a has-many relationship with a custom key', function(assert) {
+  let BaseSerializer = Serializer.extend({ embed: true });
+  let registry = new SerializerRegistry(this.schema, {
+    application: BaseSerializer,
+    wordSmith: BaseSerializer.extend({
+      attrs: ['id', 'name'],
+      include: ['draftBlogPosts']
+    }),
+  });
+
+  let link = this.schema.wordSmiths.find(1);
+  let result = registry.serialize(link);
+
+  assert.deepEqual(result, {
+    wordSmith: {
+      draftBlogPosts: [
+        {
+          id: "1",
+          title: "Lorem"
+        },
+        {
+          id: "2",
+          title: "Ipsum"
+        }
+      ],
+      id: "1",
+      name: "Link"
+    }
+  });
+});
+
+test('it can sideload a collection with a has-many relationship with a custom key', function(assert) {
+  let BaseSerializer = Serializer.extend({ embed: false });
+
+  let registry = new SerializerRegistry(this.schema, {
+    application: BaseSerializer,
+    wordSmith: BaseSerializer.extend({
+      attrs: ['id', 'name'],
+      include: ['draftBlogPosts']
+    }),
+  });
+
+  let link = this.schema.wordSmiths.find(1);
+  let result = registry.serialize(link);
+
+  assert.deepEqual(result, {
+    draftBlogPosts: [
+      {
+        id: "1",
+        title: "Lorem",
+        wordSmitheeId: "1"
+      },
+      {
+        id: "2",
+        title: "Ipsum",
+        wordSmitheeId: "1"
+      }
+    ],
+    wordSmith: {
+      draftBlogPostIds: [
+        "1",
+        "2"
+      ],
+      id: "1",
+      name: "Link"
+    }
+  });
+});

--- a/tests/integration/serializers/base/associations/custom-key-collection-test.js
+++ b/tests/integration/serializers/base/associations/custom-key-collection-test.js
@@ -17,7 +17,7 @@ module('Integration | Serializers | Base | Associations | Custom Key', {
       }),
       blogPost: Model.extend({
         wordSmithee: belongsTo('wordSmith')
-      }),
+      })
     });
 
     let link = this.schema.wordSmiths.create({ name: 'Link', age: 123 });
@@ -32,7 +32,7 @@ module('Integration | Serializers | Base | Associations | Custom Key', {
   }
 });
 
-test(`it can embed a model with a belongs-to relationship with a custom key`, function (assert) {
+test(`it can embed a model with a belongs-to relationship with a custom key`, function(assert) {
   let BaseSerializer = Serializer.extend({ embed: true });
 
   let registry = new SerializerRegistry(this.schema, {
@@ -94,7 +94,7 @@ test('it can embed a collection with a has-many relationship with a custom key',
     wordSmith: BaseSerializer.extend({
       attrs: ['id', 'name'],
       include: ['draftBlogPosts']
-    }),
+    })
   });
 
   let link = this.schema.wordSmiths.find(1);
@@ -104,16 +104,16 @@ test('it can embed a collection with a has-many relationship with a custom key',
     wordSmith: {
       draftBlogPosts: [
         {
-          id: "1",
-          title: "Lorem"
+          id: '1',
+          title: 'Lorem'
         },
         {
-          id: "2",
-          title: "Ipsum"
+          id: '2',
+          title: 'Ipsum'
         }
       ],
-      id: "1",
-      name: "Link"
+      id: '1',
+      name: 'Link'
     }
   });
 });
@@ -126,7 +126,7 @@ test('it can sideload a collection with a has-many relationship with a custom ke
     wordSmith: BaseSerializer.extend({
       attrs: ['id', 'name'],
       include: ['draftBlogPosts']
-    }),
+    })
   });
 
   let link = this.schema.wordSmiths.find(1);
@@ -135,23 +135,23 @@ test('it can sideload a collection with a has-many relationship with a custom ke
   assert.deepEqual(result, {
     draftBlogPosts: [
       {
-        id: "1",
-        title: "Lorem",
-        wordSmitheeId: "1"
+        id: '1',
+        title: 'Lorem',
+        wordSmitheeId: '1'
       },
       {
-        id: "2",
-        title: "Ipsum",
-        wordSmitheeId: "1"
+        id: '2',
+        title: 'Ipsum',
+        wordSmitheeId: '1'
       }
     ],
     wordSmith: {
       draftBlogPostIds: [
-        "1",
-        "2"
+        '1',
+        '2'
       ],
-      id: "1",
-      name: "Link"
+      id: '1',
+      name: 'Link'
     }
   });
 });

--- a/tests/integration/serializers/base/associations/sideloading-model-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-model-test.js
@@ -91,7 +91,7 @@ test(`it can sideload a named has-many association`, function(assert) {
       name: 'Link',
       postIds: ['1']
     },
-    blogPosts: [
+    posts: [
       { id: '1', title: 'Lorem', wordSmithId: '1' }
     ]
   });
@@ -197,7 +197,7 @@ test(`it can sideload a model with a named belongs-to relationship`, function(as
     blogPost: {
       id: '1', title: 'Lorem', authorId: '1'
     },
-    wordSmiths: [
+    authors: [
       { id: '1', name: 'Link' }
     ]
   });

--- a/tests/integration/serializers/json-api-serializer/associations/custom-key-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/custom-key-test.js
@@ -28,7 +28,7 @@ module('Integration | Serializers | JSON API Serializer | Associations | Custom 
   }
 });
 
-test(`it can serialize the relationship  for a model with a belongs-to relationship with a custom key`, function (assert) {
+test(`it can serialize the relationship  for a model with a belongs-to relationship with a custom key`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JSONAPISerializer
   });
@@ -37,25 +37,25 @@ test(`it can serialize the relationship  for a model with a belongs-to relations
   let result = registry.serialize(blogPost);
 
   assert.deepEqual(result, {
-    "data": {
-      "attributes": {
-        "title": "Lorem"
+    'data': {
+      'attributes': {
+        'title': 'Lorem'
       },
-      "id": "1",
-      "relationships": {
-        "word-smithee": {
-          "data": {
-            "id": "1",
-            "type": "word-smiths"
+      'id': '1',
+      'relationships': {
+        'word-smithee': {
+          'data': {
+            'id': '1',
+            'type': 'word-smiths'
           }
         }
       },
-      "type": "blog-posts"
+      'type': 'blog-posts'
     }
   });
 });
 
-test(`it include the relationship for a model with a belongs-to relationship with a custom key`, function (assert) {
+test(`it include the relationship for a model with a belongs-to relationship with a custom key`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JSONAPISerializer
   });
@@ -69,37 +69,37 @@ test(`it include the relationship for a model with a belongs-to relationship wit
   let result = registry.serialize(blogPost, request);
 
   assert.deepEqual(result, {
-    "data": {
-      "attributes": {
-        "title": "Lorem"
+    'data': {
+      'attributes': {
+        'title': 'Lorem'
       },
-      "id": "1",
-      "relationships": {
-        "word-smithee": {
-          "data": {
-            "id": "1",
-            "type": "word-smiths"
+      'id': '1',
+      'relationships': {
+        'word-smithee': {
+          'data': {
+            'id': '1',
+            'type': 'word-smiths'
           }
         }
       },
-      "type": "blog-posts"
+      'type': 'blog-posts'
     },
-    "included": [
+    'included': [
       {
-        "attributes": {
-          "age": 123,
-          "name": "Link"
+        'attributes': {
+          'age': 123,
+          'name': 'Link'
         },
-        "id": "1",
-        "relationships": {
-          "draft-blog-posts": {
-            "data": [
-              { "type": "blog-posts", id: "1" },
-              { "type": "blog-posts", id: "2" }
+        'id': '1',
+        'relationships': {
+          'draft-blog-posts': {
+            'data': [
+              { 'type': 'blog-posts', id: '1' },
+              { 'type': 'blog-posts', id: '2' }
             ]
           }
         },
-        "type": "word-smiths"
+        'type': 'word-smiths'
       }
     ]
   });

--- a/tests/integration/serializers/json-api-serializer/associations/custom-key-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/custom-key-test.js
@@ -1,0 +1,106 @@
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+import { Model, hasMany, belongsTo, JSONAPISerializer } from 'ember-cli-mirage';
+import { module, test } from 'qunit';
+
+module('Integration | Serializers | JSON API Serializer | Associations | Custom Key', {
+  beforeEach() {
+    this.schema = new Schema(new Db(), {
+      wordSmith: Model.extend({
+        draftBlogPosts: hasMany('blogPost', { inverse: 'wordSmithee' })
+      }),
+      blogPost: Model.extend({
+        wordSmithee: belongsTo('wordSmith')
+      })
+    });
+
+    let link = this.schema.wordSmiths.create({ name: 'Link', age: 123 });
+
+    link.createDraftBlogPost({ title: 'Lorem' });
+    link.createDraftBlogPost({ title: 'Ipsum' });
+
+    this.schema.wordSmiths.create({ name: 'Zelda', age: 230 });
+  },
+
+  afterEach() {
+    this.schema.db.emptyData();
+  }
+});
+
+test(`it can serialize the relationship  for a model with a belongs-to relationship with a custom key`, function (assert) {
+  let registry = new SerializerRegistry(this.schema, {
+    application: JSONAPISerializer
+  });
+
+  let blogPost = this.schema.blogPosts.find(1);
+  let result = registry.serialize(blogPost);
+
+  assert.deepEqual(result, {
+    "data": {
+      "attributes": {
+        "title": "Lorem"
+      },
+      "id": "1",
+      "relationships": {
+        "word-smithee": {
+          "data": {
+            "id": "1",
+            "type": "word-smiths"
+          }
+        }
+      },
+      "type": "blog-posts"
+    }
+  });
+});
+
+test(`it include the relationship for a model with a belongs-to relationship with a custom key`, function (assert) {
+  let registry = new SerializerRegistry(this.schema, {
+    application: JSONAPISerializer
+  });
+
+  let blogPost = this.schema.blogPosts.find(1);
+  let request = {
+    queryParams: {
+      include: 'word-smithee'
+    }
+  };
+  let result = registry.serialize(blogPost, request);
+
+  assert.deepEqual(result, {
+    "data": {
+      "attributes": {
+        "title": "Lorem"
+      },
+      "id": "1",
+      "relationships": {
+        "word-smithee": {
+          "data": {
+            "id": "1",
+            "type": "word-smiths"
+          }
+        }
+      },
+      "type": "blog-posts"
+    },
+    "included": [
+      {
+        "attributes": {
+          "age": 123,
+          "name": "Link"
+        },
+        "id": "1",
+        "relationships": {
+          "draft-blog-posts": {
+            "data": [
+              { "type": "blog-posts", id: "1" },
+              { "type": "blog-posts", id: "2" }
+            ]
+          }
+        },
+        "type": "word-smiths"
+      }
+    ]
+  });
+});


### PR DESCRIPTION
The models of a relations with serialized on the modelName. This makes it impossible to correctly serialize the relations.

See https://github.com/samselikoff/ember-cli-mirage/issues/905

**Todo:**
- [x] Fix and test the json-serializer
- [x] Fix and test the active-model-serializer
