### PR TITLE
Replace "babel" -> "ember-cli-babel" when specifying `includePolyfill`

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    babel: {
+    'ember-cli-babel': {
       includePolyfill: true
     },
   });


### PR DESCRIPTION
This satisfies the following deprecation warning:

```
DEPRECATION: Putting the "includePolyfill" option in "babel" is deprecated, please put it in "ember-cli-babel" instead.
```