### PR TITLE
support include as array

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -62,7 +62,8 @@ const JSONAPISerializer = Serializer.extend({
     let relationshipPaths;
 
     if (this.hasQueryParamIncludes()) {
-      relationshipPaths = this.request.queryParams.include.split(',');
+      let { include } = this.request.queryParams;
+      relationshipPaths = this._getIncludedRelationshipsAsArray(include);
     } else {
       let serializer = this.serializerFor(resource.modelName);
       relationshipPaths = serializer.getKeysForIncluded();
@@ -194,16 +195,21 @@ const JSONAPISerializer = Serializer.extend({
   _relationshipIsIncluded(relationshipKey) {
     if (this.hasQueryParamIncludes()) {
       let relationshipKeyAsString = this.keyForRelationship(relationshipKey);
-
-      return this.request.queryParams
-        .include
-        .split(',')
+      let { include } = this.request.queryParams;
+      let includedRelationships = this._getIncludedRelationshipsAsArray(include);
+      return includedRelationships
         .some(str => str.indexOf(relationshipKeyAsString) > -1);
     } else {
       let relationshipPaths = this.getKeysForIncluded();
 
       return relationshipPaths.includes(relationshipKey);
     }
+  },
+
+  _getIncludedRelationshipsAsArray(included) {
+    return Array.isArray(included)
+      ? included
+      : included.split(',');
   },
 
   getQueryParamIncludes() {

--- a/tests/integration/serializers/json-api-serializer/associations/includes-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/includes-test.js
@@ -172,6 +172,61 @@ module('Integration | Serializers | JSON API Serializer | Associations | Include
     });
   });
 
+  test('query param includes as an array work when serializing a model', function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: JSONAPISerializer
+    });
+
+    let post = this.schema.blogPosts.create();
+    post.createWordSmith();
+    post.createFineComment();
+    post.createFineComment();
+
+    let request = {
+      queryParams: {
+        include: ['word-smith', 'fine-comments']
+      }
+    };
+
+    let result = registry.serialize(post, request);
+
+    assert.propEqual(result, {
+      data: {
+        type: 'blog-posts',
+        id: '1',
+        attributes: {},
+        relationships: {
+          'word-smith': {
+            data: { type: 'word-smiths', id: '1' }
+          },
+          'fine-comments': {
+            data: [
+              { type: 'fine-comments', id: '1' },
+              { type: 'fine-comments', id: '2' }
+            ]
+          }
+        }
+      },
+      included: [
+        {
+          type: 'word-smiths',
+          id: '1',
+          attributes: {}
+        },
+        {
+          type: 'fine-comments',
+          id: '1',
+          attributes: {}
+        },
+        {
+          type: 'fine-comments',
+          id: '2',
+          attributes: {}
+        }
+      ]
+    });
+  });
+
   test('query param includes work when serializing a collection', function(assert) {
     let registry = new SerializerRegistry(this.schema, {
       application: JSONAPISerializer


### PR DESCRIPTION
# What's in this PR?

Ran into this issue earlier with params such as `include[]=users`.  The current JSONAPISerializer assumes that the `include` query param will be a string, but it could be passed as an array.