### PR TITLE
refactor(deps): rm deprecated lodash dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-sinon": "0.5.1",
     "eslint-plugin-ember-suave": "^1.0.0",
     "loader.js": "^4.0.10",
-    "lodash": "3.10.1",
     "mocha": "^2.1.0"
   },
   "keywords": [


### PR DESCRIPTION
This one threw me for a loop while debugging. `lodash` is now accessed via `ember-lodash`, so we can rm this dep