### PR TITLE
Allow nested mirage modules

### DIFF
--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -4,7 +4,7 @@
 
 import { assert } from '@ember/debug';
 import _camelCase from 'lodash/camelCase';
-import { pluralize } from 'ember-cli-mirage/utils/inflector';
+import { pluralize, camelize } from 'ember-cli-mirage/utils/inflector';
 import require from 'require';
 
 /*
@@ -27,10 +27,9 @@ export default function(prefix) {
       return;
     }
     let moduleParts = moduleName.split('/');
-    let moduleType = _camelCase(moduleParts[moduleParts.length - 2]);
-    let moduleKey = moduleParts[moduleParts.length - 1];
-    assert(`Subdirectories under ${moduleType} are not supported`,
-      moduleParts[moduleParts.length - 3] === 'mirage');
+    let moduleTypeIndex = moduleParts.indexOf('mirage') + 1;
+    let moduleType = _camelCase(moduleParts[moduleTypeIndex]);
+    let moduleKey = moduleParts.slice([moduleTypeIndex + 1]).join('/');
 
     if (moduleType === 'scenario') {
       assert('Only scenario/default.js is supported at this time.',
@@ -51,7 +50,7 @@ export default function(prefix) {
 
     let data = module.default;
 
-    modulesMap[moduleType][_camelCase(moduleKey)] = data;
+    modulesMap[moduleType][camelize(moduleKey)] = data;
   });
 
   return modulesMap;


### PR DESCRIPTION
When I've tried to put a factory to the nested directory inside of `mirage/factories/` directory I've got an error. Is there any reasons for this? With this change seems like everything works.