### PR TITLE
Remove broccoli-unwatched-tree dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "broccoli-funnel": "^1.0.2",
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-stew": "^1.5.0",
-    "broccoli-unwatched-tree": "^0.1.1",
     "chalk": "^1.1.1",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-node-assets": "^0.1.4",


### PR DESCRIPTION
This package is unused in ember-cli-mirage (and it has been deprecated upstream).