### PR TITLE
Fix serialization of sideloaded associations with embedded associations

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -113,7 +113,7 @@ class Serializer {
     }
 
     if (this.embed) {
-      return [hash];
+      return [hash, []];
 
     } else {
       let addToIncludes = _(serializer.getKeysForIncluded())

--- a/tests/integration/serializers/base/associations/sideloading-collection-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-collection-test.js
@@ -125,6 +125,35 @@ module('Integration | Serializers | Base | Associations | Sideloading Collection
     });
   });
 
+  test(`it can sideload a collection with a has-many relationship containing embedded models`, function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: this.BaseSerializer,
+      wordSmith: this.BaseSerializer.extend({
+        embed: false,
+        include: ["posts"]
+      }),
+      blogPost: this.BaseSerializer.extend({
+        embed: true,
+        include: ["comments"]
+      })
+    });
+
+    let wordSmiths = this.schema.wordSmiths.all();
+    let result = registry.serialize(wordSmiths);
+
+    assert.deepEqual(result, {
+      wordSmiths: [
+        { id: "1", name: "Link", postIds: ["1", "2"] },
+        { id: "2", name: "Zelda", postIds: ["3"] }
+      ],
+      blogPosts: [
+        { id: "1", title: "Lorem", comments: [{ id: "1", text: "pwned" }] },
+        { id: "2", title: "Ipsum", comments: [] },
+        { id: "3", title: "Zeldas blogPost", comments: [] }
+      ]
+    });
+  });
+
   test(`it avoids circularity when serializing a collection`, function(assert) {
     let registry = new SerializerRegistry(this.schema, {
       application: this.BaseSerializer,
@@ -202,6 +231,34 @@ module('Integration | Serializers | Base | Associations | Sideloading Collection
       ],
       wordSmiths: [
         { id: '1', name: 'Link' }
+      ]
+    });
+  });
+
+  test(`it can sideload a collection with a belongs-to relationship containing embedded models`, function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: this.BaseSerializer,
+      fineComment: this.BaseSerializer.extend({
+        embed: false,
+        include: ["post"]
+      }),
+      blogPost: this.BaseSerializer.extend({
+        embed: true,
+        include: ["author"]
+      })
+    });
+
+    let fineComments = this.schema.fineComments.all();
+    let result = registry.serialize(fineComments);
+
+    assert.deepEqual(result, {
+      fineComments: [{ id: "1", text: "pwned", postId: "1" }],
+      blogPosts: [
+        {
+          id: "1",
+          title: "Lorem",
+          author: { id: "1", name: "Link" }
+        }
       ]
     });
   });

--- a/tests/integration/serializers/base/associations/sideloading-model-test.js
+++ b/tests/integration/serializers/base/associations/sideloading-model-test.js
@@ -106,6 +106,35 @@ module('Integration | Serializers | Base | Associations | Sideloading Models', f
     });
   });
 
+  test(`it can sideload a model with a has-many relationship containing embedded models`, function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: this.BaseSerializer,
+      wordSmith: this.BaseSerializer.extend({
+        embed: false,
+        include: ["posts"]
+      }),
+      blogPost: this.BaseSerializer.extend({
+        embed: true,
+        include: ["comments"]
+      })
+    });
+
+    let link = this.schema.wordSmiths.find(1);
+    let result = registry.serialize(link);
+
+    assert.deepEqual(result, {
+      wordSmith: {
+        id: "1",
+        name: "Link",
+        postIds: ["1", "2"]
+      },
+      blogPosts: [
+        { id: "1", title: "Lorem", comments: [{ id: "1", text: "pwned" }] },
+        { id: "2", title: "Ipsum", comments: [] }
+      ]
+    });
+  });
+
   test(`it avoids circularity when serializing a model`, function(assert) {
     let registry = new SerializerRegistry(this.schema, {
       application: this.BaseSerializer,
@@ -177,6 +206,34 @@ module('Integration | Serializers | Base | Associations | Sideloading Models', f
       ],
       wordSmiths: [
         { id: '1', name: 'Link' }
+      ]
+    });
+  });
+
+  test(`it can sideload a model with a belongs-to relationship containing embedded models`, function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: this.BaseSerializer,
+      fineComment: this.BaseSerializer.extend({
+        embed: false,
+        include: ["post"]
+      }),
+      blogPost: this.BaseSerializer.extend({
+        embed: true,
+        include: ["author"]
+      })
+    });
+
+    let fineComment = this.schema.fineComments.find(1);
+    let result = registry.serialize(fineComment);
+
+    assert.deepEqual(result, {
+      fineComment: { id: "1", text: "pwned", postId: "1" },
+      blogPosts: [
+        {
+          id: "1",
+          title: "Lorem",
+          author: { id: "1", name: "Link" }
+        }
       ]
     });
   });


### PR DESCRIPTION
Consider the following models, and note the serialization method:
```
// User (serializer sideloads posts)
export default Model.extend({
  posts: hasMany('post')
});

// Post (serializer embeds comments)
export default Model.extend({
  authors: hasMany('user')
  comments: hasMany('comments')
});

// Comment
export default Model.extend({
  post: belongsTo('post')
});
```

Assuming we have populated our database and we serialize a user, the
resulting serialization may look like this:
```
{
  user: {
    id: '1',
    name: 'John',
    postIds: ['1', '2']
  },
  posts: [
    { id: '1', title: 'Lorem', comments: [{ id: '1', text: 'first' }] },
    { id: '2', title: 'Ipsum', comments: [] }
  ]
}
```

Currently, there is a bug in Mirage which causes an error to be thrown
when attempting this kind of serialization:
`TypeError: Cannot read property 'filter' of undefined`

This commit fixes the bug, and adds multiples tests to ensure proper
serialization.