### PR TITLE
Performance: Don't make copies of record arrays internally

### DIFF
--- a/addon/db.js
+++ b/addon/db.js
@@ -55,9 +55,29 @@ class Db {
       let IdentityManager = this.identityManagerFor(name);
       let newCollection = new DbCollection(name, initialData, IdentityManager);
 
+      // Public API has a convenient array interface. It comes at the cost of
+      // returning a copy of all records to avoid accidental mutations.
       Object.defineProperty(this, name, {
         get() {
           let recordsCopy = newCollection.all();
+
+          ['insert', 'find', 'findBy', 'where', 'update', 'remove', 'firstOrCreate']
+            .forEach(function(method) {
+              recordsCopy[method] = function() {
+                return newCollection[method](...arguments);
+              };
+            });
+
+          return recordsCopy;
+        }
+      });
+
+      // Private API does not have the array interface. This means internally, only
+      // db-collection methods can be used. This is so records aren't copied redundantly
+      // internally, which leads to accidental O(n^2) operations (e.g., createList).
+      Object.defineProperty(this, `_${name}`, {
+        get() {
+          let recordsCopy = [];
 
           ['insert', 'find', 'findBy', 'where', 'update', 'remove', 'firstOrCreate']
             .forEach(function(method) {

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -1,6 +1,6 @@
 import BelongsTo from './associations/belongs-to';
 import HasMany from './associations/has-many';
-import { toCollectionName } from 'ember-cli-mirage/utils/normalize-name';
+import { toCollectionName, toInternalCollectionName } from 'ember-cli-mirage/utils/normalize-name';
 import extend from '../utils/extend';
 import assert from '../assert';
 import Collection from './collection';
@@ -45,7 +45,7 @@ class Model {
    * @public
    */
   save() {
-    let collection = toCollectionName(this.modelName);
+    let collection = toInternalCollectionName(this.modelName);
 
     if (this.isNew()) {
       // Update the attrs with the db response
@@ -104,7 +104,7 @@ class Model {
     if (this.isSaved()) {
       this._disassociateFromDependents();
 
-      let collection = toCollectionName(this.modelName);
+      let collection = toInternalCollectionName(this.modelName);
       this._schema.db[collection].remove(this.attrs.id);
     }
   }
@@ -125,7 +125,7 @@ class Model {
     let hasId = this.attrs.id !== undefined && this.attrs.id !== null;
 
     if (hasId) {
-      let collectionName = toCollectionName(this.modelName);
+      let collectionName = toInternalCollectionName(this.modelName);
       let record = this._schema.db[collectionName].find(this.attrs.id);
       if (record) {
         hasDbRecord = true;
@@ -153,7 +153,7 @@ class Model {
    */
   reload() {
     if (this.id) {
-      let collection = toCollectionName(this.modelName);
+      let collection = toInternalCollectionName(this.modelName);
       let attrs = this._schema.db[collection].find(this.id);
 
       Object.keys(attrs)
@@ -458,11 +458,11 @@ class Model {
       let found;
       if (association.isPolymorphic) {
         found = foreignKeys.map(({ type, id }) => {
-          return this._schema.db[toCollectionName(type)].find(id);
+          return this._schema.db[toInternalCollectionName(type)].find(id);
         });
         found = _compact(found);
       } else {
-        found = this._schema.db[toCollectionName(association.modelName)].find(foreignKeys);
+        found = this._schema.db[toInternalCollectionName(association.modelName)].find(foreignKeys);
       }
 
       let foreignKeyLabel = association.isPolymorphic ? foreignKeys.map(fk => `${fk.type}:${fk.id}`).join(',') : foreignKeys;
@@ -475,9 +475,9 @@ class Model {
 
       let found;
       if (association.isPolymorphic) {
-        found = this._schema.db[toCollectionName(foreignKeys.type)].find(foreignKeys.id);
+        found = this._schema.db[toInternalCollectionName(foreignKeys.type)].find(foreignKeys.id);
       } else {
-        found = this._schema.db[toCollectionName(association.modelName)].find(foreignKeys);
+        found = this._schema.db[toInternalCollectionName(association.modelName)].find(foreignKeys);
       }
 
       let foreignKeyLabel = association.isPolymorphic ? `${foreignKeys.type}:${foreignKeys.id}` : foreignKeys;
@@ -690,12 +690,12 @@ class Model {
       let inverseFk = inverse.getForeignKey();
 
       if (inverse instanceof BelongsTo) {
-        this._schema.db[toCollectionName(model.modelName)]
+        this._schema.db[toInternalCollectionName(model.modelName)]
           .update(model.id, { [inverseFk]: this.id });
 
       } else {
         let ownerId = this.id;
-        let inverseCollection = this._schema.db[toCollectionName(model.modelName)];
+        let inverseCollection = this._schema.db[toInternalCollectionName(model.modelName)];
         let currentIdsForInverse = inverseCollection.find(model.id)[inverse.getForeignKey()] || [];
         let newIdsForInverse = _assign([], currentIdsForInverse);
 
@@ -711,7 +711,7 @@ class Model {
   // Used to update data directly, since #save and #update can retrigger saves,
   // which can cause cycles with associations.
   _updateInDb(attrs) {
-    this.attrs = this._schema.db[toCollectionName(this.modelName)].update(this.attrs.id, attrs);
+    this.attrs = this._schema.db[toInternalCollectionName(this.modelName)].update(this.attrs.id, attrs);
   }
 
   /**

--- a/addon/server.js
+++ b/addon/server.js
@@ -3,7 +3,7 @@
 import { Promise } from 'rsvp';
 
 import { pluralize, camelize } from './utils/inflector';
-import { toCollectionName } from 'ember-cli-mirage/utils/normalize-name';
+import { toCollectionName, toInternalCollectionName } from 'ember-cli-mirage/utils/normalize-name';
 import { getModels } from './ember-data';
 import { hasEmberData } from './utils/ember-data';
 import isAssociation from 'ember-cli-mirage/utils/is-association';
@@ -404,7 +404,7 @@ export default class Server {
       if (collectionFromCreateList) {
         collection = collectionFromCreateList;
       } else {
-        collectionName = this.schema ? toCollectionName(type) : pluralize(type);
+        collectionName = this.schema ? toInternalCollectionName(type) : `_${pluralize(type)}`;
         collection = this.db[collectionName];
       }
 
@@ -426,7 +426,7 @@ export default class Server {
     assert(_isInteger(amount), `second argument has to be an integer, you passed: ${typeof amount}`);
 
     let list = [];
-    let collectionName = this.schema ? toCollectionName(type) : pluralize(type);
+    let collectionName = this.schema ? toInternalCollectionName(type) : `_${pluralize(type)}`;
     let collection = this.db[collectionName];
 
     for (let i = 0; i < amount; i++) {

--- a/addon/utils/normalize-name.js
+++ b/addon/utils/normalize-name.js
@@ -10,6 +10,10 @@ export function toCollectionName(type) {
   return camelize(pluralize(modelName));
 }
 
+export function toInternalCollectionName(type) {
+  return `_${toCollectionName(type)}`;
+}
+
 export function toModelName(type) {
   let modelName = dasherize(type);
   return singularize(modelName);

--- a/testem.js
+++ b/testem.js
@@ -6,6 +6,7 @@ module.exports = {
     'Chrome'
   ],
   launch_in_dev: [
+    'Chrome'
   ],
   browser_args: {
     Chrome: {
@@ -16,6 +17,6 @@ module.exports = {
         '--remote-debugging-port=9222',
         '--window-size=1440,900'
       ]
-    },
+    }
   }
 };

--- a/tests/performance/faker-factory-test.js
+++ b/tests/performance/faker-factory-test.js
@@ -1,0 +1,38 @@
+import { module } from 'qunit';
+import { Model, Factory, faker } from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+import { perfTest } from './utils';
+
+module('Performance | Factory | Faker', {
+  beforeEach() {
+    this.Car = Model.extend();
+    this.CarFactory = Factory.extend({
+      make: faker.commerce.product,
+      model: () => `${faker.list.random('a', 'b', 'c', 'x')}${faker.random.number({ min: 1, max: 15 }) * 100}`,
+      year: () => faker.random.number({ min: 1980, max: 2017 })
+    });
+
+    this.server = new Server({
+      environment: 'test',
+      models: {
+        car: this.Car
+      },
+      factories: {
+        car: this.CarFactory
+      }
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+  },
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+const carMaker = (count) => {
+  server.createList('car', count);
+};
+
+perfTest(50, 'models', carMaker);
+perfTest(500, 'models', carMaker);
+perfTest(5000, 'models', carMaker);

--- a/tests/performance/simple-factory-test.js
+++ b/tests/performance/simple-factory-test.js
@@ -1,0 +1,38 @@
+import { module } from 'qunit';
+import { Model, Factory } from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+import { perfTest } from './utils';
+
+module('Performance | Factory | Simple', {
+  beforeEach() {
+    this.Car = Model.extend();
+    this.CarFactory = Factory.extend({
+      make: 'Fjord',
+      model: 'Wagon',
+      year: '1886'
+    });
+
+    this.server = new Server({
+      environment: 'test',
+      models: {
+        car: this.Car
+      },
+      factories: {
+        car: this.CarFactory
+      }
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+  },
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+const carMaker = (count) => {
+  server.createList('car', count);
+};
+
+perfTest(50, 'models', carMaker);
+perfTest(500, 'models', carMaker);
+perfTest(5000, 'models', carMaker);

--- a/tests/performance/utils.js
+++ b/tests/performance/utils.js
@@ -1,0 +1,30 @@
+import { test } from 'qunit';
+
+export function perfTest(count, message, testFn, timeout = 0) {
+  test(`(${count}) ${message}`, function(assert) {
+    var duration = time(() => {
+      testFn(count);
+    });
+
+    if (timeout) {
+      assert.ok(duration < timeout, `${duration}ms (${timeout}ms timeout)`);
+    } else {
+      assert.ok(true, `${duration}ms`);
+    }
+  });
+}
+
+export function time(fn) {
+  var start = now();
+  fn();
+
+  return now() - start;
+}
+
+export function now() {
+  return performance
+    ? performance.now()
+    : Date.now
+      ? Date.now()
+      : +new Date();
+}


### PR DESCRIPTION
Right now, whenever accessing a records property on the `db` object, a copy of all records is made. 

This has a purpose, to avoid the possibility of a user accidentally mutating the db state of Mirage, but it comes at a great cost.

```js
const records = server.db.myModel; // Makes a copy of the myModel records array
records.length = 0; // Destroys records

// Still fine, since the previous line was operating on a copy
const records2 = server.db.myModel; 
```

The cost is that every operation gets slower as the records array for a type grows. More seriously, the `createList` method has quadratic complexity.

```js
// Makes a copy of [ 1 ], [ 1, 2 ], ... [ 1, ..., 499 ]
const newRecords = server.createList('myModel', 500); 
```

This PR introduces a new private accessor for db collections that does not make a record copy. Mirage source is trusted to not accidentally mutate internal db state.

Since the private accessor doesn't make a copy, the performance of `createList` is now linear. Here is the before and after of the perf tests:

**Before**
<img width="868" alt="screen shot 2017-12-06 at 3 49 20 pm" src="https://user-images.githubusercontent.com/174740/33691684-2d33b41a-da9e-11e7-82da-a9e3ef8e9b68.png">

**After**
<img width="755" alt="screen shot 2017-12-06 at 3 32 36 pm" src="https://user-images.githubusercontent.com/174740/33691685-358e877a-da9e-11e7-84e0-94747586e30a.png">
