### PR TITLE
fix factory association feature

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -326,6 +326,7 @@ export default class Server {
 
     let OriginalFactory = this.factoryFor(type);
     if (OriginalFactory) {
+      OriginalFactory = OriginalFactory.extend({});
       let attrs = OriginalFactory.attrs || {};
       this._validateTraits(traits, OriginalFactory, type);
       let mergedExtensions = this._mergeExtensions(attrs, traits, overrides);

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -506,6 +506,11 @@ test('create allows to create objects with associations', function(assert) {
   assert.deepEqual(article.attrs, { title: 'Lorem ipsum', id: '1', authorId: '1', awesomeCategoryId: '1' });
   assert.equal(server.db.authors.length, 1);
   assert.equal(server.db.categories.length, 1);
+
+  let anotherArticle = server.create('article', 'withCategory');
+  assert.deepEqual(anotherArticle.attrs, { title: 'Lorem ipsum', id: '2', authorId: '2', awesomeCategoryId: '2' });
+  assert.equal(server.db.authors.length, 2);
+  assert.equal(server.db.categories.length, 2);
 });
 
 test('create allows to create objects with associations with traits and overrides for associations', function(assert) {


### PR DESCRIPTION
`_mapAssociationsFromAttributes` method modifies factory's attrs field.

Example:
*Before* this method callled attrs can be `{ author: { ..association } }`.
*After* this method called attrs will be `{ authorId: 1 }`

So association will be generated only first time.

As a fix I copy the original factory to apply associations.

FIx for #1021