### PR TITLE
Fixes generated code for destroy app helper

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -37,7 +37,8 @@ module.exports = {
         after: '"predef": [\n'
       }).then(() =>{
         if (existsSync('tests/helpers/destroy-app.js')) {
-          return this.insertIntoFile('tests/helpers/destroy-app.js', '  server.shutdown();', {
+          var shutdownText = '  if(window.server) {\n    window.server.shutdown();\n  }';
+          return this.insertIntoFile('tests/helpers/destroy-app.js', shutdownText, {
             after: "Ember.run(application, 'destroy');\n"
           });
         } else {


### PR DESCRIPTION
I ran into this issue when writing unit tests for an initializer. 