### PR TITLE
Revert "New Module Imports" in "app" folder

### DIFF
--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -1,10 +1,13 @@
-import { getWithDefault } from '@ember/object';
-
+import Ember from 'ember';
 import readModules from 'ember-cli-mirage/utils/read-modules';
 import ENV from '../config/environment';
 import baseConfig, { testConfig } from '../mirage/config';
 import Server from 'ember-cli-mirage/server';
 import _assign from 'lodash/assign';
+
+const {
+  getWithDefault
+} = Ember;
 
 export default {
   name: 'ember-cli-mirage',


### PR DESCRIPTION
proper solution is to just reexport stuff in the `app` folder and have the real code in the `addon` folder, but reverting that part should be enough for now.