### PR TITLE
Normalize relationship ids when normalizeIds is set to true

### DIFF
--- a/tests/unit/serializers/rest-serializer-test.js
+++ b/tests/unit/serializers/rest-serializer-test.js
@@ -1,10 +1,18 @@
 import RestSerializer from 'ember-cli-mirage/serializers/rest-serializer';
 
 import { module, test } from 'qunit';
+import { Model } from 'ember-cli-mirage';
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
 
 module('Unit | Serializers | RestSerializer', function(hooks) {
   hooks.beforeEach(function() {
-    this.serializer = new RestSerializer();
+    let schema = new Schema(new Db(), {
+      person: Model
+    });
+    this.serializer = new RestSerializer({
+      schema
+    });
   });
 
   test('it hyphenates camelized words', function(assert) {


### PR DESCRIPTION
Fixes #972 mainly with code I stole from @jelhan 

Changes the `normalize` method in `ActiveModelSerializer` to respect a `normalizeIds` property and convert REST type id arrays into JSONApi objects.

It isn't clear to me that we need a boolean to control this behavior as I don't know of any REST or ActiveModel APIs that *don't* expect data in this format. Hiding this behavior behind a flag does make this a non-breaking change though which is easier to manager.


Edit 6/30: Issues below are solved, leaving them in for posterity.

Some specific issues:
1) Should this transform be applied to ActiveModel type APIs. I think they are similar to REST in this way, but need to confirm with someone who knows.
2) ~Is piggybacking on `serializeIds` the right path here or should I add a new `normalizeIds` property to the serializer?~
3) This line is problematic: 
`let { belongsToAssociations, hasManyAssociations } = this.schema._registry[type].class.prototype;`
It depends on the private `_registry` and also breaks several tests because they will need mock schema objects injected into the serializer.

@samselikoff et al is there a better way to determine what the types of associations are for a given model?