### PR TITLE
POC: Fix teardown when pending requests

### DIFF
--- a/addon-test-support/setup-mirage.js
+++ b/addon-test-support/setup-mirage.js
@@ -1,4 +1,5 @@
 import startMirage from 'ember-cli-mirage/start-mirage';
+import { settled } from '@ember/test-helpers;
 
 //
 // Used to set up mirage for a test. Must be called after one of the
@@ -20,7 +21,9 @@ export default function setupMirage(hooks = self) {
   });
 
   hooks.afterEach(function() {
-    this.server.shutdown();
-    delete this.server;
+    return settled().then(() => {
+      this.server.shutdown();
+      delete this.server;
+    });
   });
 }


### PR DESCRIPTION
Since QUnit callbacks are async, this leaves a window where an AJAX request could happen _after_ mirage is torn down but before the application is. This can cause errors. To fix, we make sure that things have settled before we tear down the server.