### PR TITLE
Documentation for findBy

### DIFF
--- a/docs/v0.2.x/database.md
+++ b/docs/v0.2.x/database.md
@@ -58,6 +58,18 @@ Returns a single record from the *collection* if *ids* is a single id, or an arr
 db.users.find(1);      // {id: 1, name: 'Link'}
 db.users.find([1, 2]); // [{id: 1, name: 'Link'}, {id: 2, name: 'Zelda'}]
 ```
+
+<a name="findBy" href="#findBy">#</a> db.collection.<b>findBy</b>(<i>query</i>)
+
+Returns the first model from *collection* that matches the key-value pairs in the *query* object. Note that a string comparison is used. *query* is a POJO.
+
+```js
+/* 
+  Given users = [{id: 1, name: 'Link'}, {id: 2, name: 'Zelda'}]
+*/
+db.users.findBy({name: 'Link'}); // {id: 1, name: 'Link'}
+```
+
 <a name="where" href="#where">#</a> db.collection.<b>where</b>(<i>query</i>)
 
 Returns an array of models from *collection* that match the key-value pairs in the *query* object. Note that a string comparison is used. *query* is normally a POJO but can also be a function (see [PR #379 for details](https://github.com/samselikoff/ember-cli-mirage/pull/379)


### PR DESCRIPTION
Seems like [findBy](https://github.com/samselikoff/ember-cli-mirage/blob/master/addon/db-collection.js#L97) exists on db collections, but is not documented on [the site](http://www.ember-cli-mirage.com/docs/v0.2.x/database/#find)