### PR TITLE
Unable to delete records with polymorphic belongsTo associations

### DIFF
--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -232,7 +232,19 @@ export default class BelongsTo extends Association {
     }
 
     let dependents = this.schema[toCollectionName(owner)]
-      .where({ [this.getForeignKey()]: fk });
+      .where((potentialOwner) => {
+        let id = potentialOwner[this.getForeignKey()];
+
+        if (!id) {
+          return false;
+        }
+
+        if (typeof id === 'object') {
+          return id.type === fk.type && id.id === fk.id;
+        } else {
+          return id === fk;
+        }
+      });
 
     dependents.models.forEach(dependent => {
       dependent.disassociate(model, this);

--- a/tests/integration/orm/belongs-to/issue-1112-test.js
+++ b/tests/integration/orm/belongs-to/issue-1112-test.js
@@ -1,0 +1,29 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+import { module, test } from 'qunit';
+
+module('Integration | ORM | Belongs To | Issue 1112');
+
+test('deleting a record with a polymorphic belongsTo removes it from its parent', function(assert) {
+  let schema = new Schema(new Db(), {
+    comment: Model.extend({
+      commentable: belongsTo({ polymorphic: true }),
+      user: belongsTo('user')
+    }),
+
+    post: Model,
+
+    user: Model.extend({
+      comments: hasMany('comment')
+    })
+  });
+
+  let user = schema.users.create();
+  let post = schema.posts.create();
+  let comment = schema.comments.create({ commentable: post, user });
+
+  comment.destroy();
+
+  assert.deepEqual(user.commentIds, []);
+});


### PR DESCRIPTION
This PR addresses #1112. @samselikoff I wasn't sure where the test should live, so I just threw it into `tests/integration/belongs-to` for now. It might be possible to reduce the test further, this was just the simplest analogue to my app, and caused the same sort of failure I was seeing.