### PR TITLE
Let faker float from 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ember-lodash": "0.0.9",
     "exists-sync": "0.0.3",
     "fake-xml-http-request": "^1.4.0",
-    "faker": "3.0.1",
+    "faker": "^3.0.0",
     "pretender": "^1.4.1",
     "route-recognizer": "^0.1.11"
   }


### PR DESCRIPTION
This PR addresses concerns from #863 around a lack of flexibility around which version of faker is used.  This PR lets the range float from 3.0.0 so by default users will get the latest version, but if they want to use a specific version they can specify that version in their own package.json.

I tested this out a few ways:
 * No Faker version in my app's package.json, I get Faker 3.1.0
 * Faker 3.0.1 in my app's package.json, I get Faker 3.0.1
 * Faker ^3.0.0 in my app's package.json, I get Faker 3.1.0