### PR TITLE
package.json: Update "engines" property

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/samselikoff/ember-cli-mirage",
   "engines": {
-    "node": ">= 0.12.0"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "author": "Sam Selikoff",
   "license": "MIT",


### PR DESCRIPTION
We are already using stuff like `let` and `const` in `index.js` so having `engines` allow Node 0.12 has been a lie 😉 