### PR TITLE
Support coalesce option properly according to JSON:API spec

### DIFF
--- a/addon/route-handlers/shorthands/get.js
+++ b/addon/route-handlers/shorthands/get.js
@@ -29,11 +29,13 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
       } else {
         return model;
       }
-    } else if (this.options.coalesce && request.queryParams && request.queryParams.ids) {
-      return modelClass.find(request.queryParams.ids);
-    } else {
-      return modelClass.all();
+    } else if (this.options.coalesce) {
+      let ids = this.serializerOrRegistry.getCoalescedIds(request, camelizedModelName);
+      if (ids) {
+        return modelClass.find(ids);
+      }
     }
+    return modelClass.all();
   }
 
   /*

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -83,4 +83,8 @@ export default class SerializerRegistry {
     );
   }
 
+  getCoalescedIds(request, modelName) {
+    return this.serializerFor(modelName).getCoalescedIds(request);
+  }
+
 }

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -485,6 +485,9 @@ class Serializer {
 
     return formattedAttrs;
   }
+
+  getCoalescedIds(/* request */) {
+  }
 }
 
 // Defaults

--- a/addon/serializers/active-model-serializer.js
+++ b/addon/serializers/active-model-serializer.js
@@ -55,6 +55,10 @@ export default Serializer.extend({
     });
 
     return jsonApiPayload;
+  },
+
+  getCoalescedIds(request) {
+    return request.queryParams && request.queryParams.ids;
   }
 
 });

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -214,8 +214,15 @@ const JSONAPISerializer = Serializer.extend({
 
   typeKeyForModel(model) {
     return dasherize(pluralize(model.modelName));
-  }
+  },
 
+  getCoalescedIds(request) {
+    let ids = request.queryParams && request.queryParams['filter[id]'];
+    if (typeof ids === 'string') {
+      return ids.split(',');
+    }
+    return ids;
+  }
 });
 
 JSONAPISerializer.prototype.alwaysIncludeLinkageData = false;

--- a/addon/serializers/rest-serializer.js
+++ b/addon/serializers/rest-serializer.js
@@ -25,6 +25,10 @@ export default ActiveModelSerializer.extend({
 
   keyForForeignKey(relationshipName) {
     return camelize(singularize(relationshipName));
+  },
+
+  getCoalescedIds(request) {
+    return request.queryParams && request.queryParams.ids;
   }
 
 });

--- a/tests/integration/route-handlers/get-shorthand-test.js
+++ b/tests/integration/route-handlers/get-shorthand-test.js
@@ -4,6 +4,7 @@ import {
   hasMany,
   belongsTo,
   JSONAPISerializer,
+  RestSerializer,
   Response
 } from 'ember-cli-mirage';
 import Collection from 'ember-cli-mirage/orm/collection';
@@ -117,10 +118,21 @@ module('Integration | Route Handlers | GET shorthand', function(hooks) {
     assert.equal(author.name, 'Zelda');
   });
 
