### PR TITLE
[closes #1240] Fix many-to-many set bug

### DIFF
--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -212,7 +212,7 @@ export default class BelongsTo extends Association {
       this[key] = parent;
       this.save();
 
-      return parent;
+      return parent.reload();
     };
   }
 

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -21,6 +21,7 @@ export default class Schema {
     this._registry = {};
     this._dependentAssociations = { polymorphic: [] };
     this.registerModels(modelsMap);
+    this.isSaving = {}; // a hash of models that are being saved, used to avoid cycles
   }
 
   /**
@@ -53,7 +54,7 @@ export default class Schema {
     this._registry[camelizedModelName].class = ModelClass;
 
     // TODO: set here, remove from model#constructor
-    ModelClass.prototype._schema = this;
+    ModelClass.prototype.schema = this;
     ModelClass.prototype.modelName = modelName;
     // Set up associations
     ModelClass.prototype.hasManyAssociations = {};   // a registry of the model's hasMany associations. Key is key from model definition, value is association instance itself

--- a/tests/integration/orm/belongs-to/2-named/association-create-test.js
+++ b/tests/integration/orm/belongs-to/2-named/association-create-test.js
@@ -17,7 +17,7 @@ module('Integration | ORM | Belongs To | Named | association #create', function(
       let ganon = post.createAuthor({ name: 'Ganon' });
 
       assert.ok(ganon.id, 'the parent was persisted');
-      assert.deepEqual(post.author, ganon);
+      assert.deepEqual(post.author.attrs, ganon.attrs);
       assert.equal(post.authorId, ganon.id);
       assert.equal(this.helper.schema.posts.find(post.id).authorId, ganon.id, 'the child was persisted');
     });

--- a/tests/integration/orm/has-many/regressions/many-to-many-inverse-set-bug.js
+++ b/tests/integration/orm/has-many/regressions/many-to-many-inverse-set-bug.js
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { Model, hasMany } from 'ember-cli-mirage';
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+
+module('Integration | ORM | Has Many | Regressions | Many to many inverse set bug', function(hooks) {
+  hooks.beforeEach(function() {
+    this.db = new Db();
+
+    this.schema = new Schema(this.db, {
+      post: Model.extend({
+        tags: hasMany()
+      }),
+      tag: Model.extend({
+        posts: hasMany()
+      })
+    });
+  });
+
+  test(`it works`, function(assert) {
+    this.db.loadData({
+      posts: [
+        { id: '1', tagIds: [ '15', '16' ] }
+      ],
+      tags: [
+        { id: '15', postIds: [ '1' ] },
+        { id: '16', postIds: [ '1' ] }
+      ]
+    });
+
+    let post = this.schema.posts.find(1);
+    let tagA = this.schema.tags.find(15);
+    let tagB = this.schema.tags.find(16);
+
+    post.update('tagIds', [ '15' ]);
+
+    assert.equal(post.tags.length, 1);
+    assert.deepEqual(post.reload().tagIds, [ '15' ]);
+    assert.deepEqual(tagA.reload().postIds, [ '1' ]);
+    assert.deepEqual(tagB.reload().postIds, [ ]);
+  });
+});


### PR DESCRIPTION
Saving a graph of relationships was triggering multiple saves on the same object which was leading to some bugs. I added a simple `isSaving` dictionary to the Schema object to keep track of which models were already being saved during a cascading save, to avoid this.