### PR TITLE
Add removeForeignKey to _attrsForModel

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -196,7 +196,7 @@ class Serializer {
   }
 
   _hashForModel(model, removeForeignKeys, didSerialize = {}) {
-    let attrs = this._attrsForModel(model);
+    let attrs = this._attrsForModel(model, removeForeignKeys);
 
     if (removeForeignKeys) {
       model.fks.forEach((fk) => {
@@ -231,10 +231,10 @@ class Serializer {
 
   /**
    * @method _attrsForModel
-   * @param model
+   * @param model, removeForeignKeys
    * @private
    */
-  _attrsForModel(model) {
+  _attrsForModel(model, removeForeignKeys) {
     let attrs = {};
 
     if (this.attrs) {
@@ -247,8 +247,10 @@ class Serializer {
     }
 
     // Remove fks
-    model.fks.forEach(key => delete attrs[key]);
-
+    if (removeForeignKeys) {
+      model.fks.forEach(key => delete attrs[key]);
+    }
+      
     return this._formatAttributeKeys(attrs);
   }
 


### PR DESCRIPTION
Closes #1074

This fixes an issue where fk's are removed unnecessarily even if removeForeignKeys is false.