### PR TITLE
Add a note about dynamic attribute support

### DIFF
--- a/docs/v0.2.x/factories.md
+++ b/docs/v0.2.x/factories.md
@@ -41,6 +41,10 @@ export default Factory.extend({
 
 The first user generated (per test) would have a name of `User 1`, the second a name of `User 2`, and so on.
 
+<aside class='Docs-page__aside'>
+  <p>Referencing other attributes from within dynamic attributes is only available in 2.4 and later.</p>
+</aside>
+
 Finally, you can also reference attributes from within a dynamic attribute via `this`:
 
 ```js


### PR DESCRIPTION
Display which versions to expect support for referencing other attributes from within dynamic attributes.

Otherwise the docs can be misleading because the feature is half-implemented (the attributes are there but always return `undefined` because the getter is only half implemented) prior to 2.4.