### PR TITLE
Import `require` to avoid issue in babel@6.

### DIFF
--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -5,6 +5,7 @@
 import Ember from 'ember';
 import _camelCase from 'lodash/camelCase';
 import { pluralize } from 'ember-cli-mirage/utils/inflector';
+import require from 'require';
 
 const { assert } = Ember;
 


### PR DESCRIPTION
While testing babel@6 upgrades with apps and addons, there are issues when relying on the global require.

In this case, we are just trying to dynamically grab something from the loader so we can use this `import require from 'require';`.