### PR TITLE
Upgrade to ember-suave 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.3.0",
-    "ember-suave": "2.0.1",
+    "ember-suave": "4.0.0",
     "ember-try": "~0.0.8",
     "loader.js": "^4.0.0",
     "lodash": "3.10.1",

--- a/tests/acceptance/manually-starting-test.js
+++ b/tests/acceptance/manually-starting-test.js
@@ -4,6 +4,8 @@ import startApp from '../helpers/start-app';
 import { startMirage } from 'dummy/initializers/ember-cli-mirage';
 import ENV from 'dummy/config/environment';
 
+const { run } = Ember;
+
 let App;
 
 module('Acceptance: Manually starting Mirage', {
@@ -14,7 +16,7 @@ module('Acceptance: Manually starting Mirage', {
 
   afterEach() {
     server.shutdown();
-    Ember.run(App, 'destroy');
+    run(App, 'destroy');
     ENV['ember-cli-mirage'].enabled = undefined;
   }
 });

--- a/tests/dummy/app/adapters/word-smith.js
+++ b/tests/dummy/app/adapters/word-smith.js
@@ -1,3 +1,5 @@
 import DS from 'ember-data';
 
-export default DS.JSONAPIAdapter;
+const { JSONAPIAdapter }  = DS;
+
+export default JSONAPIAdapter;

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,11 +3,11 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-let App;
+const { Application } = Ember;
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-App = Ember.Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,3 +1,5 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend();
+const { Controller } = Ember;
+
+export default Controller.extend();

--- a/tests/dummy/app/models/address.js
+++ b/tests/dummy/app/models/address.js
@@ -1,7 +1,9 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  street: DS.attr('string'),
+const { Model, attr, belongsTo } = DS;
 
-  contact: DS.belongsTo('contact')
+export default Model.extend({
+  street: attr('string'),
+
+  contact: belongsTo('contact')
 });

--- a/tests/dummy/app/models/blog-post.js
+++ b/tests/dummy/app/models/blog-post.js
@@ -1,9 +1,11 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
+const { Model, attr, belongsTo } = DS;
 
-  title: DS.attr(),
+export default Model.extend({
 
-  wordSmith: DS.belongsTo()
+  title: attr(),
+
+  wordSmith: belongsTo()
 
 });

--- a/tests/dummy/app/models/contact.js
+++ b/tests/dummy/app/models/contact.js
@@ -1,9 +1,11 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  name: DS.attr('string'),
-  age: DS.attr('number'),
-  email: DS.attr('string'),
+const { Model, attr, belongsTo } = DS;
 
-  address: DS.belongsTo('address')
+export default Model.extend({
+  name: attr('string'),
+  age: attr('number'),
+  email: attr('string'),
+
+  address: belongsTo('address')
 });

--- a/tests/dummy/app/models/friend.js
+++ b/tests/dummy/app/models/friend.js
@@ -1,5 +1,8 @@
+import DS from 'ember-data';
 import Contact from './contact';
 
+const { attr } = DS;
+
 export default Contact.extend({
-  isYoung: DS.attr('boolean')
+  isYoung: attr('boolean')
 });

--- a/tests/dummy/app/models/pet.js
+++ b/tests/dummy/app/models/pet.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-  name: DS.attr('string'),
-  alive: DS.attr('boolean')
+const { Model, attr } = DS;
+
+export default Model.extend({
+  name: attr('string'),
+  alive: attr('boolean')
 });

--- a/tests/dummy/app/models/word-smith.js
+++ b/tests/dummy/app/models/word-smith.js
@@ -1,9 +1,11 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
+const { Model, attr, hasMany } = DS;
 
-  name: DS.attr(),
+export default Model.extend({
 
-  blogPosts: DS.hasMany()
+  name: attr(),
+
+  blogPosts: hasMany()
 
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const { Router } = Ember;
+
+export default Router.extend({
   location: config.locationType
 });
 
@@ -17,5 +19,3 @@ Router.map(function() {
 
   this.route('word-smith', { path: '/word-smiths/:word_smith_id' });
 });
-
-export default Router;

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
+const { Route } = Ember;
+
+export default Route.extend({
 
   actions: {
     createContact() {

--- a/tests/dummy/app/routes/close-friends.js
+++ b/tests/dummy/app/routes/close-friends.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
+const { Route } = Ember;
+
+export default Route.extend({
 
   model() {
     let store = this.get('store');

--- a/tests/dummy/app/routes/contacts.js
+++ b/tests/dummy/app/routes/contacts.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
+const { Route } = Ember;
+
+export default Route.extend({
 
   model() {
     return this.store.findAll('contact')

--- a/tests/dummy/app/routes/friends.js
+++ b/tests/dummy/app/routes/friends.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
+const { Route } = Ember;
+
+export default Route.extend({
 
   model() {
     return this.store.findAll('friend');

--- a/tests/dummy/app/routes/pets.js
+++ b/tests/dummy/app/routes/pets.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
+const { Route } = Ember;
+
+export default Route.extend({
 
   actions: {
     createPet() {

--- a/tests/dummy/app/serializers/blog-post.js
+++ b/tests/dummy/app/serializers/blog-post.js
@@ -1,3 +1,5 @@
 import DS from 'ember-data';
 
-export default DS.JSONAPISerializer;
+const { JSONAPISerializer } = DS;
+
+export default JSONAPISerializer;

--- a/tests/dummy/app/serializers/word-smith.js
+++ b/tests/dummy/app/serializers/word-smith.js
@@ -1,3 +1,5 @@
 import DS from 'ember-data';
 
-export default DS.JSONAPISerializer;
+const { JSONAPISerializer } = DS;
+
+export default JSONAPISerializer;

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 
+const { run } = Ember;
+
 export default function destroyApp(application) {
-  Ember.run(function() {
+  run(function() {
     application.destroy();
 
     server.shutdown();

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,13 +2,15 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
+const { merge, run } = Ember;
+
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(() => {
+  run(() => {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();


### PR DESCRIPTION
Upgrade is required when using the newest JSCS linter/executable.

ember-sauve 4.0 uses the 3.0 JSCS linter instead of the 2.x. with defaults the “esnext” and “verbose” option. This will continuously show an error in atom which this update fixes.

![screen shot 2016-11-25 at 14 59 50](https://cloud.githubusercontent.com/assets/226130/20627385/ef8b3224-b31f-11e6-973f-5bc1dcf38416.png)
