### PR TITLE
fix(base-route-handler): add polymorphism support to _getAttrsForRequest

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -457,10 +457,10 @@ class Model {
         });
         found = _compact(found);
       } else {
-        found = this._schema.db[toCollectionName(association.modelName)].find(foreignKeys);
+        found = this._schema.db[toCollectionName(association.modelName)].find(foreignKeys.id || foreignKeys);
       }
 
-      let foreignKeyLabel = association.isPolymorphic ? foreignKeys.map(fk => `${fk.type}:${fk.id}`).join(',') : foreignKeys;
+      let foreignKeyLabel = association.isPolymorphic ? foreignKeys.map(fk => `${fk.type}:${fk.id}`).join(',') : (foreignKeys.id || foreignKeys);
       assert(found.length === foreignKeys.length, `You're instantiating a ${this.modelName} that has a ${foreignKeyName} of ${foreignKeyLabel}, but some of those records don't exist in the database.`);
 
     } else {
@@ -472,10 +472,10 @@ class Model {
       if (association.isPolymorphic) {
         found = this._schema.db[toCollectionName(foreignKeys.type)].find(foreignKeys.id);
       } else {
-        found = this._schema.db[toCollectionName(association.modelName)].find(foreignKeys);
+        found = this._schema.db[toCollectionName(association.modelName)].find(foreignKeys.id || foreignKeys);
       }
 
-      let foreignKeyLabel = association.isPolymorphic ? `${foreignKeys.type}:${foreignKeys.id}` : foreignKeys;
+      let foreignKeyLabel = association.isPolymorphic ? `${foreignKeys.type}:${foreignKeys.id}` : foreignKeys.id || foreignKeys;
       assert(found, `You're instantiating a ${this.modelName} that has a ${foreignKeyName} of ${foreignKeyLabel}, but that record doesn't exist in the database.`);
     }
   }

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -59,9 +59,14 @@ export default class BaseRouteHandler {
         let relationship = json.data.relationships[key];
 
         if (Array.isArray(relationship.data)) {
-          attrs[`${camelize(singularize(key))}Ids`] = relationship.data.map(rel => rel.id);
+          attrs[`${camelize(singularize(key))}Ids`] = relationship.data.map(rel => {
+            return { id: rel.id, type: rel.type };
+          });
         } else {
-          attrs[`${camelize(key)}Id`] = relationship.data && relationship.data.id;
+          attrs[`${camelize(key)}Id`] = relationship.data && {
+            id: relationship.data.id,
+            type: relationship.data.type
+          };
         }
       }, {});
     }

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -102,10 +102,25 @@ test('_getAttrsForRequest works with attributes and relationships', function(ass
     {
       name: 'Sam',
       doesMirage: true,
-      companyId: '1',
-      employeeIds: ['1', '2', '3'],
+      companyId: {
+        id: '1',
+        type: 'companies'
+      },
+      employeeIds: [{
+        id: '1',
+        type: 'employees'
+      }, {
+        id: '2',
+        type: 'employees'
+      }, {
+        id: '3',
+        type: 'employees'
+      }],
       nothingIds: [],
-      githubAccountId: '1',
+      githubAccountId: {
+        id: '1',
+        type: 'github-accounts'
+      },
       somethingId: null
     },
     'it normalizes data correctly.'
@@ -136,7 +151,10 @@ test('_getAttrsForRequest works with just relationships', function(assert) {
   assert.deepEqual(
     attrs,
     {
-      companyId: '1'
+      companyId: {
+        id: '1',
+        type: 'companies'
+      }
     },
     'it normalizes data correctly.'
   );


### PR DESCRIPTION
_could not copy Twiddle; was noted as private / secret_

Assume a model `Image` with polymorphic relation `imageable`, and `User` + `Post` which may several relations to `image`:

```javascript
// mirage/models/image.js
import { Model, belongsTo } from 'ember-cli-mirage';

export default Model.extend({
  imageable: belongsTo({ polymorphic: true }),
});
```

```javascript
// mirage/models/user.js
import { Model, belongsTo } from 'ember-cli-mirage';

export default Model.extend({
  // ...
  image: belongsTo('image'),
});
```
```javascript
// mirage/models/post.js
import { Model, hasMany } from 'ember-cli-mirage';

export default Model.extend({
  // ...
  images: hasMany('image'),
});
```

The base route handler `mirage.post('/images')` at master was throwing 500s, as it cannot find the inverse of the polymorphic rel.

Sleuthing showed that [_getAttrsForRequest's JSON-API relationships loop](https://github.com/samselikoff/ember-cli-mirage/blob/master/addon/route-handlers/base.js#L57-L66) sets only `rel.id` vs. `rel.type`. Changing this only affected tests re: exact serialization expected from `_getAttrsForRequest`, so updated those.

In a real app, I observed failures at the ORM level, as mirage could not parse the new rel objects passed for non-polymorphic relationships. This did not cause test failure. Updated the orm objects accordingly; erred on the side of conservatism in case `foreignKeys.id` was unavailable.

This PR resolves the issue (#201created 👍), but seems to propagate further issues with a real-life ORM in spite of the passing tests.