### PR TITLE
[fixes #1146] Change default JSONAPI data linkage behavior

### DIFF
--- a/tests/integration/serializers/json-api-serializer/associations/includes-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/includes-test.js
@@ -57,9 +57,6 @@ test('includes get serialized with correct serializer', function(assert) {
         'title': 'We love Mirage!'
       },
       relationships: {
-        'fine-comments': {
-          'data': []
-        },
         'word-smith': {
           data: { type: 'word-smiths', id: '1' }
         }
@@ -71,13 +68,6 @@ test('includes get serialized with correct serializer', function(assert) {
         id: '1',
         attributes: {
           'first-name': 'Sam'
-        },
-        relationships: {
-          'blog-posts': {
-            data: [
-              { type: 'blog-posts', id: '1' }
-            ]
-          }
         }
       }
     ]
@@ -123,36 +113,17 @@ test('query param includes work when serializing a model', function(assert) {
       {
         type: 'word-smiths',
         id: '1',
-        attributes: {},
-        relationships: {
-          'blog-posts': {
-            data: [
-              { type: 'blog-posts', id: '1' }
-            ]
-          }
-        }
+        attributes: {}
       },
       {
         type: 'fine-comments',
         id: '1',
-        attributes: {},
-        relationships: {
-          'blog-post': {
-            data: { type: 'blog-posts', id: '1' }
-          },
-          category: { data: null }
-        }
+        attributes: {}
       },
       {
         type: 'fine-comments',
         id: '2',
-        attributes: {},
-        relationships: {
-          'blog-post': {
-            data: { type: 'blog-posts', id: '1' }
-          },
-          category: { data: null }
-        }
+        attributes: {}
       }
     ]
   });
@@ -213,36 +184,17 @@ test('query param includes work when serializing a collection', function(assert)
       {
         type: 'word-smiths',
         id: '1',
-        attributes: {},
-        relationships: {
-          'blog-posts': {
-            data: [
-              { type: 'blog-posts', id: '1' }
-            ]
-          }
-        }
+        attributes: {}
       },
       {
         type: 'fine-comments',
         id: '1',
-        attributes: {},
-        relationships: {
-          'blog-post': {
-            data: { type: 'blog-posts', id: '1' }
-          },
-          category: { data: null }
-        }
+        attributes: {}
       },
       {
         type: 'fine-comments',
         id: '2',
-        attributes: {},
-        relationships: {
-          'blog-post': {
-            data: { type: 'blog-posts', id: '1' }
-          },
-          category: { data: null }
-        }
+        attributes: {}
       }
     ]
   });
@@ -275,9 +227,6 @@ test('query param includes take precedence over default server includes', functi
       id: '1',
       attributes: {},
       relationships: {
-        'word-smith': {
-          data: { type: 'word-smiths', id: '1' }
-        },
         'fine-comments': {
           data: [
             { type: 'fine-comments', id: '1' },
@@ -290,24 +239,12 @@ test('query param includes take precedence over default server includes', functi
       {
         type: 'fine-comments',
         id: '1',
-        attributes: {},
-        relationships: {
-          'blog-post': {
-            data: { type: 'blog-posts', id: '1' }
-          },
-          category: { data: null }
-        }
+        attributes: {}
       },
       {
         type: 'fine-comments',
         id: '2',
-        attributes: {},
-        relationships: {
-          'blog-post': {
-            data: { type: 'blog-posts', id: '1' }
-          },
-          category: { data: null }
-        }
+        attributes: {}
       }
     ]
   });
@@ -337,7 +274,7 @@ test('query param includes support dot-paths when serializing a model', function
   });
   let request = {
     queryParams: {
-      include: 'wordSmith,fineComments.category.labels'
+      include: 'word-smith,fine-comments.category.labels'
     }
   };
   let result = registry.serialize(this.schema.blogPosts.first(), request);
@@ -366,13 +303,6 @@ test('query param includes support dot-paths when serializing a model', function
         id: '1',
         attributes: {
           name: 'Sam'
-        },
-        relationships: {
-          'blog-posts': {
-            data: [
-              { type: 'blog-posts', id: '2' }
-            ]
-          }
         }
       },
       {
@@ -382,9 +312,6 @@ test('query param includes support dot-paths when serializing a model', function
           text: 'Foo'
         },
         relationships: {
-          'blog-post': {
-            data: { type: 'blog-posts', id: '2' }
-          },
           'category': {
             data: { type: 'categories', id: '10' }
           }
@@ -440,7 +367,7 @@ test('query param includes support dot-paths when serializing a collection', fun
   });
   let request = {
     queryParams: {
-      include: 'wordSmith,fineComments.category.labels'
+      include: 'word-smith,fine-comments.category.labels'
     }
   };
   let result = registry.serialize(this.schema.blogPosts.all(), request);
@@ -475,8 +402,7 @@ test('query param includes support dot-paths when serializing a collection', fun
             data: { type: 'word-smiths', id: '1' }
           },
           'fine-comments': {
-            data: [
-            ]
+            data: []
           }
         }
       }
