### PR TITLE
implementing subdirectories - Fixes #540

### DIFF
--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -5,8 +5,7 @@
 'use strict';
 
 import Ember from 'ember';
-import _camelCase from 'lodash/string/camelCase';
-import { pluralize } from 'ember-cli-mirage/utils/inflector';
+import { pluralize, camelize } from 'ember-cli-mirage/utils/inflector';
 
 const { assert } = Ember;
 
@@ -30,10 +29,8 @@ export default function(prefix) {
       return;
     }
     let moduleParts = moduleName.split('/');
-    let moduleType = moduleParts[moduleParts.length - 2];
-    let moduleKey = moduleParts[moduleParts.length - 1];
-    assert(`Subdirectories under ${moduleType} are not supported`,
-                 moduleParts[moduleParts.length - 3] === 'mirage');
+    let [, , moduleType, ...moduleKeyParts] = moduleParts;
+    let moduleKey = moduleKeyParts.join('/');
 
     if (moduleType === 'scenario') {
       assert('Only scenario/default.js is supported at this time.',
@@ -54,7 +51,7 @@ export default function(prefix) {
 
     let data = module['default'];
 
-    modulesMap[moduleType][_camelCase(moduleKey)] = data;
+    modulesMap[moduleType][camelize(moduleKey)] = data;
   });
 
   return modulesMap;

--- a/tests/acceptance/fixtures-test.js
+++ b/tests/acceptance/fixtures-test.js
@@ -35,3 +35,14 @@ test('I can use fixtures with the filename api', function(assert) {
   });
 });
 
+test('I can use fixtures with subdirectories', function(assert) {
+  server.loadFixtures();
+
+  visit(`/user/profile`);
+
+  andThen(() => {
+    let userProfilesInStore = this.store.peekAll('user/profile');
+
+    assert.equal(userProfilesInStore.get('length'), 3);
+  });
+});

--- a/tests/dummy/app/models/user/profile.js
+++ b/tests/dummy/app/models/user/profile.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+const { Model, attr } = DS;
+
+export default Model.extend({
+
+  name: attr()
+
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -18,4 +18,8 @@ Router.map(function() {
   this.route('pets');
 
   this.route('word-smith', { path: '/word-smiths/:word_smith_id' });
+
+  this.route('user', function() {
+    this.route('profile');
+  });
 });

--- a/tests/dummy/app/routes/user/profile.js
+++ b/tests/dummy/app/routes/user/profile.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+
+  model() {
+    let store = this.get('store');
+    return store.findAll('user/profile');
+  }
+
+});

--- a/tests/dummy/app/serializers/user/profile.js
+++ b/tests/dummy/app/serializers/user/profile.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+const { JSONAPISerializer } = DS;
+
+export default JSONAPISerializer;

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -40,6 +40,19 @@ export default function() {
 
   this.get('/word-smiths/:id');
 
+  this.get('/user/profiles', function(db, request) {
+    let things = db['user/profiles'].all();
+
+    return {
+      data: things.models.map((thing) => {
+        return {
+          id: thing.id,
+          name: thing.name,
+          type: thing.modelName
+        };
+      })
+    };
+  });
 }
 
 export function testConfig() {

--- a/tests/dummy/mirage/fixtures/user/profiles.js
+++ b/tests/dummy/mirage/fixtures/user/profiles.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    id: 1,
+    name: 'Lorem'
+  },
+  {
+    id: 2,
+    name: 'Ipsum'
+  },
+  {
+    id: 3,
+    name: 'Dolor'
+  }
+];

--- a/tests/dummy/mirage/models/user/profile.js
+++ b/tests/dummy/mirage/models/user/profile.js
@@ -1,0 +1,5 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+
+});


### PR DESCRIPTION
Howdy 👋 

I ran across the same issue described in https://github.com/samselikoff/ember-cli-mirage/issues/540 and have essentially attempted to implement the tests requested in the closed pull request https://github.com/samselikoff/ember-cli-mirage/pull/780 (the implementation is almost exactly the same as @jrhe initially implemented)

This essentially works but if you take a look at the mirage config you can see that I have had to do some pretty awful stuff to make it work 😭 

I'm not entirely sure where to go from here. Ideally, I would like to use the cleaner helper API for the config like this `this.get('/user/profiles');` and for it to *"know"* that it is supposed to use the 'user/profiles' model. 

Any suggestions you have on how to proceed would be appreciated. 