### PR TITLE
note that Faker.js is included with mirage

### DIFF
--- a/docs/v0.3.x/quickstart.md
+++ b/docs/v0.3.x/quickstart.md
@@ -82,7 +82,7 @@ Let's create a factory for our author with
 $ ember g mirage-factory author
 ```
 
-and add some properties to it:
+Mirage also includes the Faker.js library. Let's use this in the Factory and add some properties to it:
 
 ```js
 // mirage/factories/author.js


### PR DESCRIPTION
hi 👋 

I am getting a new project started with Mirage and I noticed the quickstart guide didn't mention that Faker.js was included but was requiring it in the factory files. I did a bit of hunting in the guides and found it [here](http://www.ember-cli-mirage.com/docs/v0.3.x/seeding-your-database/), so I went ahead and added it to the quickstart guide for clarity.

Hopefully it saves someone else a few minutes of hunting to determine if Faker.js is included 😄 