### PR TITLE
Typo fix: Remove errant "i" from subdirectory msg

### DIFF
--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -32,7 +32,7 @@ export default function(prefix) {
     let moduleParts = moduleName.split('/');
     let moduleType = moduleParts[moduleParts.length - 2];
     let moduleKey = moduleParts[moduleParts.length - 1];
-    assert(`Subdirectories under i${moduleType} are not supported`,
+    assert(`Subdirectories under ${moduleType} are not supported`,
                  moduleParts[moduleParts.length - 3] === 'mirage');
 
     if (moduleType === 'scenario') {


### PR DESCRIPTION
This removes the letter "i" from the message. It appears to be a typo that snuck in. (A previous version of this file doesn't have the i: https://github.com/samselikoff/ember-cli-mirage/blob/f95aa53262164953f70c970812d8462aa13feab2/addon/utils/read-modules.js#L32).