### PR TITLE
chore(pretender): upgrade to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "exists-sync": "0.0.3",
     "fake-xml-http-request": "^1.4.0",
     "faker": "^3.0.0",
-    "pretender": "^1.5.1",
+    "pretender": "^1.6.1",
     "route-recognizer": "^0.2.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5056,9 +5056,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretender@^1.5.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/pretender/-/pretender-1.6.0.tgz#0bb6dc9622b576772938814bc36f7cf2f86660dd"
+pretender@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-1.6.1.tgz#77d1e42ac8c6b298f5cd43534a87645df035db8c"
   dependencies:
     fake-xml-http-request "^1.6.0"
     route-recognizer "^0.3.3"


### PR DESCRIPTION
Upgrades to 1.6.1 as we should see improvements in memory leaks from pretender. Helps merge #1217 