-  test('undefined shorthand with coalesce true returns the appropriate models', function(assert) {
-    let request = { url: '/authors?ids[]=1&ids[]=3', queryParams: { ids: [1, 3] } };
+  test('undefined shorthand with coalesce true returns the appropriate models [JSONAPI]', function(assert) {
+    let request = { url: '/authors?filter[id]=1,3', queryParams: { 'filter[id]': '1,3' } };
     let options = { coalesce: true };
     let handler = new GetShorthandRouteHandler(this.schema, this.serializer, undefined, '/authors', options);
+
+    let authors = handler.handle(request);
+
+    assert.equal(authors.models.length, 2);
+    assert.deepEqual(authors.models.map((author) => author.name), ['Link', 'Epona']);
+  });
+
+  test('undefined shorthand with coalesce true returns the appropriate models [REST]', function(assert) {
+    let request = { url: '/authors?ids[]=1&ids[]=3', queryParams: { ids: [1, 3] } };
+    let options = { coalesce: true };
+    let handler = new GetShorthandRouteHandler(this.schema, new RestSerializer(), undefined, '/authors', options);
 
     let authors = handler.handle(request);
 
@@ -160,10 +172,21 @@ module('Integration | Route Handlers | GET shorthand', function(hooks) {
     assert.equal(author.code, 404);
   });
 
-  test('string shorthand with coalesce returns the correct models', function(assert) {
-    let request = { url: '/people?ids[]=1&ids[]=3', queryParams: { ids: [1, 3] } };
+  test('string shorthand with coalesce returns the correct models [JSONAPI]', function(assert) {
+    let request = { url: '/authors?filter[id]=1,3', queryParams: { 'filter[id]': '1,3' } };
     let options = { coalesce: true };
     let handler = new GetShorthandRouteHandler(this.schema, this.serializer, 'author', '/people', options);
+
+    let authors = handler.handle(request);
+
+    assert.equal(authors.models.length, 2);
+    assert.deepEqual(authors.models.map((author) => author.name), ['Link', 'Epona']);
+  });
+
+  test('string shorthand with coalesce returns the correct models [REST]', function(assert) {
+    let request = { url: '/people?ids[]=1&ids[]=3', queryParams: { ids: [1, 3] } };
+    let options = { coalesce: true };
+    let handler = new GetShorthandRouteHandler(this.schema, new RestSerializer(), 'author', '/people', options);
 
     let authors = handler.handle(request);
 

--- a/tests/unit/serializers/active-model-serializer-test.js
+++ b/tests/unit/serializers/active-model-serializer-test.js
@@ -66,5 +66,15 @@ module('Unit | Serializers | ActiveModelSerializer', function(hooks) {
       }
     });
   });
+
+  test('it returns coalesce Ids if present', function(assert) {
+    let request = { url: '/authors', queryParams: { ids: ['1', '3'] } };
+    assert.deepEqual(this.serializer.getCoalescedIds(request), ['1', '3']);
+  });
+
+  test('it returns undefined coalesce Ids if not present', function(assert) {
+    let request = { url: '/authors', queryParams: {} };
+    assert.strictEqual(this.serializer.getCoalescedIds(request), undefined);
+  });
 });
 

--- a/tests/unit/serializers/json-api-serializer-test.js
+++ b/tests/unit/serializers/json-api-serializer-test.js
@@ -1,0 +1,18 @@
+import JSONAPISerializer from 'ember-cli-mirage/serializers/json-api-serializer';
+import { module, test } from 'qunit';
+
+module('Unit | Serializers | JSON API Serializer', function(hooks) {
+  hooks.beforeEach(function() {
+    this.serializer = new JSONAPISerializer();
+  });
+
+  test('it returns coalesce Ids if present', function(assert) {
+    let request = { url: '/authors', queryParams: { 'filter[id]': '1,3' } };
+    assert.deepEqual(this.serializer.getCoalescedIds(request), ['1', '3']);
+  });
+
+  test('it returns undefined coalesce Ids if not present', function(assert) {
+    let request = { url: '/authors', queryParams: {} };
+    assert.strictEqual(this.serializer.getCoalescedIds(request), undefined);
+  });
+});

--- a/tests/unit/serializers/rest-serializer-test.js
+++ b/tests/unit/serializers/rest-serializer-test.js
@@ -1,6 +1,6 @@
 import RestSerializer from 'ember-cli-mirage/serializers/rest-serializer';
 
-import {module, test} from 'qunit';
+import { module, test } from 'qunit';
 
 module('Unit | Serializers | RestSerializer', function(hooks) {
   hooks.beforeEach(function() {
@@ -27,5 +27,15 @@ module('Unit | Serializers | RestSerializer', function(hooks) {
         }
       }
     });
+  });
+
+  test('it returns coalesce Ids if present', function(assert) {
+    let request = { url: '/authors', queryParams: { ids: ['1', '3'] } };
+    assert.deepEqual(this.serializer.getCoalescedIds(request), ['1', '3']);
+  });
+
+  test('it returns undefined coalesce Ids if not present', function(assert) {
+    let request = { url: '/authors', queryParams: {} };
+    assert.strictEqual(this.serializer.getCoalescedIds(request), undefined);
   });
 });


### PR DESCRIPTION
Introduces a new `getCoalescedIds` method for serializers, to encapsulate knowledge on how to deserialize coalesced Ids from the given request in that layer, so we can support the proper way for each serializer independently.

Fixes #1202 

cc @cibernox 