### PR TITLE
HasMany association on its own model fix

### DIFF
--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -68,13 +68,17 @@ export default class Schema {
         let [ fkHolder, fk ] = association.getForeignKeyArray();
 
         fksAddedFromThisModel[fkHolder] = fksAddedFromThisModel[fkHolder] || [];
-        assert(
-          !_includes(fksAddedFromThisModel[fkHolder], fk),
-          `Your '${type}' model definition has multiple possible inverse relationships of type '${fkHolder}'.
 
-          Please read the associations guide and specify explicit inverses: http://www.ember-cli-mirage.com/docs/v0.2.x/models/#associations`
-        );
-        fksAddedFromThisModel[fkHolder].push(fk);
+        // For model association with its own model with a custom foreignKey
+        if (fk !== association.opts.foreignKey) {
+          assert(
+            !_includes(fksAddedFromThisModel[fkHolder], fk),
+            `Your '${type}' model definition has multiple possible inverse relationships of type '${fkHolder}'.
+
+            Please read the associations guide and specify explicit inverses: http://www.ember-cli-mirage.com/docs/v0.2.x/models/#associations`
+          );
+          fksAddedFromThisModel[fkHolder].push(fk);
+        }
 
         this._addForeignKeyToRegistry(fkHolder, fk);
 

--- a/tests/acceptance/inverse-relationship-test.js
+++ b/tests/acceptance/inverse-relationship-test.js
@@ -1,0 +1,35 @@
+import {test} from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | Inverse Relationship');
+
+test('Add nested comments to blog post', function(assert) {
+  let blogPost = server.create('blog-post');
+  let comment = server.create('comment', 1, {
+    blogPostId: blogPost.id
+  });
+  server.createList('comment', 5, {
+    blogPostId: blogPost.id,
+    parentCommentId: comment.id
+  });
+
+  server.get('/blog_posts/:id', function({ blogPosts }, req) {
+    let blogPost = blogPosts.find(req.params.id);
+    let serialize = this.serialize(blogPost);
+    let parentComment = serialize.comments.filter((comment) => !comment.parent_comment_id);
+    let childComments = serialize.comments.filter((comment) => comment.parent_comment_id);
+
+    assert.equal(serialize.blog_post.comment_ids.length, 6, 'has 6 comment ids');
+    assert.equal(parentComment.length, 1, 'has 1 parent comment');
+    assert.equal(childComments.length, 5, 'has 5 child comments');
+
+    return serialize;
+  });
+
+  visit(`/blog-posts/${blogPost.id}`);
+
+  andThen(()=> {
+    assert.equal(find('.blog-parentComment').length, 1, 'parent comment');
+    assert.equal(find('.blog-childComments li').length, 5, 'child comments');
+  });
+});

--- a/tests/dummy/app/models/blog-post.js
+++ b/tests/dummy/app/models/blog-post.js
@@ -1,9 +1,12 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 
 export default DS.Model.extend({
 
   title: DS.attr(),
 
-  wordSmith: DS.belongsTo()
+  comments: DS.hasMany(),
+  wordSmith: DS.belongsTo(),
 
+  parentComments: Ember.computed.filterBy('comments', 'parentComment', null)
 });

--- a/tests/dummy/app/models/comment.js
+++ b/tests/dummy/app/models/comment.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+
+  content: DS.attr(),
+
+  childComments: DS.hasMany('comment', {
+    inverse: 'parentComment',
+    async: false
+  }),
+  parentComment: DS.belongsTo('comment', {
+    async: false
+  })
+});

--- a/tests/dummy/app/models/friend.js
+++ b/tests/dummy/app/models/friend.js
@@ -1,3 +1,4 @@
+import DS from 'ember-data';
 import Contact from './contact';
 
 export default Contact.extend({

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,6 +16,8 @@ Router.map(function() {
   this.route('pets');
 
   this.route('word-smith', { path: '/word-smiths/:word_smith_id' });
+
+  this.route('blog-post', { path: '/blog-posts/:blog_post_id' });
 });
 
 export default Router;

--- a/tests/dummy/app/routes/blog-post.js
+++ b/tests/dummy/app/routes/blog-post.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+  model(params) {
+    return this.store.findRecord('blog-post', params.blog_post_id);
+  }
+
+});

--- a/tests/dummy/app/serializers/blog-post.js
+++ b/tests/dummy/app/serializers/blog-post.js
@@ -1,3 +1,0 @@
-import DS from 'ember-data';
-
-export default DS.JSONAPISerializer;

--- a/tests/dummy/app/templates/blog-post.hbs
+++ b/tests/dummy/app/templates/blog-post.hbs
@@ -1,0 +1,17 @@
+<h1>{{model.title}}</h1>
+
+<ul>
+{{#each model.parentComments as |parentComment|}}
+  <li class="blog-parentComment">
+    {{parentComment.content}}
+
+    {{#if parentComment.childComments}}
+      <ul class="blog-childComments">
+        {{#each parentComment.childComments as |childComment|}}
+          <li>{{childComment.content}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  </li>
+{{/each}}
+</ul>

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -39,7 +39,6 @@ export default function() {
   this.delete('/pets/:id', function({ db }, req) { }, 200);
 
   this.get('/word-smiths/:id');
-
 }
 
 export function testConfig() {

--- a/tests/dummy/mirage/factories/comment.js
+++ b/tests/dummy/mirage/factories/comment.js
@@ -1,0 +1,9 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+
+  content() {
+    return faker.hacker.phrase();
+  }
+
+});

--- a/tests/dummy/mirage/models/blog-post.js
+++ b/tests/dummy/mirage/models/blog-post.js
@@ -1,5 +1,5 @@
-import { Model } from 'ember-cli-mirage';
+import { Model, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
-
+  comments: hasMany()
 });

--- a/tests/dummy/mirage/models/comment.js
+++ b/tests/dummy/mirage/models/comment.js
@@ -1,0 +1,10 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  blogPost: belongsTo(),
+  parentComment: belongsTo('comment'),
+  childComments: hasMany('comment', {
+    inverse: 'parentComment',
+    foreignKey: 'parentCommentId'
+  })
+});

--- a/tests/dummy/mirage/serializers/blog-post.js
+++ b/tests/dummy/mirage/serializers/blog-post.js
@@ -1,5 +1,5 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import Serializer from './application';
 
-export default JSONAPISerializer.extend({
+export default Serializer.extend({
+  include: ['comments']
 });
-


### PR DESCRIPTION
I ran into a problem with ember-cli-mirage >= v0.2.2 when a model has a hasMany relationship to its own model that references to a its own belongsTo relationship with a foreignKey. It was due to `fksAddedFromThisModel` already including fk on the inverse relationship since it was referencing to a belongsTo relationship on its own model. So the fix was by adding `foreignKey` option to the hasMany association and checking if `fk !== assocation.opts.foreignKey` before trying to check if current `fk` is included in the `fksAddedFromThisModel[fkHolder]`.

Example of the model structure I had issue with is added in the acceptance test.