### PR TITLE
include note about import path in an Ember addon

### DIFF
--- a/docs/v0.2.x/manually-starting-mirage.md
+++ b/docs/v0.2.x/manually-starting-mirage.md
@@ -21,3 +21,5 @@ moduleForComponent('your-component', 'Integration | Component | your component',
   }
 });
 ```
+
+If you are using Mirage in an Ember addon, you'll need to change the import path to `dummy/initializers/ember-cli-mirage`.


### PR DESCRIPTION
This bit me on a recent project. `import 'yourapp/initializers/ember-cli-mirage'` is not a valid path inside an ember addon. Needs to be:

```js
import { startMirage } from 'dummy/initializers/ember-cli-mirage';
```