### PR TITLE
[WIP] Feat/polymorphism

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -265,14 +265,25 @@ class Model {
       if (parent && parent.isNew()) {
         let fk = association.getForeignKey();
         parent.save();
-        this.update(fk, parent.id);
+
+        if (association.opts.polymorphic) {
+          this.update(`${fk}Type`, parent.modelName);
+        }
+
+        this.update(`${fk}Id`, parent.id);
       }
     });
 
     Object.keys(this.hasManyAssociations).forEach((key) => {
       let association = this.hasManyAssociations[key];
       let children = this[key];
-      children.update(association.getForeignKey(), this.id);
+      let fk = association.getForeignKey();
+
+      if (association.opts.polymorphic) {
+        children.update(`${fk}Type`, this.modelName);
+      }
+
+      children.update(`${fk}Id`, this.id);
     });
   }
 

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -54,6 +54,7 @@ export default class Schema {
     ModelClass.prototype.belongsToAssociations = {}; // a registry of the model's belongsTo associations. Key is key from model definition, value is association instance itself
     ModelClass.prototype.associationKeys = [];       // ex: address.user, user.addresses
     ModelClass.prototype.associationIdKeys = [];     // ex: address.user_id, user.address_ids. may or may not be a fk.
+    ModelClass.prototype.associationTypeKeys = [];
 
     let fksAddedFromThisModel = {};
     for (let associationProperty in ModelClass.prototype) {

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -59,7 +59,15 @@ export default class BaseRouteHandler {
         let relationship = json.data.relationships[key];
 
         if (!Array.isArray(relationship.data)) {
+          let type = relationship.data && relationship.data.type;
+          let lastSlashIndex = type.lastIndexOf('/');
+
           attrs[`${camelize(key)}Id`] = relationship.data && relationship.data.id;
+
+          if (lastSlashIndex > -1) {
+            let typeSuffix = type.slice(lastSlashIndex + 1);
+            attrs[`${camelize(key)}Type`] = singularize(typeSuffix);
+          }
         }
       }, {});
     }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-sinon": "0.5.1",
     "eslint-plugin-ember-suave": "^1.0.0",
     "loader.js": "^4.0.10",
-    "lodash": "3.10.1",
     "mocha": "^2.1.0"
   },
   "keywords": [


### PR DESCRIPTION
This is a working reference implementation of polymorphic relationships in mirage (#677 #808). It breaks a bunch of tests, so should not be merged immediately.

Turn on polymorphic behaviour by declaring `polymorphic: true` in your `hasMany` / `belongsTo` opts object. `hasMany` rels will benefit from declaring a specific inverse. For example:

```javascript
// mirage/models/cart.js
import { Model, hasMany } from 'ember-cli-mirage';

export default Model.extend({
  lineItems: hasMany({ polymorphic: true, inverse: 'cart' })
});

// mirage/models/line-item.js
import { Model, belongsTo } from 'ember-cli-mirage';

export default Model.extend({
  cart: belongsTo({ polymorphic: true })
});
```

Subsequent models may implement cart-like behaviour (e.g. via mixin or inheritance), and all objects will retain access to their parent / children objects.

Prior discussion recommended mucking with serializers; I avoided doing so here as serialization will always be application-specific (e.g. do I prefix as `cart/foo`, `cart-bar`, or omit the prefix for `baz`?).

Behaviour appears stable in my consuming app, so I think it's worth discussing:
- If this is the preferred implementation, or if there are better proposals waiting to be implemented;
- Edge cases not yet accounted for; and
- How / why tests are failing

Includes a commit from https://github.com/samselikoff/ember-cli-mirage/pull/1015.