### PR TITLE
Improve detection/determination of inverse associations

### DIFF
--- a/tests/integration/orm/schema-verification/mixed-test.js
+++ b/tests/integration/orm/schema-verification/mixed-test.js
@@ -123,3 +123,87 @@ module('Integration | ORM | Schema Verification | Mixed', function() {
     assert.deepEqual(frodo.inverseFor(parentAssociation), frodo.associationFor('children'));
   });
 });
+
+test('multiple implicit inverse associations with the same key throws an error', function(assert) {
+  let schema = new Schema(new Db({
+    users: [
+      { id: 1, name: 'Frodo' }
+    ],
+    posts: [
+      { id: 1, title: 'Lorem' }
+    ]
+  }), {
+    user: Model.extend({
+      posts: hasMany('post')
+    }),
+    post: Model.extend({
+      editor: belongsTo('user'),
+      authors: hasMany('user')
+    })
+  });
+
+  let frodo = schema.users.find(1);
+  let userPostsAssociation = frodo.associationFor('posts');
+  let post = schema.posts.find(1);
+
+  assert.throws(function() {
+    post.inverseFor(userPostsAssociation);
+  }, /The post model has multiple possible inverse associations for the user.posts association./);
+});
+
+test('multiple explicit inverse associations with the same key throws an error', function(assert) {
+  let schema = new Schema(new Db({
+    users: [
+      { id: 1, name: 'Frodo' }
+    ],
+    posts: [
+      { id: 1, title: 'Lorem' }
+    ]
+  }), {
+    user: Model.extend({
+      posts: hasMany('post', { inverse: 'authors' })
+    }),
+    post: Model.extend({
+      editor: belongsTo('user', { inverse: 'posts' }),
+      authors: hasMany('user', { inverse: 'posts' })
+    })
+  });
+
+  let frodo = schema.users.find(1);
+  let userPostsAssociation = frodo.associationFor('posts');
+  let post = schema.posts.find(1);
+
+  assert.throws(function() {
+    post.inverseFor(userPostsAssociation);
+  }, /The post model has defined multiple explicit inverse associations for the user.posts association./);
+});
+
+test('explicit inverse is chosen over implicit inverses', function(assert) {
+  let schema = new Schema(new Db({
+    users: [
+      { id: 1, name: 'Frodo' }
+    ],
+    posts: [
+      { id: 1, title: 'Lorem' }
+    ]
+  }), {
+    user: Model.extend({
+      posts: hasMany('post', { inverse: 'authors' })
+    }),
+    post: Model.extend({
+      editor: belongsTo('user'),
+      authors: hasMany('user', { inverse: 'posts' })
+    })
+  });
+
+  let frodo = schema.users.find(1);
+  let userPostsAssociation = frodo.associationFor('posts');
+
+  assert.equal(userPostsAssociation.key, 'posts');
+  assert.equal(userPostsAssociation.modelName, 'post');
+  assert.equal(userPostsAssociation.ownerModelName, 'user');
+
+  let post = schema.posts.find(1);
+
+  assert.deepEqual(post.inverseFor(userPostsAssociation), post.associationFor('authors'));
+});


### PR DESCRIPTION
`inverseFor` currently throws an error when there are multiple potential
inverse associations defined, unless they are all explicit.

It is possible to have multiple explicit and implicit inverses on the
same model, and still detect the correct associations.

Consider the following example:
```
// User
posts: belongsTo('post', { inverse: 'authors' })

// Post
authors: hasMany('user', { inverse: 'posts' }),
editor: belongsTo('user'),
```

`user.posts` is explicitly defined as the inverse of `post.authors` (and
vice-versa), so we know these are meant to be inverse associations.

This commit updates `inverseFor` to first choose the explicit inverse
(if provided), before defaulting to implicit inverses. It will also
throw an error if multiple explicit inverses are defined with the same
key, or if multiple implicit inverses are defined.