### PR TITLE
feat(Lodash): adapting to use lodash 4 using latest ember-lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ Update notes:
 
     ```js
     let usersCollection = schema.users.all();
-    let uniqueUsers = _.uniq(usersCollection.models, u => u.firstName);
+    let uniqueUsers = _.uniqBy(usersCollection.models, 'firstName');
     ```
 
     - Collection no longer attempts to mimic an array. This turned out to be confusing, since you can't really subclass arrays in JavaScript, and it would sometimes be compatible with functions that operate on arrays, but sometimes not.

--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -1,6 +1,7 @@
-import _assign from 'lodash/object/assign';
-import _isEqual from 'lodash/lang/isEqual';
-import _sortBy from 'lodash/collection/sortBy';
+import _assign from 'lodash/assign';
+import _map from 'lodash/map';
+import _isEqual from 'lodash/isEqual';
+import _sortBy from 'lodash/sortBy';
 
 function duplicate(data) {
   if (Array.isArray(data)) {
@@ -53,7 +54,8 @@ class DbCollection {
       return this._insertRecord(data);
     } else {
       // Need to sort in order to ensure IDs inserted in the correct order
-      return _sortBy(data, 'id').map(this._insertRecord, this);
+      let sorted = _sortBy(data, 'id');
+      return _map(sorted, (x) => this._insertRecord(x));
     }
   }
 

--- a/addon/factory.js
+++ b/addon/factory.js
@@ -1,8 +1,8 @@
-import _assign from 'lodash/object/assign';
-import _isFunction from 'lodash/lang/isFunction';
-import _mapValues from 'lodash/object/mapValues';
+import _assign from 'lodash/assign';
+import _isFunction from 'lodash/isFunction';
+import _mapValues from 'lodash/mapValues';
 import referenceSort from './utils/reference-sort';
-import _isPlainObject from 'lodash/lang/isPlainObject';
+import _isPlainObject from 'lodash/isPlainObject';
 
 let Factory = function() {
   this.build = function(sequence) {

--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -1,5 +1,5 @@
 import Association from './association';
-import _assign from 'lodash/object/assign';
+import _assign from 'lodash/assign';
 import { capitalize, camelize } from 'ember-cli-mirage/utils/inflector';
 import { toCollectionName } from 'ember-cli-mirage/utils/normalize-name';
 import assert from 'ember-cli-mirage/assert';

--- a/addon/orm/associations/has-many.js
+++ b/addon/orm/associations/has-many.js
@@ -1,8 +1,8 @@
 // jscs:disable requireParenthesesAroundArrowParam
 import Association from './association';
 import Collection from '../collection';
-import _assign from 'lodash/object/assign';
-import _compact from 'lodash/array/compact';
+import _assign from 'lodash/assign';
+import _compact from 'lodash/compact';
 import { capitalize, camelize, singularize } from 'ember-cli-mirage/utils/inflector';
 import { toCollectionName } from 'ember-cli-mirage/utils/normalize-name';
 import assert from 'ember-cli-mirage/assert';

--- a/addon/orm/collection.js
+++ b/addon/orm/collection.js
@@ -1,4 +1,4 @@
-import _invoke from 'lodash/collection/invoke';
+import _invokeMap from 'lodash/invokeMap';
 import assert from '../assert';
 
 /**
@@ -39,7 +39,7 @@ export default class Collection {
    * @public
    */
   update(...args) {
-    _invoke(this.models, 'update', ...args);
+    _invokeMap(this.models, 'update', ...args);
 
     return this;
   }
@@ -51,7 +51,7 @@ export default class Collection {
    * @public
    */
   destroy() {
-    _invoke(this.models, 'destroy');
+    _invokeMap(this.models, 'destroy');
 
     return this;
   }
@@ -63,7 +63,7 @@ export default class Collection {
    * @public
    */
   save() {
-    _invoke(this.models, 'save');
+    _invokeMap(this.models, 'save');
 
     return this;
   }
@@ -75,7 +75,7 @@ export default class Collection {
    * @public
    */
   reload() {
-    _invoke(this.models, 'reload');
+    _invokeMap(this.models, 'reload');
 
     return this;
   }

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -2,8 +2,8 @@ import { pluralize, camelize, dasherize } from '../utils/inflector';
 import { toCollectionName, toModelName } from 'ember-cli-mirage/utils/normalize-name';
 import Association from './associations/association';
 import Collection from './collection';
-import _forIn from 'lodash/object/forIn';
-import _includes from 'lodash/collection/includes';
+import _forIn from 'lodash/forIn';
+import _includes from 'lodash/includes';
 import assert from '../assert';
 
 /**

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -6,7 +6,7 @@ import JsonApiSerializer from 'ember-cli-mirage/serializers/json-api-serializer'
 import { pluralize, camelize } from './utils/inflector';
 import assert from './assert';
 
-import _assign from 'lodash/object/assign';
+import _assign from 'lodash/assign';
 
 export default class SerializerRegistry {
 

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -3,12 +3,12 @@ import Collection from './orm/collection';
 import extend from './utils/extend';
 import { singularize, pluralize, camelize } from './utils/inflector';
 
-import _isFunction from 'lodash/lang/isFunction';
-import _isArray from 'lodash/lang/isArray';
-import _isEmpty from 'lodash/lang/isEmpty';
-import _includes from 'lodash/collection/includes';
-import _assign from 'lodash/object/assign';
-import _get from 'lodash/object/get';
+import _isFunction from 'lodash/isFunction';
+import _isArray from 'lodash/isArray';
+import _isEmpty from 'lodash/isEmpty';
+import _includes from 'lodash/includes';
+import _assign from 'lodash/assign';
+import _get from 'lodash/get';
 import _ from 'lodash';
 
 class Serializer {
@@ -116,7 +116,7 @@ class Serializer {
         })
         .flatten()
         .compact()
-        .uniq(m => m.toString())
+        .uniqBy(m => m.toString())
         .value();
 
       return [ hash, addToIncludes ];

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -1,7 +1,7 @@
 import Serializer from '../serializer';
 import { dasherize, pluralize, camelize } from '../utils/inflector';
 
-import _get from 'lodash/object/get';
+import _get from 'lodash/get';
 import _ from 'lodash';
 
 export default Serializer.extend({
@@ -83,7 +83,7 @@ export default Serializer.extend({
     return _(includes)
       .flatten()
       .compact()
-      .uniq(m => m.toString())
+      .uniqBy(m => m.toString())
       .value();
   },
 

--- a/addon/server.js
+++ b/addon/server.js
@@ -11,10 +11,10 @@ import assert from './assert';
 import SerializerRegistry from './serializer-registry';
 import RouteHandler from './route-handler';
 
-import _pick from 'lodash/object/pick';
-import _assign from 'lodash/object/assign';
-import _find from 'lodash/collection/find';
-import _isPlainObject from 'lodash/lang/isPlainObject';
+import _pick from 'lodash/pick';
+import _assign from 'lodash/assign';
+import _find from 'lodash/find';
+import _isPlainObject from 'lodash/isPlainObject';
 
 const { RSVP: { Promise } } = Ember;
 

--- a/addon/utils/extend.js
+++ b/addon/utils/extend.js
@@ -1,5 +1,5 @@
-import _assign from 'lodash/object/assign';
-import _has from 'lodash/object/has';
+import _assign from 'lodash/assign';
+import _has from 'lodash/has';
 
 export default function(protoProps, staticProps) {
   let parent = this;

--- a/addon/utils/is-association.js
+++ b/addon/utils/is-association.js
@@ -1,4 +1,4 @@
-import _isPlainObject from 'lodash/lang/isPlainObject';
+import _isPlainObject from 'lodash/isPlainObject';
 
 export default function(object) {
   return _isPlainObject(object) && object.__isAssociation__ === true;

--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -5,7 +5,7 @@
 'use strict';
 
 import Ember from 'ember';
-import _camelCase from 'lodash/string/camelCase';
+import _camelCase from 'lodash/camelCase';
 import { pluralize } from 'ember-cli-mirage/utils/inflector';
 
 const { assert } = Ember;

--- a/addon/utils/reference-sort.js
+++ b/addon/utils/reference-sort.js
@@ -1,6 +1,6 @@
 // jscs:disable disallowVar, requireArrayDestructuring
-import _uniq from 'lodash/array/uniq';
-import _flatten from 'lodash/array/flatten';
+import _uniq from 'lodash/uniq';
+import _flatten from 'lodash/flatten';
 
 export default function(edges) {
   var nodes = _uniq(_flatten(edges));

--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -2,7 +2,7 @@ import readModules from 'ember-cli-mirage/utils/read-modules';
 import ENV from '../config/environment';
 import baseConfig, { testConfig } from '../mirage/config';
 import Server from 'ember-cli-mirage/server';
-import _assign from 'lodash/object/assign';
+import _assign from 'lodash/assign';
 
 export default {
   name: 'ember-cli-mirage',

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "ember-suave": "4.0.0",
     "ember-try": "~0.0.8",
     "loader.js": "^4.0.0",
-    "lodash": "3.10.1",
     "mocha": "^2.1.0"
   },
   "keywords": [
@@ -71,7 +70,7 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-node-assets": "^0.1.4",
     "ember-inflector": "^1.9.2",
-    "ember-lodash": "0.0.9",
+    "ember-lodash": "^4.0",
     "exists-sync": "0.0.3",
     "fake-xml-http-request": "^1.4.0",
     "faker": "^3.0.0",

--- a/tests/integration/route-handlers/function-handler-test.js
+++ b/tests/integration/route-handlers/function-handler-test.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 import Server from 'ember-cli-mirage/server';
 import Response from 'ember-cli-mirage/response';
 import FunctionRouteHandler from 'ember-cli-mirage/route-handlers/function';
-import _uniq from 'lodash/array/uniq';
+import _uniqBy from 'lodash/uniqBy';
 
 const { RSVP: { Promise } } = Ember;
 
@@ -139,7 +139,7 @@ test('#serialize noops on plain JS arrays', function(assert) {
   this.server.schema.users.create({ name: 'Ganondorf' });
 
   let users = this.schema.users.all().models;
-  let uniqueNames = _uniq(users, u => u.name);
+  let uniqueNames = _uniqBy(users, 'name');
   let serializedResponse = this.functionHandler.serialize(uniqueNames);
 
   assert.deepEqual(serializedResponse, uniqueNames);
@@ -151,7 +151,7 @@ test('#serialize on a Collection takes an optional serializer type', function(as
   this.server.schema.users.create({ name: 'Ganondorf', tall: true, evil: true });
 
   let users = this.schema.users.all().models;
-  let uniqueNames = _uniq(users, u => u.name);
+  let uniqueNames = _uniqBy(users, 'name');
   let collection = new Collection('user', uniqueNames);
   let json = this.functionHandler.serialize(collection, 'sparse-user');
 

--- a/tests/integration/serializers/base/basic-test.js
+++ b/tests/integration/serializers/base/basic-test.js
@@ -2,7 +2,7 @@ import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
 import schemaHelper from '../schema-helper';
 import { module, test } from 'qunit';
 
-import _uniq from 'lodash/array/uniq';
+import _uniqBy from 'lodash/uniqBy';
 
 module('Integration | Serializers | Base | Basic', {
   beforeEach() {
@@ -79,7 +79,7 @@ test('it returns POJAs of models unaffected', function(assert) {
   this.schema.wordSmiths.create({ name: 'Ganondorf' });
 
   let wordSmiths = this.schema.wordSmiths.all().models;
-  let uniqueNames = _uniq(wordSmiths, u => u.name);
+  let uniqueNames = _uniqBy(wordSmiths, 'name');
   let result = this.registry.serialize(uniqueNames);
 
   assert.deepEqual(result, uniqueNames);


### PR DESCRIPTION
adapted:
- load patterns (lodash4 uses `lodash/function` instead of `lodash/category/function`
- `uniq` to `uniqBy` using shorthands.
- `map` does not have a context anymore, changed for a 2 step sort + mapped insertion
- `invoke` to `invokeMap` when applied to a collection