### PR TITLE
make pretender request tracking configurable

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -61,7 +61,7 @@ function createPretender(server) {
          mirage/config.js file. Did you forget to add your namespace?`
       );
     };
-  }, { trackRequests: false });
+  }, { trackRequests: server.shouldTrackRequests() });
 }
 
 const defaultRouteOptions = {
@@ -154,6 +154,7 @@ export default class Server {
     this.timing = this.timing || config.timing || 400;
     this.namespace = this.namespace || config.namespace || '';
     this.urlPrefix = this.urlPrefix || config.urlPrefix || '';
+    this.trackRequests = config.trackRequests;
 
     this._defineRouteHandlerHelpers();
 
@@ -181,6 +182,9 @@ export default class Server {
     let hasFactories = this._hasModulesOfType(config, 'factories');
     let hasDefaultScenario = config.scenarios && config.scenarios.hasOwnProperty('default');
 
+    let didOverridePretenderConfig = (config.trackRequests !== undefined) && this.pretender;
+    assert(!didOverridePretenderConfig,
+      'You cannot modify Pretender\'s request tracking once the server is created');
     this.pretender = this.pretender || createPretender(this);
 
     if (config.baseConfig) {
@@ -230,6 +234,17 @@ export default class Server {
    */
   shouldLog() {
     return typeof this.logging !== 'undefined' ? this.logging : !this.isTest();
+  }
+
+  /**
+   * Determines if the server should track requests.
+   *
+   * @method shouldTrackRequests
+   * @return The value of this.trackRequests if defined, false otherwise.
+   * @public
+   */
+  shouldTrackRequests() {
+    return typeof this.trackRequests !== 'undefined' ? this.trackRequests : false;
   }
 
   /**

--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -22,7 +22,8 @@ export function startMirage(env = ENV) {
   let environment = env.environment;
   let discoverEmberDataModels = getWithDefault(env['ember-cli-mirage'] || {}, 'discoverEmberDataModels', true);
   let modules = readModules(env.modulePrefix);
-  let options = _assign(modules, {environment, baseConfig, testConfig, discoverEmberDataModels});
+  let trackRequests = env['ember-cli-mirage'];
+  let options = _assign(modules, {environment, baseConfig, testConfig, discoverEmberDataModels, trackRequests});
 
   return new Server(options);
 }

--- a/tests/integration/server-config-test.js
+++ b/tests/integration/server-config-test.js
@@ -250,4 +250,51 @@ module('Integration | Server Config', function(hooks) {
       });
     }, /You cannot modify Mirage's environment once the server is created/);
   });
+
+  test('changing the trackRequests configuration of the server throws an error', function(assert) {
+    let { server } = this;
+
+    assert.throws(function() {
+      server.config({
+        trackRequests: true
+      });
+    }, /You cannot modify Pretender's request tracking once the server is created/);
+  });
+});
+
+module('Integration | Server Config | Pretender', function(hooks) {
+  hooks.beforeEach(function() {
+    this.server = new Server({
+      environment: 'development',
+      models: {
+        contact: Model,
+        post: Model
+      },
+      serializers: {
+        contact: ActiveModelSerializer
+      },
+      trackRequests: true
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+  }),
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  }),
+
+  test('pretender request logging can be configured', function(assert) {
+    assert.expect(1);
+    let done = assert.async();
+
+    let { server } = this;
+    server.trackRequests = true;
+    server.get('/contacts');
+
+    $.getJSON('/contacts', function(data) {
+      let handledRequest = server.pretender.handledRequests[0];
+      assert.equal(handledRequest.method, 'GET');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Track requests with Pretender in test mode [#1200](https://github.com/samselikoff/ember-cli-mirage/issues/1200)

Our app depends on pretender tracking for assertions in our tests about outgoing requests. It would be great if this were configurable.