### PR TITLE
Fixed existence of `relationships.data` if `links` are defined

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -137,33 +137,32 @@ export default Serializer.extend({
     model.associationKeys.forEach((key) => {
       let relationship = model[key];
       let relationshipKey = this.keyForRelationship(key);
-      let relationshipHash;
+      let relationshipHash = {};
       hash.relationships = hash.relationships || {};
 
       if (this.hasLinksForRelationship(model, key)) {
         let serializer = this.serializerFor(model.modelName);
         let links = serializer.links(model);
-        relationshipHash = { links: links[key] };
-
-      } else {
-        let data = null;
-
-        if (this.isModel(relationship)) {
-          data = {
-            type: this.typeKeyForModel(relationship),
-            id: relationship.id
-          };
-        } else if (this.isCollection(relationship)) {
-          data = relationship.models.map((model) => {
-            return {
-              type: this.typeKeyForModel(model),
-              id: model.id
-            };
-          });
-        }
-
-        relationshipHash = { data };
+        relationshipHash.links = links[key];
       }
+
+      let data = null;
+
+      if (this.isModel(relationship)) {
+        data = {
+          type: this.typeKeyForModel(relationship),
+          id: relationship.id
+        };
+      } else if (this.isCollection(relationship)) {
+        data = relationship.models.map((model) => {
+          return {
+            type: this.typeKeyForModel(model),
+            id: model.id
+          };
+        });
+      }
+
+      relationshipHash.data = data;
 
       hash.relationships[relationshipKey] = relationshipHash;
     });

--- a/tests/integration/serializers/json-api-serializer/associations/links-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/links-test.js
@@ -24,7 +24,7 @@ module('Integration | Serializers | JSON API Serializer | Associations | Links',
   }
 });
 
-test(`it can link to relationships, omitting 'data'`, function(assert) {
+test(`it can link to relationships, including data'`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JSONAPISerializer,
     blogPost: JSONAPISerializer.extend({
@@ -57,12 +57,17 @@ test(`it can link to relationships, omitting 'data'`, function(assert) {
       },
       relationships: {
         'word-smith': {
+          data: {
+            id: "3",
+            type: "word-smiths"
+          },
           links: {
             related: `/api/word_smiths/${link.id}`,
             self: `/api/blog_posts/${blogPost.id}/relationships/word_smith`
           }
         },
         'fine-comments': {
+          data: [],
           links: {
             related: `/api/fine_comments?blog_post_id=${blogPost.id}`,
             self: `/api/blog_posts/${blogPost.id}/relationships/fine_comments`


### PR DESCRIPTION
JSON API spec says that a `relationships` object must contain at least one of the props, but it could contain all of them. So, `links` are able to be with `data` as well.
Link to the article of the spec: http://jsonapi.org/format/#document-resource-object-relationships
An article about relationships when they are defined, but empty: http://jsonapi.org/format/#document-resource-object-linkage (like a case in tests)

fixes #973