### PR TITLE
correct the file path to example model definition

### DIFF
--- a/docs/v0.2.x/models.md
+++ b/docs/v0.2.x/models.md
@@ -285,13 +285,13 @@ would add all the named `author` and `comment` methods as listed above, but use 
 Sometimes a `hasMany` relationship can point to a model with multiple associations of the same type. You can use the `inverse` option to specify which property on the related model is the inverse of the given relationship:
 
 ```js
-// app/models/talk.js
+// mirage/models/talk.js
 export default Model.extend({
   primaryEvent: belongsTo('event'),
   secondaryEvent: belongsTo('event'),
 });
 
-// app/models/event.js
+// mirage/models/event.js
 export default Model.extend({
   talks: hasMany('talk', { inverse: 'primaryEvent' }),
 });


### PR DESCRIPTION
I am fairly certain that these were meant to still be describing models in Mirage, and not in the Ember app.