@@ -487,14 +413,6 @@ test('query param includes support dot-paths when serializing a collection', fun
         id: '1',
         attributes: {
           name: 'Sam'
-        },
-        relationships: {
-          'blog-posts': {
-            data: [
-              { type: 'blog-posts', id: '2' },
-              { type: 'blog-posts', id: '5' }
-            ]
-          }
         }
       },
       {
@@ -504,9 +422,6 @@ test('query param includes support dot-paths when serializing a collection', fun
           text: 'Foo'
         },
         relationships: {
-          'blog-post': {
-            data: { type: 'blog-posts', id: '2' }
-          },
           'category': {
             data: { type: 'categories', id: '10' }
           }

--- a/tests/integration/serializers/json-api-serializer/associations/key-for-relationship-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/key-for-relationship-test.js
@@ -17,11 +17,15 @@ module('Integration | Serializers | JSON API Serializer | Key for relationship',
 });
 
 test(`keyForRelationship works`, function(assert) {
+  let ApplicationSerializer = JSONAPISerializer.extend({
+    keyForRelationship(key) {
+      return underscore(key);
+    }
+  });
   let registry = new SerializerRegistry(this.schema, {
-    application: JSONAPISerializer.extend({
-      keyForRelationship(key) {
-        return underscore(key);
-      }
+    application: ApplicationSerializer,
+    wordSmith: ApplicationSerializer.extend({
+      include: ['blogPosts']
     })
   });
   let wordSmith = this.schema.wordSmiths.create({
@@ -50,6 +54,15 @@ test(`keyForRelationship works`, function(assert) {
           ]
         }
       }
-    }
+    },
+    included: [
+      {
+        attributes: {
+          title: "Lorem ipsum"
+        },
+        id: "1",
+        type: "blog-posts"
+      }
+    ]
   });
 });

--- a/tests/integration/serializers/json-api-serializer/associations/links-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/links-test.js
@@ -24,7 +24,7 @@ module('Integration | Serializers | JSON API Serializer | Associations | Links',
   }
 });
 
-test(`it can link to relationships, including data'`, function(assert) {
+test(`it supports links`, function(assert) {
   let registry = new SerializerRegistry(this.schema, {
     application: JSONAPISerializer,
     blogPost: JSONAPISerializer.extend({
@@ -57,9 +57,61 @@ test(`it can link to relationships, including data'`, function(assert) {
       },
       relationships: {
         'word-smith': {
-          data: {
-            id: "3",
-            type: "word-smiths"
+          links: {
+            related: `/api/word_smiths/${link.id}`,
+            self: `/api/blog_posts/${blogPost.id}/relationships/word_smith`
+          }
+        },
+        'fine-comments': {
+          links: {
+            related: `/api/fine_comments?blog_post_id=${blogPost.id}`,
+            self: `/api/blog_posts/${blogPost.id}/relationships/fine_comments`
+          }
+        }
+      }
+    }
+  });
+});
+
+test(`it supports links alongside data linkage`, function(assert) {
+  let ApplicationSerializer = JSONAPISerializer.extend({
+    alwaysIncludeLinkageData: true
+  });
+  let registry = new SerializerRegistry(this.schema, {
+    application: ApplicationSerializer,
+    blogPost: ApplicationSerializer.extend({
+      links(model) {
+        return {
+          'wordSmith': {
+            related: `/api/word_smiths/${model.wordSmith.id}`,
+            self: `/api/blog_posts/${model.id}/relationships/word_smith`
+          },
+          'fineComments': {
+            related: `/api/fine_comments?blog_post_id=${model.id}`,
+            self: `/api/blog_posts/${model.id}/relationships/fine_comments`
+          }
+        };
+      }
+    })
+  });
+
+  let link = this.schema.wordSmiths.create({ id: 3, name: 'Link' }); // specify id to really test our links function
+  let blogPost = link.createBlogPost({ title: 'Lorem ipsum' });
+
+  let result = registry.serialize(blogPost);
+
+  assert.deepEqual(result, {
+    data: {
+      type: 'blog-posts',
+      id: blogPost.id,
+      attributes: {
+        'title': 'Lorem ipsum'
+      },
+      relationships: {
+        'word-smith': {
+          "data": {
+            "id": "3",
+            "type": "word-smiths"
           },
           links: {
             related: `/api/word_smiths/${link.id}`,

--- a/tests/integration/serializers/json-api-serializer/associations/polymorphic-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/polymorphic-test.js
@@ -16,7 +16,10 @@ test('it works for belongs to polymorphic relationships', function(assert) {
   });
 
   let registry = new SerializerRegistry(this.schema, {
-    application: JSONAPISerializer
+    application: JSONAPISerializer,
+    comment: JSONAPISerializer.extend({
+      include: ['commentable']
+    })
   });
   let photo = schema.photos.create({ title: 'Foo' });
   schema.comments.create({ text: 'Pretty foo!', commentable: photo });
@@ -51,6 +54,22 @@ test('it works for belongs to polymorphic relationships', function(assert) {
         },
         "type": "comments"
       }
+    ],
+    included: [
+      {
+        attributes: {
+          title: "Foo"
+        },
+        id: "1",
+        type: "photos"
+      },
+      {
+        attributes: {
+          "title": "Bar"
+        },
+        id: "1",
+        type: "videos"
+      }
     ]
   });
 });
@@ -65,7 +84,10 @@ test('it works for has many polymorphic relationships', function(assert) {
   });
 
   let registry = new SerializerRegistry(this.schema, {
-    application: JSONAPISerializer
+    application: JSONAPISerializer,
+    user: JSONAPISerializer.extend({
+      include: ['things']
+    })
   });
 
   let car = schema.cars.create({ make: 'Infiniti' });
@@ -92,6 +114,22 @@ test('it works for has many polymorphic relationships', function(assert) {
         }
       },
       "type": "users"
-    }
+    },
+    "included": [
+      {
+        "attributes": {
+          "make": "Infiniti"
+        },
+        "id": "1",
+        "type": "cars"
+      },
+      {
+        "attributes": {
+          "make": "Citizen"
+        },
+        "id": "1",
+        "type": "watches"
+      }
+    ]
   });
 });


### PR DESCRIPTION
Add alwaysIncludeLinkageData option to JSONAPISerializer, default to
false. By default, linkage data will be present for included resources.