### PR TITLE
Upgrade route-recognizer to decode dyanmic path segments

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "exists-sync": "0.0.3",
     "fake-xml-http-request": "^1.4.0",
     "faker": "^3.0.0",
-    "pretender": "^1.4.1",
-    "route-recognizer": "^0.1.11"
+    "pretender": "^1.4.2",
+    "route-recognizer": "^0.2.3"
   }
 }

--- a/tests/integration/serializers/base/full-request-test.js
+++ b/tests/integration/serializers/base/full-request-test.js
@@ -81,6 +81,27 @@ test('the appropriate serializer is used', function(assert) {
   });
 });
 
+test('components decoded', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  this.server.get('/authors/:id', function(schema, request) {
+    let { id } = request.params;
+
+    return { data: { id } };
+  });
+
+  $.ajax({
+    method: 'GET',
+    url: '/authors/%3A1'
+  }).done(function(res) {
+    assert.deepEqual(res, {
+      data: { id: ':1' }
+    });
+    done();
+  });
+});
+
 test('a response falls back to the application serializer, if it exists', function(assert) {
   assert.expect(1);
   let done = assert.async();


### PR DESCRIPTION
See https://github.com/tildeio/route-recognizer/pull/91

Right now if id contains a special character like ```/``` or ```:``` then we need to use a workaround like:

```
this.get('/posts/:id', (request, schema) {
    let decodedId = decodeURIComponent(request.params.id);
    return schema.posts.find(decodedId);
});
```