### PR TITLE
Update "ember-data" to v2.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "2.10.x",
+    "ember-data": "~2.11.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",


### PR DESCRIPTION
This makes CI pass again since it includes https://github.com/emberjs/data/pull/4743 which fixes the broken `_lookupFactory()` call in Ember Data.

/cc @samselikoff 