### PR TITLE
add support to serialize hasMany relationships

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -58,8 +58,11 @@ export default class BaseRouteHandler {
       Object.keys(json.data.relationships).forEach((key) => {
         let relationship = json.data.relationships[key];
 
+        let attrKey = camelize(key);
         if (!Array.isArray(relationship.data)) {
-          attrs[`${camelize(key)}Id`] = relationship.data && relationship.data.id;
+          attrs[`${attrKey}Id`] = relationship.data && relationship.data.id;
+        } else {
+          attrs[`${attrKey}Id`] = relationship.data.map((relationObject) => relationObject.id);
         }
       }, {});
     }

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -92,6 +92,7 @@ test('_getAttrsForRequest works with attributes and relationships', function(ass
       doesMirage: true,
       companyId: '1',
       githubAccountId: '1',
+      manyThingsId: [],
       somethingId: null
     },
     'it normalizes data correctly.'
@@ -123,6 +124,49 @@ test('_getAttrsForRequest works with just relationships', function(assert) {
     attrs,
     {
       companyId: '1'
+    },
+    'it normalizes data correctly.'
+  );
+});
+
+test('_getAttrsForRequest works with has-may relationships', function(assert) {
+  let payload = {
+    'data': {
+      'relationships': {
+        'company': {
+          'data': {
+            'id': '1',
+            'type': 'companies'
+          }
+        },
+        'employes': {
+          data: [{
+            id: '1',
+            type: 'employ'
+          }, {
+            id: '2',
+            type: 'employ'
+          }, {
+            id: '3',
+            type: 'employ'
+          }]
+        }
+      },
+      'type': 'github-account'
+    }
+  };
+
+  this.handler._getJsonApiDocForRequest = function() {
+    return payload;
+  };
+
+  let attrs = this.handler._getAttrsForRequest(this.request, 'user');
+
+  assert.deepEqual(
+    attrs,
+    {
+      companyId: '1',
+      employesId: ['1', '2', '3']
     },
     'it normalizes data correctly.'
   );


### PR DESCRIPTION
Hi, I just found that when you get the body of a request, even though you can send a has many relationships in it doing this.

```js
// models/order.js
export default DS.Model.extend({
  details: DS.hasMany('order-detail', {
    inverse: 'order'
  })
})

// models/order-detail.js
export default DS.Model.extend({
  order: DS.belongsTo('order', {
    polymorphic: true,
    inverse: 'details'
  })
})

export default DS.JSONAPISerializer.extend({
  attrs: {
    details: {
      serialize: true
    }
  }
});
```
you don't recognize it, this PR add's support to that case.