### PR TITLE
Underlying fixture data should not be affected when associations are updated

### DIFF
--- a/addon/db.js
+++ b/addon/db.js
@@ -1,6 +1,7 @@
 import DbCollection from './db-collection';
 import IdentityManager from './identity-manager';
 import { singularize } from './utils/inflector';
+import _cloneDeep from 'lodash/cloneDeep';
 
 /**
  * The db, an identity map.
@@ -27,7 +28,7 @@ class Db {
    */
   loadData(data) {
     for (let key in data) {
-      this.createCollection(key, data[key]);
+      this.createCollection(key, _cloneDeep(data[key]));
     }
   }
 

--- a/tests/integration/orm/mixed/2-many-to-one/create-test.js
+++ b/tests/integration/orm/mixed/2-many-to-one/create-test.js
@@ -29,6 +29,34 @@ test('it sets up associations correctly when passing in the foreign key', functi
   assert.deepEqual(db.users[0], { id: '1', postIds: [ '1' ] });
 });
 
+test('it does not mutate source fixture data when modifying associations', function(assert) {
+  let { db, schema } = this.helper;
+  let sourceData = {
+    users: [{ id: '1', postIds: ['1'] }],
+    posts: [{ id: '1', userId: '1' }]
+  };
+  db.loadData(sourceData);
+
+  let user = schema.users.find('1');
+  let post1 = schema.posts.find('1');
+  let post2 = schema.create('post', {
+    userId: user.id
+  });
+
+  assert.deepEqual(post2.user.attrs, user.attrs);
+  assert.equal(post2.userId, user.id);
+  assert.ok(user.posts.includes(post2), 'inverse was set');
+  assert.deepEqual(user.postIds, [ post1.id, post2.id ]);
+
+  assert.equal(db.posts.length, 2);
+  assert.deepEqual(db.posts[0], { id: '1', userId: '1' });
+  assert.deepEqual(db.posts[1], { id: '2', userId: '1' });
+  assert.equal(db.users.length, 1);
+  assert.deepEqual(db.users[0], { id: '1', postIds: [ '1', '2' ] });
+
+  assert.deepEqual(sourceData.users[0].postIds, ['1'], 'source data is not affected');
+});
+
 test('it sets up associations correctly when passing in the association itself', function(assert) {
   let { schema } = this.helper;
   let user = schema.create('user');


### PR DESCRIPTION
- [x] failing test
- [x] fix