### PR TITLE
Camelize type for dasherized model names

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -333,14 +333,14 @@ export default class Server {
     this.factorySequences = this.factorySequences || {};
     this.factorySequences[camelizedType] = this.factorySequences[camelizedType] + 1 || 0;
 
-    let OriginalFactory = this.factoryFor(type);
+    let OriginalFactory = this.factoryFor(camelizedType);
     if (OriginalFactory) {
       OriginalFactory = OriginalFactory.extend({});
       let attrs = OriginalFactory.attrs || {};
-      this._validateTraits(traits, OriginalFactory, type);
+      this._validateTraits(traits, OriginalFactory, camelizedType);
       let mergedExtensions = this._mergeExtensions(attrs, traits, overrides);
-      this._mapAssociationsFromAttributes(type, attrs);
-      this._mapAssociationsFromAttributes(type, mergedExtensions);
+      this._mapAssociationsFromAttributes(camelizedType, attrs);
+      this._mapAssociationsFromAttributes(camelizedType, mergedExtensions);
 
       let Factory = OriginalFactory.extend(mergedExtensions);
       let factory = new Factory();


### PR DESCRIPTION
#1076 - Dasherized model names throws model unregistered error.  All tests pass. @samselikoff Do see any issues surrounding this request?