### PR TITLE
Mirage as express middleware

### DIFF
--- a/addon/.jshintrc
+++ b/addon/.jshintrc
@@ -1,0 +1,3 @@
+{
+  "esnext" : true
+}

--- a/addon/interceptors/create-express-middleware.js
+++ b/addon/interceptors/create-express-middleware.js
@@ -1,0 +1,52 @@
+class ExpressRouteHandler {
+  constructor(router) {
+    this.router = router;
+    this.passthrough = {};
+  }
+  handle(type, path, promise) {
+    if (promise === this.passthrough) {
+      this.router[type](path, (req, res, next) => {
+        next();
+      });
+    } else {
+      this.router[type](path,
+        (req, res) => {
+          promise(req).then((responseArray) => {
+            let [ code, headers, response ] = responseArray;
+            let allowAccessFromOnceFastbootLoadedJS = { 'Access-Control-Allow-Origin': '*' };
+            res.status(code).set(allowAccessFromOnceFastbootLoadedJS).set(headers).send(response);
+          });
+        });
+    }
+  }
+  get(path, promise) {
+    this.handle('get', path, promise);
+  }
+  post(path, promise) {
+    this.handle('post', path, promise);
+  }
+  put(path, promise) {
+    this.handle('put', path, promise);
+  }
+  delete(path, promise) {
+    this.handle('delete', path, promise);
+  }
+  patch(path, promise) {
+    this.handle('patch', path, promise);
+  }
+  shutdown() {}
+}
+
+/**
+ * Creates a new Express Interceptro handling requests throught and express router.
+ *
+ * @method createExpressInterceptor
+ * @param {Server} server
+ * @return {Object} Express router to install routes to
+ * @public
+ */
+function createExpressInterceptor(server, router) {
+  return new ExpressRouteHandler(router);
+}
+
+export default createExpressInterceptor;

--- a/addon/interceptors/create-pretender.js
+++ b/addon/interceptors/create-pretender.js
@@ -1,0 +1,52 @@
+/* eslint no-console: 0 */
+
+import Pretender from 'pretender';
+import assert from '../assert';
+
+/**
+ * Creates a new Pretender instance.
+ *
+ * @method createPretender
+ * @param {Server} server
+ * @return {Object} A new Pretender instance.
+ * @public
+ */
+function createPretender(server) {
+  let pretender = new Pretender(function() {
+    this.passthroughRequest = function(verb, path, request) {
+      if (server.shouldLog()) {
+        console.log(`Passthrough request: ${verb.toUpperCase()} ${request.url}`);
+      }
+    };
+
+    this.handledRequest = function(verb, path, request) {
+      if (server.shouldLog()) {
+        console.log(`Mirage: [${request.status}] ${verb.toUpperCase()} ${request.url}`);
+        let { responseText } = request;
+        let loggedResponse;
+
+        try {
+          loggedResponse = JSON.parse(responseText);
+        } catch(e) {
+          loggedResponse = responseText;
+        }
+
+        console.log(loggedResponse);
+      }
+    };
+
+    this.unhandledRequest = function(verb, path) {
+      path = decodeURI(path);
+      assert(
+        `Your Ember app tried to ${verb} '${path}',
+         but there was no route defined to handle this request.
+         Define a route that matches this path in your
+         mirage/config.js file. Did you forget to add your namespace?`
+      );
+    };
+  });
+  server.pretender = pretender;
+  return pretender;
+}
+
+export default createPretender;

--- a/addon/server.js
+++ b/addon/server.js
@@ -4,12 +4,12 @@ import { pluralize, camelize } from './utils/inflector';
 import { toCollectionName } from 'ember-cli-mirage/utils/normalize-name';
 import Ember from 'ember';
 import isAssociation from 'ember-cli-mirage/utils/is-association';
-import Pretender from 'pretender';
 import Db from './db';
 import Schema from './orm/schema';
 import assert from './assert';
 import SerializerRegistry from './serializer-registry';
 import RouteHandler from './route-handler';
+import createPretender from './interceptors/create-pretender';
 
 import _pick from 'lodash/pick';
 import _assign from 'lodash/assign';
@@ -19,48 +19,12 @@ import _isInteger from 'lodash/isInteger';
 
 const { RSVP: { Promise } } = Ember;
 
