### PR TITLE
Make host/namespace support more robust

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -510,7 +510,51 @@ export default class Server {
     path = path[0] === '/' ? path.slice(1) : path;
     let fullPath = '';
     let urlPrefix = this.urlPrefix ? this.urlPrefix.trim() : '';
-    let namespace = this.namespace ? this.namespace.trim() : '';
+    let namespace = '';
+
+    // if there is a urlPrefix and a namespace
+    if (this.urlPrefix && this.namespace) {
+      if (this.namespace[0] === '/' && this.namespace[this.namespace.length - 1] === '/') {
+        namespace = this.namespace.substring(0, this.namespace.length - 1).substring(1);
+      }
+
+      if (this.namespace[0] === '/' &&  this.namespace[this.namespace.length - 1] !== '/') {
+        namespace = this.namespace.substring(1);
+      }
+
+      if (this.namespace[0] !== '/' &&  this.namespace[this.namespace.length - 1] === '/') {
+        namespace = this.namespace.substring(0, this.namespace.length - 1);
+      }
+
+      if (this.namespace[0] !== '/' &&  this.namespace[this.namespace.length - 1] !== '/') {
+        namespace = this.namespace;
+      }
+    }
+
+    // if there is a namespace and no urlPrefix
+    if (this.namespace && !this.urlPrefix) {
+      if (this.namespace[0] === '/' && this.namespace[this.namespace.length - 1] === '/') {
+        namespace = this.namespace.substring(0, this.namespace.length - 1);
+      }
+
+      if (this.namespace[0] === '/' &&  this.namespace[this.namespace.length - 1] !== '/') {
+        namespace = this.namespace;
+      }
+
+      if (this.namespace[0] !== '/' &&  this.namespace[this.namespace.length - 1] === '/') {
+        let namespaceSub = this.namespace.substring(0, this.namespace.length - 1);
+        namespace = `/${namespaceSub}`;
+      }
+
+      if (this.namespace[0] !== '/' &&  this.namespace[this.namespace.length - 1] !== '/') {
+        namespace = `/${this.namespace}`;
+      }
+    }
+
+    // if no namespace
+    if (!this.namespace) {
+      namespace = '';
+    }
 
     // check to see if path is a FQDN. if so, ignore any urlPrefix/namespace that was set
     if (/^https?:\/\//.test(path)) {

--- a/tests/integration/server/get-full-path-test.js
+++ b/tests/integration/server/get-full-path-test.js
@@ -1,0 +1,98 @@
+import {module, test} from 'qunit';
+import Server from 'ember-cli-mirage/server';
+
+module('Integration | Server | Get full path', {
+  beforeEach() {
+    this.server = new Server({
+      environment: 'test'
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+  },
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+test('it works with a configured namespace with a leading slash', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.namespace = '/api';
+
+  assert.equal(server._getFullPath('/contacts'), '/api/contacts');
+});
+
+test('it works with a configured namespace with a trailing slash', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.namespace = 'api/';
+
+  assert.equal(server._getFullPath('/contacts'), '/api/contacts');
+});
+
+test('it works with a configured namespace without a leading slash', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.namespace = 'api';
+
+  assert.equal(server._getFullPath('/contacts'), '/api/contacts');
+});
+
+test('it works with a configured namespace is an empty string', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.namespace = '';
+
+  assert.equal(server._getFullPath('/contacts'), '/contacts');
+});
+
+test('it works with a configured urlPrefix with a trailing slash', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.urlPrefix = 'http://localhost:3000/';
+
+  assert.equal(server._getFullPath('/contacts'), 'http://localhost:3000/contacts');
+});
+
+test('it works with a configured urlPrefix without a trailing slash', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.urlPrefix = 'http://localhost:3000';
+
+  assert.equal(server._getFullPath('/contacts'), 'http://localhost:3000/contacts');
+});
+
+test('it works with a configured urlPrefix as an empty string', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.urlPrefix = '';
+
+  assert.equal(server._getFullPath('/contacts'), '/contacts');
+});
+
+test('it works with a configured namespace and a urlPrefix', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.namespace = 'api';
+  server.urlPrefix = 'http://localhost:3000';
+
+  assert.equal(server._getFullPath('/contacts'), 'http://localhost:3000/api/contacts');
+});
+
+test('it works with a configured namespace with a leading slash and a urlPrefix', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.namespace = '/api';
+  server.urlPrefix = 'http://localhost:3000';
+
+  assert.equal(server._getFullPath('/contacts'), 'http://localhost:3000/api/contacts');
+});
+
+test('it works with a configured namespace and a urlPrefix as empty strings', function(assert) {
+  assert.expect(1);
+  let { server } = this;
+  server.namespace = '';
+  server.urlPrefix = '';
+
+  assert.equal(server._getFullPath('/contacts'), '/contacts');
+});


### PR DESCRIPTION
Fixes issue #901. 

Adds tests to reproduce issues brought up in issue #901 and makes them pass. These test for 4 conditions for different namespace and urlPrefix inputs

1. with a leading slash
2. without a leading slash
3. with a trailing slash
4. as empty strings

Any feedback is welcome.