### PR TITLE
Support `Class.extend()` in ES6 environments

### DIFF
--- a/addon/utils/extend.js
+++ b/addon/utils/extend.js
@@ -3,38 +3,20 @@ import _has from 'lodash/has';
 
 export default function(protoProps, staticProps) {
   let parent = this;
-  let child;
-
-  // The constructor function for the new subclass is either defined by you
-  // (the "constructor" property in your `extend` definition), or defaulted
-  // by us to simply call the parent's constructor.
-  if (protoProps && _has(protoProps, 'constructor')) {
-    child = protoProps.constructor;
-  } else {
-    child = function() {
-      return parent.apply(this, arguments);
-    };
-  }
-
-  // Add static properties to the constructor function, if supplied.
-
-  _assign(child, parent, staticProps);
-
-  // Set the prototype chain to inherit from `parent`, without calling
-  // `parent`'s constructor function.
-  let Surrogate = function() {
-    this.constructor = child;
+  let child = class extends parent {
+    // The constructor function for the new subclass is either defined by you
+    // (the "constructor" property in your `extend` definition), or defaulted
+    // by us to simply call the parent's constructor.
+    constructor(...params) {
+      super(...params);
+      if (protoProps && _has(protoProps, 'constructor')) {
+        return protoProps.constructor.apply(this, params);
+      }
+    }
   };
 
-  Surrogate.prototype = parent.prototype;
-  child.prototype = new Surrogate();
-
-  // Add prototype properties (instance properties) to the subclass,
-  // if supplied.
-  if (protoProps) {
-    _assign(child.prototype, protoProps);
-  }
-  // if (protoProps) { _assign(child.prototype, protoProps); }
+  _assign(child, staticProps);
+  _assign(child.prototype, protoProps);
 
   // Set a convenience property in case the parent's prototype is needed
   // later.


### PR DESCRIPTION
If a dev disables support for IE in their `targets.js`, Babel will leave ES6 classes untranspiled. This is great for debugging, but unfortunately the `extend` implementation in Mirage blows up when trying to invoke the base constructor for a native class:

![image](https://user-images.githubusercontent.com/108688/31352089-6fc3cf20-acfb-11e7-9b21-38598da29af8.png)

Babel has a `classCallCheck` that it inserts in transpiled constructors to try to capture this behavior, but it's not full fidelity, which is why this only shows up with native classes.

The fix I'm proposing here uses class syntax to set up the inheritance instead of wiring everything together by hand, which avoids the issue since it can then call actual `super` in the constructor. This is _almost_ a drop-in replacement (and the test suite still all passes), but unfortunately there are some subtle differences in observable behavior:
 - custom `constructor()` methods now have the super constructor invoked before they're run—this is unavoidable since you have to call `super` before you're allowed to touch `this` in a constructor
 - static properties from the parent class are now available on the child via the prototype chain rather than being copied over directly (that's just how ES6 static inheritance works, though we _could_ work around it)

The second bullet point doesn't seem like a big deal, but the first might be significant enough to block a change like this from landing until the next breaking release—not sure. Either way, I wanted to at least raise the issue since I came across it, and I suspect others will as folks start to play more with the targets stuff in development.