### PR TITLE
[POC] Mirage on FastBoot with express

### DIFF
--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -21,7 +21,8 @@ export default {
 export function startMirage(env = ENV) {
   let environment = env.environment;
   let modules = readModules(env.modulePrefix);
-  let options = _assign(modules, {environment, baseConfig, testConfig});
+  let serverOptions = (env['ember-cli-mirage'] && env['ember-cli-mirage'].serverOptions) || {};
+  let options = _assign(modules, {environment, baseConfig, testConfig, serverOptions});
 
   return new Server(options);
 }

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = {
   },
 
   _shouldIncludeFiles: function() {
-    if (process.env.EMBER_CLI_FASTBOOT) { return false; }
+    if (process.env.EMBER_CLI_FASTBOOT && !process.env.FASTBOOT_LOAD_MIRAGE) { return false; }
     var enabledInProd = this.app.env === 'production' && this.addonConfig.enabled;
     var explicitExcludeFiles = this.addonConfig.excludeFilesFromBuild;
     if (enabledInProd && explicitExcludeFiles) {

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
     "faker": "^3.0.0",
     "pretender": "^1.4.2",
     "route-recognizer": "^0.2.3"
-  }
+  },
+  "fastbootDependencies": [
+    "express"
+  ]
 }


### PR DESCRIPTION
This is more a POC/RFC than a PR to be merge.

The idea is that in fastboot mode we can start a [express](http://expressjs.com/) server instead of pretender to respond to backend requests during development/testing. (Disclaimer: I'm newbie so not sure if this all makes sense.)

Issues/changes:
1. replace pretender with express - this looks more or less straightforward see the [PR](https://github.com/samselikoff/ember-cli-mirage/pull/975/files#diff-3da129bcd0b0367d1b65b28e9ecc34c9R22)
2. unlike normal mode we want an express server once which will be shared across ember app instances, as fastboot creates one instance of app for each request. I'm using a hack like this [instance-initializers/fastboot/start-mirage.js](https://github.com/mfazekas/fastboot-mirage-test/blob/master/app/instance-initializers/fastboot/start-mirage.js) to get it started just once.
3. I need to disable regular pretender based mirage which would be per instance. I'm using an env var, in [config/environment.js](https://github.com/mfazekas/fastboot-mirage-test/blob/master/config/environment.js#L29-L32)
   ```es6
   if (process.env.FASTBOOT) {
      ENV['ember-cli-mirage'] = { enabled: false };
   }
   ```
4. I need to point ember data to the express instance started. I'm using an env var: `FASTBOOT_MIRAGE_PORT` for that. In [config/environment.js](https://github.com/mfazekas/fastboot-mirage-test/blob/master/config/environment.js#L33-L37) i do 
   ```es6
   if (process.env.FASTBOOT_MIRAGE_PORT) {
      let port = parseInt(process.env.FASTBOOT_MIRAGE_PORT);
      ENV['ember-cli-mirage'].fastbootGlobal = { port };
      config.api_host = `http://localhost:${port}`
    }
   ```
   then in [app/adapters/application.js](https://github.com/mfazekas/fastboot-mirage-test/blob/master/app/adapters/application.js#L6) i do
   ```
   export default DS.JSONAPIAdapter.extend({
      namespace: 'api',
      host: config.api_host || '...'
   });
   ```
5. App needs to be started with an env vars like: 
```sh
FASTBOOT=1 FASTBOOT_MIRAGE_PORT=1234 FASTBOOT_LOAD_MIRAGE=1 ember fastboot --serve-assets
```

The result is an ember app running in fastboot served by mirage. See https://github.com/mfazekas/fastboot-mirage-test for working example

