### PR TITLE
Add Resource helper custom path parameter

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -424,7 +424,14 @@ export default class Server {
     }
   }
 
-  resource(resourceName, { only, except } = {}) {
+  resource(resourceName, routePath, { only, except } = {}) {
+    if (typeof routePath === 'object') {
+      only = routePath.only;
+      except = routePath.except;
+      routePath = resourceName;
+    }
+
+    routePath = routePath || resourceName;
     only = only || [];
     except = except || [];
 
@@ -433,11 +440,11 @@ export default class Server {
     }
 
     let actionsMethodsAndsPathsMappings = {
-      index: { methods: ['get'], path: `/${resourceName}` },
-      show: { methods: ['get'], path: `/${resourceName}/:id` },
-      create: { methods: ['post'], path: `/${resourceName}` },
-      update: { methods: ['put', 'patch'], path: `/${resourceName}/:id` },
-      delete: { methods: ['del'], path: `/${resourceName}/:id` }
+      index: { methods: ['get'], path: `/${routePath}` },
+      show: { methods: ['get'], path: `/${routePath}/:id` },
+      create: { methods: ['post'], path: `/${routePath}` },
+      update: { methods: ['put', 'patch'], path: `/${routePath}/:id` },
+      delete: { methods: ['del'], path: `/${routePath}/:id` }
     };
 
     let allActions = Object.keys(actionsMethodsAndsPathsMappings);
@@ -448,7 +455,11 @@ export default class Server {
     actions.forEach((action) => {
       let methodsWithPath = actionsMethodsAndsPathsMappings[action];
 
-      methodsWithPath.methods.forEach((method) => this[method](methodsWithPath.path));
+      methodsWithPath.methods.forEach((method) => {
+        return routePath === resourceName
+          ? this[method](methodsWithPath.path)
+          : this[method](methodsWithPath.path, resourceName);
+      });
     });
   }
 

--- a/addon/server.js
+++ b/addon/server.js
@@ -424,14 +424,8 @@ export default class Server {
     }
   }
 
-  resource(resourceName, routePath, { only, except } = {}) {
-    if (typeof routePath === 'object') {
-      only = routePath.only;
-      except = routePath.except;
-      routePath = resourceName;
-    }
-
-    routePath = routePath || resourceName;
+  resource(resourceName, { only, except, rootPath } = {}) {
+    rootPath = rootPath || `/${resourceName}`;
     only = only || [];
     except = except || [];
 
@@ -440,11 +434,11 @@ export default class Server {
     }
 
     let actionsMethodsAndsPathsMappings = {
-      index: { methods: ['get'], path: `/${routePath}` },
-      show: { methods: ['get'], path: `/${routePath}/:id` },
-      create: { methods: ['post'], path: `/${routePath}` },
-      update: { methods: ['put', 'patch'], path: `/${routePath}/:id` },
-      delete: { methods: ['del'], path: `/${routePath}/:id` }
+      index: { methods: ['get'], path: `${rootPath}` },
+      show: { methods: ['get'], path: `${rootPath}/:id` },
+      create: { methods: ['post'], path: `${rootPath}` },
+      update: { methods: ['put', 'patch'], path: `${rootPath}/:id` },
+      delete: { methods: ['del'], path: `${rootPath}/:id` }
     };
 
     let allActions = Object.keys(actionsMethodsAndsPathsMappings);
@@ -456,7 +450,7 @@ export default class Server {
       let methodsWithPath = actionsMethodsAndsPathsMappings[action];
 
       methodsWithPath.methods.forEach((method) => {
-        return routePath === resourceName
+        return rootPath === resourceName
           ? this[method](methodsWithPath.path)
           : this[method](methodsWithPath.path, resourceName);
       });

--- a/addon/server.js
+++ b/addon/server.js
@@ -424,8 +424,8 @@ export default class Server {
     }
   }
 
-  resource(resourceName, { only, except, rootPath } = {}) {
-    rootPath = rootPath || `/${resourceName}`;
+  resource(resourceName, { only, except, path } = {}) {
+    path = path || `/${resourceName}`;
     only = only || [];
     except = except || [];
 
@@ -434,11 +434,11 @@ export default class Server {
     }
 
     let actionsMethodsAndsPathsMappings = {
-      index: { methods: ['get'], path: `${rootPath}` },
-      show: { methods: ['get'], path: `${rootPath}/:id` },
-      create: { methods: ['post'], path: `${rootPath}` },
-      update: { methods: ['put', 'patch'], path: `${rootPath}/:id` },
-      delete: { methods: ['del'], path: `${rootPath}/:id` }
+      index: { methods: ['get'], path: `${path}` },
+      show: { methods: ['get'], path: `${path}/:id` },
+      create: { methods: ['post'], path: `${path}` },
+      update: { methods: ['put', 'patch'], path: `${path}/:id` },
+      delete: { methods: ['del'], path: `${path}/:id` }
     };
 
     let allActions = Object.keys(actionsMethodsAndsPathsMappings);
@@ -450,7 +450,7 @@ export default class Server {
       let methodsWithPath = actionsMethodsAndsPathsMappings[action];
 
       methodsWithPath.methods.forEach((method) => {
-        return rootPath === resourceName
+        return path === resourceName
           ? this[method](methodsWithPath.path)
           : this[method](methodsWithPath.path, resourceName);
       });

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -132,7 +132,7 @@ test('resource generates post shorthand', function(assert) {
     })
   }).fail((xhr, textStatus, error) => {
     assert.ok(false, 'failed to find custom path');
-    done()
+    done();
   }).done((res, status, xhr) => {
     assert.ok(true);
     done();

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -106,7 +106,7 @@ test('resource generates post shorthand', function(assert) {
   let done = assert.async(2);
 
   server.resource('contacts');
-  server.resource('blog-posts', { path: 'posts' });
+  server.resource('blog-posts', { path: '/posts' });
 
   $.ajax({
     method: 'POST',
@@ -154,7 +154,7 @@ test('resource generates put shorthand', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', { path: 'posts' });
+  server.resource('blog-posts', { path: '/posts' });
 
   $.ajax({
     method: 'PUT',
@@ -202,7 +202,7 @@ test('resource generates patch shorthand', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', { path: 'posts' });
+  server.resource('blog-posts', { path: '/posts' });
 
   $.ajax({
     method: 'PATCH',
@@ -250,7 +250,7 @@ test('resource generates delete shorthand works', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', { path: 'posts' });
+  server.resource('blog-posts', { path: '/posts' });
 
   $.ajax({
     method: 'DELETE',
@@ -294,7 +294,7 @@ test('resource generates shorthands which are whitelisted by :only option', func
   });
 
   server.resource('contacts', { only: ['index'] });
-  server.resource('blog-posts', { path: 'posts',  only: ['index'] });
+  server.resource('blog-posts', { path: '/posts',  only: ['index'] });
 
   $.ajax({
     method: 'GET',

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -38,7 +38,7 @@ test('resource generates get shorthand for index action', function(assert) {
   });
 
   this.server.resource('contacts');
-  this.server.resource('blog-posts', { rootPath: '/posts' });
+  this.server.resource('blog-posts', { path: '/posts' });
 
   $.ajax({
     method: 'GET',
@@ -77,7 +77,7 @@ test('resource generates get shorthand for show action', function(assert) {
   });
 
   this.server.resource('contacts');
-  this.server.resource('blog-posts', { rootPath: '/posts' });
+  this.server.resource('blog-posts', { path: '/posts' });
 
   $.ajax({
     method: 'GET',
@@ -106,7 +106,7 @@ test('resource generates post shorthand', function(assert) {
   let done = assert.async(2);
 
   server.resource('contacts');
-  server.resource('blog-posts', { rootPath: 'posts' });
+  server.resource('blog-posts', { path: 'posts' });
 
   $.ajax({
     method: 'POST',
@@ -154,7 +154,7 @@ test('resource generates put shorthand', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', { rootPath: 'posts' });
+  server.resource('blog-posts', { path: 'posts' });
 
   $.ajax({
     method: 'PUT',
@@ -202,7 +202,7 @@ test('resource generates patch shorthand', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', { rootPath: 'posts' });
+  server.resource('blog-posts', { path: 'posts' });
 
   $.ajax({
     method: 'PATCH',
@@ -250,7 +250,7 @@ test('resource generates delete shorthand works', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', { rootPath: 'posts' });
+  server.resource('blog-posts', { path: 'posts' });
 
   $.ajax({
     method: 'DELETE',
@@ -294,7 +294,7 @@ test('resource generates shorthands which are whitelisted by :only option', func
   });
 
   server.resource('contacts', { only: ['index'] });
-  server.resource('blog-posts', { rootPath: 'posts',  only: ['index'] });
+  server.resource('blog-posts', { path: 'posts',  only: ['index'] });
 
   $.ajax({
     method: 'GET',

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -7,7 +7,8 @@ module('Integration | Server | Resource shorthand', {
     this.server = new Server({
       environment: 'test',
       models: {
-        contact: Model
+        contact: Model,
+        blogPost: Model
       },
       serializers: {
         application: ActiveModelSerializer
@@ -22,17 +23,22 @@ module('Integration | Server | Resource shorthand', {
 });
 
 test('resource generates get shorthand for index action', function(assert) {
-  assert.expect(2);
-  let done = assert.async();
+  assert.expect(3);
+  let done = assert.async(2);
 
   this.server.db.loadData({
     contacts: [
       { id: 1, name: 'Link' },
       { id: 2, name: 'Zelda' }
+    ],
+    blogPosts: [
+      { id: 1, title: 'Post 1' },
+      { id: 2, title: 'Post 2' }
     ]
   });
 
   this.server.resource('contacts');
+  this.server.resource('blog-posts', 'posts');
 
   $.ajax({
     method: 'GET',
@@ -42,20 +48,36 @@ test('resource generates get shorthand for index action', function(assert) {
     assert.deepEqual(res, { contacts: [{ id: '1', name: 'Link' }, { id: '2', name: 'Zelda' }] });
     done();
   });
+
+  $.ajax({
+    method: 'GET',
+    url: '/posts'
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(false, 'failed to find custom path');
+    done();
+  }).done(function(res, status, xhr) {
+    assert.ok(true);
+    done();
+  });
 });
 
 test('resource generates get shorthand for show action', function(assert) {
-  assert.expect(2);
-  let done = assert.async();
+  assert.expect(3);
+  let done = assert.async(2);
 
   this.server.db.loadData({
     contacts: [
       { id: 1, name: 'Link' },
       { id: 2, name: 'Zelda' }
+    ],
+    blogPosts: [
+      { id: 1, title: 'Post 1' },
+      { id: 2, title: 'Post 2' }
     ]
   });
 
   this.server.resource('contacts');
+  this.server.resource('blog-posts', 'posts');
 
   $.ajax({
     method: 'GET',
@@ -65,14 +87,26 @@ test('resource generates get shorthand for show action', function(assert) {
     assert.deepEqual(res, { contact: { id: '2', name: 'Zelda' } });
     done();
   });
+
+  $.ajax({
+    method: 'GET',
+    url: '/posts/2'
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(false, 'failed to find custom path');
+    done();
+  }).done(function(res, status, xhr) {
+    assert.ok(true);
+    done();
+  });
 });
 
 test('resource generates post shorthand', function(assert) {
   let { server } = this;
-  assert.expect(2);
-  let done = assert.async();
+  assert.expect(3);
+  let done = assert.async(2);
 
   server.resource('contacts');
+  server.resource('blog-posts', 'posts');
 
   $.ajax({
     method: 'POST',
@@ -87,20 +121,40 @@ test('resource generates post shorthand', function(assert) {
     assert.equal(server.db.contacts.length, 1);
     done();
   });
+
+  $.ajax({
+    method: 'POST',
+    url: '/posts',
+    data: JSON.stringify({
+      blog_post: {
+        name: 'Post 1'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(false, 'failed to find custom path');
+    done()
+  }).done((res, status, xhr) => {
+    assert.ok(true);
+    done();
+  });
 });
 
 test('resource generates put shorthand', function(assert) {
   let { server } = this;
-  assert.expect(2);
-  let done = assert.async();
+  assert.expect(3);
+  let done = assert.async(2);
 
   this.server.db.loadData({
     contacts: [
       { id: 1, name: 'Link' }
+    ],
+    blogPosts: [
+      { id: 1, title: 'Post 1' }
     ]
   });
 
   server.resource('contacts');
+  server.resource('blog-posts', 'posts');
 
   $.ajax({
     method: 'PUT',
@@ -115,20 +169,40 @@ test('resource generates put shorthand', function(assert) {
     assert.equal(server.db.contacts[0].name, 'Zelda');
     done();
   });
+
+  $.ajax({
+    method: 'PUT',
+    url: '/posts/1',
+    data: JSON.stringify({
+      blog_post: {
+        name: 'Post 2'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(false, 'failed to find custom path');
+    done();
+  }).done((res, status, xhr) => {
+    assert.ok(true);
+    done();
+  });
 });
 
 test('resource generates patch shorthand', function(assert) {
   let { server } = this;
-  assert.expect(2);
-  let done = assert.async();
+  assert.expect(3);
+  let done = assert.async(2);
 
   this.server.db.loadData({
     contacts: [
       { id: 1, name: 'Link' }
+    ],
+    blogPosts: [
+      { id: 1, title: 'Post 1' }
     ]
   });
 
   server.resource('contacts');
+  server.resource('blog-posts', 'posts');
 
   $.ajax({
     method: 'PATCH',
@@ -143,20 +217,40 @@ test('resource generates patch shorthand', function(assert) {
     assert.equal(server.db.contacts[0].name, 'Zelda');
     done();
   });
+
+  $.ajax({
+    method: 'PATCH',
+    url: '/posts/1',
+    data: JSON.stringify({
+      blog_post: {
+        name: 'Post 2'
+      }
+    })
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(false, 'failed to find custom path');
+    done();
+  }).done((res, status, xhr) => {
+    assert.ok(true);
+    done();
+  });
 });
 
 test('resource generates delete shorthand works', function(assert) {
   let { server } = this;
-  assert.expect(2);
-  let done = assert.async();
+  assert.expect(3);
+  let done = assert.async(2);
 
   this.server.db.loadData({
     contacts: [
       { id: 1, name: 'Link' }
+    ],
+    blogPosts: [
+      { id: 1, title: 'Post 1' }
     ]
   });
 
   server.resource('contacts');
+  server.resource('blog-posts', 'posts');
 
   $.ajax({
     method: 'DELETE',
@@ -164,6 +258,17 @@ test('resource generates delete shorthand works', function(assert) {
   }).done((res, status, xhr) => {
     assert.equal(xhr.status, 204);
     assert.equal(server.db.contacts.length, 0);
+    done();
+  });
+
+  $.ajax({
+    method: 'DELETE',
+    url: '/posts/1'
+  }).fail((xhr, textStatus, error) => {
+    assert.ok(false, 'failed to find custom path');
+    done();
+  }).done((res, status, xhr) => {
+    assert.ok(true);
     done();
   });
 });
@@ -178,8 +283,8 @@ test('resource does not accept both :all and :except options', function(assert) 
 
 test('resource generates shorthands which are whitelisted by :only option', function(assert) {
   let { server } = this;
-  assert.expect(1);
-  let done = assert.async();
+  assert.expect(2);
+  let done = assert.async(2);
 
   server.db.loadData({
     contacts: [
@@ -189,10 +294,22 @@ test('resource generates shorthands which are whitelisted by :only option', func
   });
 
   server.resource('contacts', { only: ['index'] });
+  server.resource('blog-posts', 'posts', { only: ['index'] });
 
   $.ajax({
     method: 'GET',
     url: '/contacts'
+  }).done((res, status, xhr) => {
+    assert.equal(xhr.status, 200);
+    done();
+  });
+
+  $.ajax({
+    method: 'GET',
+    url: '/posts'
+  }).fail(function() {
+    assert.ok(false, 'failed to find custom path');
+    done();
   }).done((res, status, xhr) => {
     assert.equal(xhr.status, 200);
     done();

--- a/tests/integration/server/resource-shorthand-test.js
+++ b/tests/integration/server/resource-shorthand-test.js
@@ -38,7 +38,7 @@ test('resource generates get shorthand for index action', function(assert) {
   });
 
   this.server.resource('contacts');
-  this.server.resource('blog-posts', 'posts');
+  this.server.resource('blog-posts', { rootPath: '/posts' });
 
   $.ajax({
     method: 'GET',
@@ -77,7 +77,7 @@ test('resource generates get shorthand for show action', function(assert) {
   });
 
   this.server.resource('contacts');
-  this.server.resource('blog-posts', 'posts');
+  this.server.resource('blog-posts', { rootPath: '/posts' });
 
   $.ajax({
     method: 'GET',
@@ -106,7 +106,7 @@ test('resource generates post shorthand', function(assert) {
   let done = assert.async(2);
 
   server.resource('contacts');
-  server.resource('blog-posts', 'posts');
+  server.resource('blog-posts', { rootPath: 'posts' });
 
   $.ajax({
     method: 'POST',
@@ -154,7 +154,7 @@ test('resource generates put shorthand', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', 'posts');
+  server.resource('blog-posts', { rootPath: 'posts' });
 
   $.ajax({
     method: 'PUT',
@@ -202,7 +202,7 @@ test('resource generates patch shorthand', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', 'posts');
+  server.resource('blog-posts', { rootPath: 'posts' });
 
   $.ajax({
     method: 'PATCH',
@@ -250,7 +250,7 @@ test('resource generates delete shorthand works', function(assert) {
   });
 
   server.resource('contacts');
-  server.resource('blog-posts', 'posts');
+  server.resource('blog-posts', { rootPath: 'posts' });
 
   $.ajax({
     method: 'DELETE',
@@ -294,7 +294,7 @@ test('resource generates shorthands which are whitelisted by :only option', func
   });
 
   server.resource('contacts', { only: ['index'] });
-  server.resource('blog-posts', 'posts', { only: ['index'] });
+  server.resource('blog-posts', { rootPath: 'posts',  only: ['index'] });
 
   $.ajax({
     method: 'GET',


### PR DESCRIPTION
This adds in the ability to specify a customized path in the resource helper.

Currently with a `server.get()` shorthand, the second parameter can be a string for the collection name, if it doesn't match the given path. This PR will bring the `server.resource()` helper in line with that customizability, although it places this option inside the second parameter's option hash as `path`.

```js
// given "blog-posts" resource name and a custom path:
server.resource('blog-posts', { path: '/posts' });

// returns shorthands:
server.get('/posts', 'blog-posts');
server.get('/posts/:id', 'blog-posts');
server.post('/posts', 'blog-posts');
server.put('/posts/:id', 'blog-posts');
server.patch('/posts/:id', 'blog-posts');
server.delete('/posts/:id', 'blog-posts');
```

You could also specify an absolute url as the custom path:

```js
server.resource('blog-posts', { path: 'https://localhost/posts' });

// returns shorthands:
server.get('https://localhost/posts', 'blog-posts');
server.get('https://localhost/posts/:id', 'blog-posts');
server.post('https://localhost/posts', 'blog-posts');
server.put('https://localhost/posts/:id', 'blog-posts');
server.patch('https://localhost/posts/:id', 'blog-posts');
server.delete('https://localhost/posts/:id', 'blog-posts');
```