### PR TITLE
Add options verb mocking

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -149,7 +149,7 @@ export default class Server {
       'You cannot modify Mirage\'s environment once the server is created');
     this.environment = config.environment || 'development';
 
-    this._options = config;
+    this._config = config;
 
     this.timing = this.timing || config.timing || 400;
     this.namespace = this.namespace || config.namespace || '';
@@ -296,7 +296,7 @@ export default class Server {
    * @public
    */
   loadFixtures(...args) {
-    let { fixtures } = this._options;
+    let { fixtures } = this._config;
     if (args.length) {
       let camelizedArgs = args.map(camelize);
       fixtures = _pick(fixtures, ...camelizedArgs);

--- a/addon/server.js
+++ b/addon/server.js
@@ -482,7 +482,7 @@ export default class Server {
    * @private
    */
   _defineRouteHandlerHelpers() {
-    [['get'], ['post'], ['put'], ['delete', 'del'], ['patch'], ['head']].forEach(([verb, alias]) => {
+    [['get'], ['post'], ['put'], ['delete', 'del'], ['patch'], ['head'], ['options']].forEach(([verb, alias]) => {
       this[verb] = (path, ...args) => {
         let [ rawHandler, customizedCode, options ] = extractRouteArguments(args);
         this._registerRouteHandler(verb, path, rawHandler, customizedCode, options);

--- a/addon/server.js
+++ b/addon/server.js
@@ -149,7 +149,7 @@ export default class Server {
       'You cannot modify Mirage\'s environment once the server is created');
     this.environment = config.environment || 'development';
 
-    this.options = config;
+    this._options = config;
 
     this.timing = this.timing || config.timing || 400;
     this.namespace = this.namespace || config.namespace || '';
@@ -270,7 +270,7 @@ export default class Server {
    * @public
    */
   passthrough(...paths) {
-    let verbs = ['get', 'post', 'put', 'delete', 'patch'];
+    let verbs = ['get', 'post', 'put', 'delete', 'patch', 'options'];
     let lastArg = paths[paths.length - 1];
 
     if (paths.length === 0) {
@@ -296,7 +296,7 @@ export default class Server {
    * @public
    */
   loadFixtures(...args) {
-    let { fixtures } = this.options;
+    let { fixtures } = this._options;
     if (args.length) {
       let camelizedArgs = args.map(camelize);
       fixtures = _pick(fixtures, ...camelizedArgs);

--- a/tests/integration/http-verbs-test.js
+++ b/tests/integration/http-verbs-test.js
@@ -122,4 +122,19 @@ module('Integration | HTTP Verbs', function(hooks) {
       assert.ok(e.xhr.status, 404);
     }
   });
+
+  test('mirage responds to options', async function(assert) {
+    assert.expect(1);
+
+    this.server.options('/contacts', function() {
+      return true;
+    });
+
+    let { data } = await promiseAjax({
+      method: 'OPTIONS',
+      url: '/contacts'
+    });
+
+    assert.equal(data, true);
+  });
 });


### PR DESCRIPTION
Hi guys!

Good job with this plugin, we at Uniplaces use it in all our projects and it makes the development super easy, it is completely essential now!

# Context
This adds the possibility to mock `option` requests. I followed what you guys said here (https://github.com/samselikoff/ember-cli-mirage/issues/804). Hope it is alright!

- I've renamed the internal `options` (configuration options) as it is limiting us (we couldn't define the `options` method). I would love to hear from you guys if you think this can break APIs. 

- From my understanding, we shouldn't be changing options from outside of the server and I obviously renamed the inside calls to `this.options` solving the above problem. 

If it does break, it would be cool to discuss a better way of doing this :) (and create tests to confirm people don't rename `this.options` without tests breaking.

Thanks!