### PR TITLE
update error message for 3.x version

### DIFF
--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -80,7 +80,7 @@ export default class Schema {
           !_includes(fksAddedFromThisModel[fkHolder], fk),
           `Your '${type}' model definition has multiple possible inverse relationships of type '${fkHolder}'.
 
-          Please read the associations guide and specify explicit inverses: http://www.ember-cli-mirage.com/docs/v0.2.x/models/#associations`
+          Please read the associations guide and specify explicit inverses: http://www.ember-cli-mirage.com/docs/v0.3.x/models/#associations`
         );
         fksAddedFromThisModel[fkHolder].push(fk);
 

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -44,7 +44,7 @@ export default class BaseRouteHandler {
 
     assert(
       json.data && (json.data.attributes || json.data.type || json.data.relationships),
-      `You're using a shorthand or #normalizedRequestAttrs, but your serializer's normalize function did not return a valid JSON:API document. http://www.ember-cli-mirage.com/docs/v0.2.x/serializers/#normalizejson`
+      `You're using a shorthand or #normalizedRequestAttrs, but your serializer's normalize function did not return a valid JSON:API document. http://www.ember-cli-mirage.com/docs/v0.3.x/serializers/#normalizejson`
     );
 
     if (json.data.attributes) {

--- a/addon/server.js
+++ b/addon/server.js
@@ -674,7 +674,7 @@ export default class Server {
 
     let association = model.class.findBelongsToAssociation(associationAttribute);
     if (!association) {
-      throw new Error(`You're using the \`association\` factory helper on the '${associationAttribute}' attribute of your ${modelType} factory, but that attribute is not a \`belongsTo\` association. Read the Factories docs for more information: http://www.ember-cli-mirage.com/docs/v0.2.x/factories/#factories-and-relationships`);
+      throw new Error(`You're using the \`association\` factory helper on the '${associationAttribute}' attribute of your ${modelType} factory, but that attribute is not a \`belongsTo\` association. Read the Factories docs for more information: http://www.ember-cli-mirage.com/docs/v0.3.x/factories/#factories-and-relationships`);
     }
     return camelize(association.modelName);
   }


### PR DESCRIPTION
This is just cosmetic. Though the docs are largely unchanged, users could navigate to the link thinking they're looking at 0.3.x docs when it's 0.2.x.

Apologies if there was another PR addressing this. I didn't see it if when I tried searching for it.
