### PR TITLE
Use lodash assign

### DIFF
--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -2,6 +2,7 @@ import { pluralize, camelize, dasherize } from '../utils/inflector';
 import { toCollectionName, toModelName } from 'ember-cli-mirage/utils/normalize-name';
 import Association from './associations/association';
 import Collection from './collection';
+import _assign from 'lodash/object/assign';
 import _forIn from 'lodash/object/forIn';
 import _includes from 'lodash/collection/includes';
 import assert from '../assert';
@@ -234,7 +235,7 @@ export default class Schema {
   associationsFor(modelName) {
     let modelClass = this.modelClassFor(modelName);
 
-    return Object.assign({}, modelClass.belongsToAssociations, modelClass.hasManyAssociations);
+    return _assign({}, modelClass.belongsToAssociations, modelClass.hasManyAssociations);
   }
 
   /*


### PR DESCRIPTION
Fixes https://github.com/samselikoff/ember-cli-mirage/issues/979

`Object.assign` is not supported by PhantomJS, which is the default test runner for ember apps. This replaces usage of `Object.assign` with [Lodash's assign](https://lodash.com/docs/4.17.4#assign).

LMK if this isn't the correct target branch.