### PR TITLE
Remove mention of bower in install guide

### DIFF
--- a/docs/v0.3.x/installation.md
+++ b/docs/v0.3.x/installation.md
@@ -9,6 +9,6 @@ To install Mirage, run
 ember install ember-cli-mirage
 ```
 
-Ember should install the addon and some Bower dependencies, and add a `/mirage` directory to the root of your project.
+Ember should install the addon and add a `/mirage` directory to the root of your project.
 
 Check out the [upgrade guide](../upgrading) if you're coming from Mirage 0.2.x.


### PR DESCRIPTION
As far as I'm aware, bower isn't required to run this addon anymore.