-/**
- * Creates a new Pretender instance.
- *
- * @method createPretender
- * @param {Server} server
- * @return {Object} A new Pretender instance.
- * @public
- */
-function createPretender(server) {
-  return new Pretender(function() {
-    this.passthroughRequest = function(verb, path, request) {
-      if (server.shouldLog()) {
-        console.log(`Passthrough request: ${verb.toUpperCase()} ${request.url}`);
-      }
-    };
-
-    this.handledRequest = function(verb, path, request) {
-      if (server.shouldLog()) {
-        console.log(`Mirage: [${request.status}] ${verb.toUpperCase()} ${request.url}`);
-        let { responseText } = request;
-        let loggedResponse;
-
-        try {
-          loggedResponse = JSON.parse(responseText);
-        } catch(e) {
-          loggedResponse = responseText;
-        }
-
-        console.log(loggedResponse);
-      }
-    };
-
-    this.unhandledRequest = function(verb, path) {
-      path = decodeURI(path);
-      assert(
-        `Your Ember app tried to ${verb} '${path}',
-         but there was no route defined to handle this request.
-         Define a route that matches this path in your
-         mirage/config.js file. Did you forget to add your namespace?`
-      );
-    };
-  });
+function createInterceptor(server) {
+  if (server.options.createInterceptor) {
+    return server.options.createInterceptor(server);
+  } else {
+    return createPretender(server);
+  }
 }
 
 const defaultRouteOptions = {
@@ -168,7 +132,7 @@ export default class Server {
     let hasFactories = this._hasModulesOfType(config, 'factories');
     let hasDefaultScenario = config.scenarios && config.scenarios.hasOwnProperty('default');
 
-    this.pretender = this.pretender || createPretender(this);
+    this.interceptor = this.interceptor || createInterceptor(this);
 
     if (config.baseConfig) {
       this.loadConfig(config.baseConfig);
@@ -255,7 +219,7 @@ export default class Server {
     verbs.forEach((verb) => {
       paths.forEach((path) => {
         let fullPath = this._getFullPath(path);
-        this.pretender[verb](fullPath, this.pretender.passthrough);
+        this.interceptor[verb](fullPath, this.interceptor.passthrough);
       });
     });
   }
@@ -409,7 +373,7 @@ export default class Server {
   }
 
   shutdown() {
-    this.pretender.shutdown();
+    this.interceptor.shutdown();
     if (this.environment === 'test') {
       window.server = undefined;
     }
@@ -481,7 +445,7 @@ export default class Server {
     let fullPath = this._getFullPath(path);
     let timing = options.timing !== undefined ? options.timing : (() => this.timing);
 
-    this.pretender[verb](
+    this.interceptor[verb](
       fullPath,
       (request) => {
         return new Promise(resolve => {

--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -38,7 +38,7 @@ function _shouldUseMirage(env, addonConfig) {
   to initialize Mirage.
 */
 function _defaultEnabled(env, addonConfig) {
-  let usingInDev = env === 'development' && !addonConfig.usingProxy;
+  let usingInDev = env === 'development' && !addonConfig.usingProxy && !addonConfig.useExpress;
   let usingInTest = env === 'test';
 
   return usingInDev || usingInTest;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,49 @@ var path = require('path');
 var mergeTrees = require('broccoli-merge-trees');
 var Funnel = require('broccoli-funnel');
 
+function toNodeJSBuilder(projectRoot, mirageDirectory) {
+  var esTranspiler = require('broccoli-babel-transpiler');
+  var broccoli = require('broccoli-builder');
+
+  var appEnvPath = path.join(projectRoot, 'config', 'environment.js');
+  var appEnv = require(appEnvPath);
+
+  var emberCliMiragePath = __dirname;
+  var mirageAddon = new Funnel(emberCliMiragePath, {srcDir: 'addon', destDir: 'ember-cli-mirage'});
+  var appMirageSrc = new Funnel(mirageDirectory, {srcDir:'.', destDir: 'mirage'});
+  var nodejsSrc = new Funnel(emberCliMiragePath, {srcDir:'nodejs', destDir: 'nodejs'});
+  var combinedSrcTree = mergeTrees([mirageAddon, nodejsSrc, appMirageSrc]);
+  var transpiledTree = esTranspiler(combinedSrcTree, {
+    browserPolyfill: true,
+    resolveModuleSource: function(source, filename) {
+      var result = source;
+      var result_abs;
+
+      var dirname = path.dirname(path.join(transpiledTree.outputPath,filename));
+      if (source === 'ember') {
+        result_abs = path.join(transpiledTree.outputPath,'nodejs/ember-compat');
+      } else if (source === 'pretender') {
+        result_abs = path.join(transpiledTree.outputPath,'nodejs/no-pretender');
+      } else if (source.startsWith('ember-cli-mirage/')) {
+        result_abs = path.join(transpiledTree.outputPath,source);
+      } else if (source.startsWith('../mirage/')) {
+        result_abs = path.join(transpiledTree.outputPath,'na',source);
+      } else if (source === '../config/environment') {
+        result = appEnvPath;
+      }
+      if (result_abs) {
+        result = path.relative(dirname, result_abs);
+        if (!(result.startsWith('../') || result.startsWith('./'))) {
+          result = './' + result;
+        }
+      }
+      return result;
+    }
+  });
+  var builder = new broccoli.Builder(transpiledTree);
+  return { builder, appEnv };
+}
+
 module.exports = {
   name: 'ember-cli-mirage',
 
@@ -16,6 +59,34 @@ module.exports = {
       'fake-xml-http-request': npmAsset('fake_xml_http_request.js'),
       'pretender': npmAsset('pretender.js'),
       'faker': npmAsset('build/build/faker.js')
+    }
+  },
+
+  loadMirageToNode: function(router) {
+    var { builder, appEnv } = toNodeJSBuilder(this.app.project.root, this.mirageDirectory);
+    builder.build().then(function(output) {
+      var startExpressServer = require(path.join(output.directory,'nodejs/start-express-server.js'));
+      var res = startExpressServer(router, appEnv);
+    }).catch(function(err) {
+      console.log('Error during build for node.js:', err);
+    }).finally(function() {
+      console.log('Build for node.js finished!');
+    });
+  },
+
+  serverMiddleware: function(options) {
+    if (this.addonConfig.useExpress) {
+      this.expressRouter = require('express').Router();
+      var router = this.expressRouter;
+      var app = options.app;
+      app.use(router);
+    }
+  },
+
+  postBuild: function(result) {
+    if (this.expressRouter) {
+      this.expressRouter.stack = [];
+      this.loadMirageToNode(this.expressRouter);
     }
   },
 

--- a/nodejs/.jshintrc
+++ b/nodejs/.jshintrc
@@ -1,0 +1,3 @@
+{
+  "esnext" : true
+}

--- a/nodejs/ember-compat.js
+++ b/nodejs/ember-compat.js
@@ -1,0 +1,34 @@
+import RSVP from 'rsvp';
+
+const TYPE_MAP = {
+  '[object Boolean]': 'boolean',
+  '[object Number]': 'number',
+  '[object String]': 'string',
+  '[object Function]': 'function',
+  '[object Array]': 'array',
+  '[object Date]': 'date',
+  '[object RegExp]': 'regexp',
+  '[object Object]': 'object',
+  '[object FileList]': 'filelist'
+};
+
+export default {
+  String: {
+    capitalize: "",
+    camelize: "",
+    dasherize: "",
+    underscore: ""
+  },
+  RSVP: { Promise: RSVP.Promise },
+  isBlank: "",
+  typeOf: function(item) {
+    if (item === null) {
+      return 'null';
+    }
+    if (item === undefined) {
+      return 'undefined';
+    }
+    let ret = TYPE_MAP[toString.call(item)] || 'object';
+    return ret;
+  }
+};

--- a/nodejs/no-pretender.js
+++ b/nodejs/no-pretender.js
@@ -1,0 +1,3 @@
+// we're not going to use pretender in node.js but we still need to make `import "pretender"` work
+export default {
+};

--- a/nodejs/start-express-server.js
+++ b/nodejs/start-express-server.js
@@ -1,0 +1,19 @@
+import ENV from '../config/environment';
+import baseConfig, { testConfig } from '../mirage/config';
+import Server from 'ember-cli-mirage/server';
+import createExpressMiddleware from 'ember-cli-mirage/interceptors/create-express-middleware';
+import _assign from 'lodash/assign';
+
+function startMirage(env, createInterceptor) {
+  let environment = env.environment;
+  let options = _assign({}, {environment, baseConfig, testConfig});
+
+  return new Server(Object.assign({createInterceptor: createInterceptor}, options));
+}
+
+export default function(router, env) {
+  var createInterceptor = function(server) {
+    return createExpressMiddleware(server, router);
+  };
+  startMirage(env, createInterceptor);
+}


### PR DESCRIPTION
This PR adds the option to use express instead of pretender.

### Usecases: 
- use real HTTP traffic, use browser's network inspector
- let multiple instances talk to mirage backend that survives reload
- get fastboot apps running without a real backend, fastboot testing

### Implementation:

We compile `ember-cli-mirage` and app's `mirage` dir to node.js using babel and borccoli. Since `ember-cli-mirage` uses `ember` some places we have `ember-compat` that provides the used parts of `Ember` in node.js

~this is piggybacks on `Fastboot`, the main issue with is that current implementation of mirage runs in browser and we need it to run it on `node.js`. Fastboot already does that for the whole ember app. So we install an express middleware so that on first network request we can lazily create a Fastbooted (sandboxed) app instance, and we pass an express router to it. Then the sandboxed app can use the passed in express router to respond to real HTTP requests.~

~It also depends on universal serving intruduced in ember `2.12` apps needs to include `ember-cli-fastboot`, so .js assets are compiled to node.js env.~

### TODO

- tests
- reload

### How to use

1. set `useExpress: true` in your ENV['ember-cli-mirage']  in `config/environment.js`

For example app see: https://github.com/mfazekas/fastboot-mirage-test/
