### PR TITLE
Only _definePlainAttribute if not an association

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -81,7 +81,9 @@ class Model {
     }
 
     Object.keys(attrs).forEach(function(attr) {
-      this._definePlainAttribute(attr);
+      if (this.associationKeys.indexOf(attr) === -1 && this.associationIdKeys.indexOf(attr) === -1) {
+        this._definePlainAttribute(attr);
+      }
       this[attr] = attrs[attr];
     }, this);
 


### PR DESCRIPTION
Fixes #1061 and a loading delay when using this in development which causes the browser to hang.