### PR TITLE
Update without changing the parent

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -84,7 +84,7 @@ class Model {
     }
 
     Object.keys(attrs).forEach(function(attr) {
-      if (this.associationKeys.indexOf(attr) === -1 && this.associationIdKeys.indexOf(attr) === -1) {
+      if (this.associationKeys.indexOf(attr) === -1) {
         this._definePlainAttribute(attr);
       }
       this[attr] = attrs[attr];
@@ -379,7 +379,6 @@ class Model {
    * @private
    */
   _definePlainAttribute(attr) {
-
     // Ensure the property hasn't already been defined
     let existingProperty = Object.getOwnPropertyDescriptor(this, attr);
     if (existingProperty && existingProperty.get) {

--- a/tests/integration/orm/belongs-to/1-basic/update-test.js
+++ b/tests/integration/orm/belongs-to/1-basic/update-test.js
@@ -1,0 +1,44 @@
+import Helper from './_helper';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+import Schema from 'ember-cli-mirage/orm/schema';
+import { module, test } from 'qunit';
+
+module('Integration | ORM | Belongs To | Basic | update', function(hooks) {
+  hooks.beforeEach(function() {
+    this.helper = new Helper();
+
+    this.helper.schema = new Schema(this.helper.db, {
+      author: Model.extend({
+        posts: hasMany()
+      }),
+      post: Model.extend({
+        author: belongsTo()
+      })
+    });
+
+    this.helper.schema.registerModel('foo', Model);
+  });
+
+  test('it works if the parent id changes', function(assert) {
+    let king = this.helper.schema.create('author', { name: 'King' });
+    let queen = this.helper.schema.create('author', { name: 'Queen' });
+    let post = this.helper.schema.create('post', { authorId: king.id, title: 'Create' });
+
+    post.update({ authorId: queen.id, title: 'Update' });
+
+    assert.equal(post.title, 'Update');
+    assert.equal(post.attrs.title, 'Update');
+    assert.deepEqual(this.helper.schema.db.posts[0], { id: '1', authorId: queen.id, title: 'Update' });
+  });
+
+  test('it works if the parent id does not change', function(assert) {
+    let king = this.helper.schema.create('author');
+    let post = this.helper.schema.create('post', { authorId: king.id, title: 'Create' });
+
+    post.update({ authorId: king.id, title: 'Update' });
+
+    assert.equal(post.title, 'Update');
+    assert.equal(post.attrs.title, 'Update');
+    assert.deepEqual(this.helper.schema.db.posts[0], { id: '1', authorId: king.id, title: 'Update' });
+  });
+});

--- a/tests/integration/orm/belongs-to/8-one-to-one/update-test.js
+++ b/tests/integration/orm/belongs-to/8-one-to-one/update-test.js
@@ -1,0 +1,20 @@
+import Helper from './_helper';
+import { Model } from 'ember-cli-mirage';
+import { module, test } from 'qunit';
+
+module('Integration | ORM | Belongs To | One To One | update', function(hooks) {
+  hooks.beforeEach(function() {
+    this.helper = new Helper();
+    this.helper.schema.registerModel('foo', Model);
+  });
+
+  test('updating a one to one relation works', function(assert) {
+    let { schema } = this.helper;
+    let user = schema.create('user');
+    let profile = schema.create('profile', { user });
+
+    let result = user.update({ profile });
+
+    assert.ok(result);
+  });
+});

--- a/tests/integration/serializers/base/associations/one-to-one-test.js
+++ b/tests/integration/serializers/base/associations/one-to-one-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { Model, belongsTo, Serializer } from 'ember-cli-mirage';
+import Db from 'ember-cli-mirage/db';
+import Schema from 'ember-cli-mirage/orm/schema';
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+
+module('Integration | Serializers | Base | Associations | One to One', function(hooks) {
+  hooks.beforeEach(function() {
+    this.db = new Db();
+
+    this.schema = new Schema(this.db, {
+      user: Model.extend({
+        profile: belongsTo()
+      }),
+      profile: Model.extend({
+        user: belongsTo()
+      })
+    });
+
+    this.registry = new SerializerRegistry(this.schema, {
+      user: Serializer.extend({
+        include: ['profile']
+      }),
+      profile: Serializer.extend({
+        include: ['user']
+      })
+    });
+  });
+
+  // Failing test for issue [#1061](https://github.com/samselikoff/ember-cli-mirage/issues/1061)
+  test('it serializes one to one relations', function(assert) {
+    let user = this.schema.create('user');
+    let profile = this.schema.create('profile', { user });
+    user.update({ profile });
+
+    let result = this.registry.serialize(user);
+
+    assert.ok(result);
+  });
+});


### PR DESCRIPTION
This is just a failing test, related to #1207 

Looks like the problem is not with the none numeric IDs, but with updates that do not involve updating the parent. 

