### PR TITLE
Add slice method to collections

### DIFF
--- a/addon/orm/collection.js
+++ b/addon/orm/collection.js
@@ -94,6 +94,19 @@ export default class Collection {
   }
 
   /**
+   * @method slice
+   * @param {Integer} begin
+   * @param {Integer} end
+   * @return {Collection}
+   * @public
+   */
+  slice(...args) {
+    let slicedModels = this.models.slice(...args);
+
+    return new Collection(this.modelName, slicedModels);
+  }
+
+  /**
    * @method mergeCollection
    * @param collection
    * @return this

--- a/tests/integration/orm/collection-test.js
+++ b/tests/integration/orm/collection-test.js
@@ -63,6 +63,17 @@ test('a collection can sort its models', function(assert) {
   assert.deepEqual(newCollection.models.map(m => m.name), ['Ganon', 'Link', 'Zelda']);
 });
 
+test('a collection can slice its models', function(assert) {
+  let collection = this.schema.users.all();
+  assert.deepEqual(collection.models.map(m => m.name), ['Link', 'Zelda', 'Ganon'], 'Starts with 3');
+
+  let newCollection = collection.slice(-2);
+
+  assert.ok(newCollection instanceof Collection);
+  assert.equal(newCollection.modelName, 'user', 'the sliced collection has the right type');
+  assert.deepEqual(newCollection.models.map(m => m.name), ['Zelda', 'Ganon']);
+});
+
 test('a collection can merge with another collection', function(assert) {
   let goodGuys = this.schema.users.where(user => user.good);
   let badGuys = this.schema.users.where(user => !user.good);


### PR DESCRIPTION
Adds slice method to collections. If someone else gets to a solution for proxying enumerable methods to Array and lodash first, great. But this would be helpful too.