### PR TITLE
Updating docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is new and the API is subject to change. When updating your project
 
 ## Getting started
 
-Check out the [Docs](http://www.ember-cli-mirage.com/docs/v0.2.x/)!
+Check out the [Docs](http://www.ember-cli-mirage.com/docs/v0.3.x/)!
 
 ## Support
 


### PR DESCRIPTION
Noticed docs link was pointing to old version. Couldn't find a link that auto-redirected to latest.