### PR TITLE
Normalize hasMany relationships

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -58,7 +58,9 @@ export default class BaseRouteHandler {
       Object.keys(json.data.relationships).forEach((key) => {
         let relationship = json.data.relationships[key];
 
-        if (!Array.isArray(relationship.data)) {
+        if (Array.isArray(relationship.data)) {
+          attrs[`${camelize(singularize(key))}Ids`] = relationship.data.map(rel => rel.id);
+        } else {
           attrs[`${camelize(key)}Id`] = relationship.data && relationship.data.id;
         }
       }, {});

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -62,6 +62,21 @@ test('_getAttrsForRequest works with attributes and relationships', function(ass
             'type': 'companies'
           }
         },
+        'employees': {
+          'data': [{
+            'id': '1',
+            'type': 'employees'
+          }, {
+            'id': '2',
+            'type': 'employees'
+          }, {
+            'id': '3',
+            'type': 'employees'
+          }]
+        },
+        'nothings': {
+          'data': []
+        },
         'github-account': {
           'data': {
             'id': '1',
@@ -70,9 +85,6 @@ test('_getAttrsForRequest works with attributes and relationships', function(ass
         },
         'something': {
           'data': null
-        },
-        'many-things': {
-          'data': []
         }
       },
       'type': 'github-account'
@@ -91,6 +103,8 @@ test('_getAttrsForRequest works with attributes and relationships', function(ass
       name: 'Sam',
       doesMirage: true,
       companyId: '1',
+      employeeIds: ['1', '2', '3'],
+      nothingIds: [],
       githubAccountId: '1',
       somethingId: null
     },


### PR DESCRIPTION
This commit updates `_getRequestAttrs` to normalize any `hasMany`
relationships in a request's JSON data.

By default, Ember Data will serialize `hasMany` relationships if they
are many-to-none, many-to-many, or if serialization is forced via
`serialize: true` in the `attrs` property on [DS.JSONSerializer](https://emberjs.com/api/data/classes/DS.JSONSerializer.html).
(One-to-many are not serialized by default).

Before this commit, Mirage only normalized attributes and `belongsTo`
relationships. Because `hasMany` relationships weren't normalized, many-
to-many relationships weren't saved via the shorthand route handlers or
any custom route handlers that used `this.normalizedRequestAttrs()`
(which calls `_getRequestAttrs`).

For example, assume a many-to-many relationship between `Authors` and
`Books`. In Ember, if additional `Books` are associated with an `Author`
and saved, i.e.:
```javascript
author.get('books').pushObjects([anotherBook, yetAnotherBook]);
author.save();
```
These changes wouldn't be saved and reflected in Mirage, because the
normalization didn't include the new Ids.

Please let me know if this is an appropriate solution, or if you'd like to see any changes. Thanks!