### PR TITLE
- Fix regular expression Syntax error

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -45,7 +45,7 @@ module.exports = {
 
   insertServerIntoJSHintrc: function() {
     var text = '    "server",';
-    var after = '"predef": [\n';
+    var after = '"predef": \\[\n';
 
     return this.insertIntoFile('.jshintrc', text, { after: after });
   },


### PR DESCRIPTION
`[` as a special symbol must be slashed
That fixed install error for me on node `8.9.2` with latest `ember-cli`