### PR TITLE
Add server as a global for ESLint in afterInstall

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -29,30 +29,56 @@ module.exports = {
     };
   },
 
+  insertServerIntoESLintrc: function() {
+    // Insert server to globals declaration in eslintrc files.
+    // If globals declaration is not present insert it.
+    var text, after;
+    text = '    server: true,';
+    after ='globals: {\n';
+    return this.insertIntoFile('.eslintrc.js', text, { after: after }).then(() => {
+      return this.insertIntoFile('tests/.eslintrc.js', text, { after: after }).then(() => {
+        text = '  globals: {\n    server: true,\n  },';
+        after = 'module.exports = {\n';
+        return this.insertIntoFile('.eslintrc.js', text, { after: after }).then(() => {
+          return this.insertIntoFile('tests/.eslintrc.js', text, { after: after });
+        });
+      });
+    });
+  },
+
+  insertServerIntoJSHintrc: function() {
+    var text = '    "server",';
+    var after = '"predef": [\n';
+
+    return this.insertIntoFile('.jshintrc', text, { after: after }).then(() => {
+      return this.insertIntoFile('tests/.jshintrc', text, { after: after });
+    });
+  },
+
+  insertShutdownIntoDestroyApp: function() {
+    if (existsSync('tests/helpers/destroy-app.js')) {
+      var shutdownText = '  if (window.server) {\n    window.server.shutdown();\n  }';
+      return this.insertIntoFile('tests/helpers/destroy-app.js', shutdownText, {
+        after: "Ember.run(application, 'destroy');\n"
+      });
+    } else {
+      this.ui.writeLine(
+        EOL +
+        chalk.yellow(
+          '******************************************************' + EOL +
+          'destroy-app.js helper is not present. Please read this' + EOL +
+          'https://gist.github.com/blimmer/35d3efbb64563029505a' + EOL +
+          'to see how to fix the problem.' + EOL +
+          '******************************************************' + EOL
+        )
+      );
+    }
+  },
+
   afterInstall: function() {
-    return this.insertIntoFile('.jshintrc', '    "server",', {
-      after: '"predef": [\n'
-    }).then(() => {
-      return this.insertIntoFile('tests/.jshintrc', '    "server",', {
-        after: '"predef": [\n'
-      }).then(() =>{
-        if (existsSync('tests/helpers/destroy-app.js')) {
-          var shutdownText = '  if (window.server) {\n    window.server.shutdown();\n  }';
-          return this.insertIntoFile('tests/helpers/destroy-app.js', shutdownText, {
-            after: "Ember.run(application, 'destroy');\n"
-          });
-        } else {
-          this.ui.writeLine(
-            EOL +
-            chalk.yellow(
-              '******************************************************' + EOL +
-              'destroy-app.js helper is not present. Please read this' + EOL +
-              'https://gist.github.com/blimmer/35d3efbb64563029505a' + EOL +
-              'to see how to fix the problem.' + EOL +
-              '******************************************************' + EOL
-            )
-          );
-        }
+    return this.insertServerIntoESLintrc().then(() => {
+      return this.insertServerIntoJSHintrc().then(() => {
+        return this.insertShutdownIntoDestroyApp();
       });
     });
   }


### PR DESCRIPTION
Hey folks,

Great addon. Thanks for all the hard work.

ESLint has been preferred over JSHint. https://github.com/ember-cli/ember-cli/pull/6526
I adapted the `afterInstall` hook to change `.eslintrc` and `tests/.eslintrc`. 
It also changes JSHint files if they exists, for ember-cli < 2.12.

Cheers!
