### PR TITLE
Add documentation for findBy

### DIFF
--- a/docs/v0.2.x/models.md
+++ b/docs/v0.2.x/models.md
@@ -93,7 +93,7 @@ let posts = blogPosts.find([1, 3, 4]);
 
 ### findBy(*query*)
 
-Returns the first model in the database that matches the key-value pairs in the `query` object. Note that a string comparison is used. `query` is a POJO.
+Returns the first model in the database that matches the key-value pairs in the `query` object. Note that a string comparison is used.
 
 ```js
 let post = blogPosts.findBy({ published: true });
@@ -109,7 +109,7 @@ let post = blogPosts.first();
 
 ### where(*query*)
 
-Return an array of models in the database matching the key-value pairs in *query*. Note that a string comparison is used. `query` is a POJO.
+Return an array of models in the database matching the key-value pairs in *query*. Note that a string comparison is used.
 
 ```js
 let posts = blogPosts.where({ published: true });

--- a/docs/v0.2.x/models.md
+++ b/docs/v0.2.x/models.md
@@ -96,7 +96,7 @@ let posts = blogPosts.find([1, 3, 4]);
 Returns the first model in the database that matches the key-value pairs in the `query` object. Note that a string comparison is used. `query` is a POJO.
 
 ```js
-let posts = blogPosts.where({ published: true });
+let post = blogPosts.findBy({ published: true });
 ```
 
 ### first()

--- a/docs/v0.2.x/models.md
+++ b/docs/v0.2.x/models.md
@@ -91,6 +91,14 @@ let post = blogPosts.find(1);
 let posts = blogPosts.find([1, 3, 4]);
 ```
 
+### findBy(*query*)
+
+Returns the first model in the database that matches the key-value pairs in the `query` object. Note that a string comparison is used. `query` is a POJO.
+
+```js
+let posts = blogPosts.where({ published: true });
+```
+
 ### first()
 
 Returns the first model in the database.
@@ -101,7 +109,7 @@ let post = blogPosts.first();
 
 ### where(*query*)
 
-Return an array of models in the database matching the key-value pairs in *query*.
+Return an array of models in the database matching the key-value pairs in *query*. Note that a string comparison is used. `query` is a POJO.
 
 ```js
 let posts = blogPosts.where({ published: true });


### PR DESCRIPTION
TIL mirage has `findBy`, and I can stop writing `users.where({ username }).models[0]` 😜