### PR TITLE
Camelize model type to fix `association` helper in dasherized factories

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -666,7 +666,8 @@ export default class Server {
    * @private
    */
   _fetchAssociationNameFromModel(modelType, associationAttribute) {
-    let model = this.schema.modelFor(modelType);
+    let camelizedModelType = camelize(modelType);
+    let model = this.schema.modelFor(camelizedModelType);
     if (!model) {
       throw new Error(`Model not registered: ${modelType}`);
     }

--- a/tests/integration/factories/helpers-test.js
+++ b/tests/integration/factories/helpers-test.js
@@ -3,46 +3,82 @@ import { Model, Factory, belongsTo, hasMany, trait, association } from 'ember-cl
 import Server from 'ember-cli-mirage/server';
 
 module('Integration | Server | Factories | helpers', {
-  beforeEach() {
-    this.server = new Server({
-      environment: 'test',
-      models: {
-        author: Model.extend({
-          posts: hasMany()
-        }),
-        category: Model.extend({
-          posts: hasMany('post', { inverse: 'kind' })
-        }),
-        post: Model.extend({
-          author: belongsTo(),
-          kind: belongsTo('category')
-        })
-      },
-      factories: {
-        author: Factory.extend({
-          name: 'Sam'
-        }),
-        category: Factory.extend({
-          name: 'awesome software'
-        }),
-        post: Factory.extend({
-          title: 'Lorem ipsum',
-
-          author: association(),
-
-          withCategory: trait({
-            kind: association()
-          })
-        })
-      }
-    });
-  },
   afterEach() {
     this.server.shutdown();
   }
 });
 
+test('it creates associations with "association" helper in a dasherized factory', function(assert) {
+  this.server = new Server({
+    environment: 'test',
+    models: {
+      author: Model.extend({
+        blogPosts: hasMany()
+      }),
+      blogPost: Model.extend({
+        author: belongsTo()
+      })
+    },
+    factories: {
+      author: Factory.extend({
+        name: 'Sam'
+      }),
+      blogPost: Factory.extend({
+        title: 'Lorem ipsum',
+
+        author: association()
+      })
+    }
+  });
+
+  let blogPost = this.server.create('blog-post');
+
+  assert.ok(blogPost.author);
+
+  let { db } = this.server;
+
+  assert.equal(db.authors.length, 1);
+  assert.deepEqual(db.authors[0], {
+    id: '1',
+    name: 'Sam',
+    blogPostIds: ['1']
+  });
+});
+
 test('it creates associations with "association" helper combininig with traits', function(assert) {
+  this.server = new Server({
+    environment: 'test',
+    models: {
+      author: Model.extend({
+        posts: hasMany()
+      }),
+      category: Model.extend({
+        posts: hasMany('post', { inverse: 'kind' })
+      }),
+      post: Model.extend({
+        author: belongsTo(),
+        kind: belongsTo('category')
+      })
+    },
+    factories: {
+      author: Factory.extend({
+        name: 'Sam'
+      }),
+      category: Factory.extend({
+        name: 'awesome software'
+      }),
+      post: Factory.extend({
+        title: 'Lorem ipsum',
+
+        author: association(),
+
+        withCategory: trait({
+          kind: association()
+        })
+      })
+    }
+  });
+
   let post = this.server.create('post', 'withCategory');
 
   assert.ok(post.kind);


### PR DESCRIPTION
#1076 This will fix the `Model not registered` when including the `association` in a dasherized factory/model name (i.e. `blog-post`).  I have added a breaking test in the first commit and followed it up with the commit to fix it.

This is a duplicate PR building off of the one started in [1101](https://github.com/samselikoff/ember-cli-mirage/pull/1101).

Thanks!

