### PR TITLE
fix(rest-serializer): return correctly serialized objects 

### DIFF
--- a/addon/serializers/rest-serializer.js
+++ b/addon/serializers/rest-serializer.js
@@ -1,5 +1,8 @@
 import ActiveModelSerializer from './active-model-serializer';
 import { camelize, singularize, pluralize } from '../utils/inflector';
+import _assign from 'lodash/assign';
+import Collection from '../orm/collection';
+import PolymorphicCollection from '../orm/polymorphic-collection';
 
 export default ActiveModelSerializer.extend({
 
@@ -29,6 +32,64 @@ export default ActiveModelSerializer.extend({
 
   getCoalescedIds(request) {
     return request.queryParams && request.queryParams.ids;
-  }
+  },
 
+  /**
+   * @method _maybeAddAssociationIds
+   * @param model
+   * @param attrs
+   * @private
+   */
+  _maybeAddAssociationIds(model, attrs) {
+    let newHash = _assign({}, attrs);
+
+    if (this.serializeIds === 'always') {
+      model.associationKeys.forEach((key) => {
+        let association = model[key];
+        if (this.isCollection(association)) {
+          let formattedKey = this.keyForRelationshipIds(key);
+          newHash[formattedKey] = model[key].models.map((m) => {
+            return { id: m.id, type: m.modelName };
+          });
+        } else if (association) {
+          let formattedKey = this.keyForForeignKey(key);
+          newHash[formattedKey] = model[`${key}Id`];
+        }
+      });
+    } else if (this.serializeIds === 'included') {
+      this.getKeysForIncluded().forEach((key) => {
+        let association = model[key];
+
+        if (model.associationFor(key).isPolymorphic) {
+          if (association instanceof PolymorphicCollection) {
+            let formattedKey = this.keyForRelationship(key);
+
+            newHash[formattedKey] = model[`${singularize(key)}Ids`];
+          } else if (association instanceof Collection) {
+            let formattedKey = this.keyForRelationshipIds(key);
+
+            newHash[formattedKey] = model[key].models.map((m) => m.id);
+          } else {
+            let formattedTypeKey = this.keyForPolymorphicForeignKeyType(key);
+            let formattedIdKey = this.keyForPolymorphicForeignKeyId(key);
+
+            newHash[formattedTypeKey] = model[`${key}Id`].type;
+            newHash[formattedIdKey] = model[`${key}Id`].id;
+          }
+        } else {
+          if (this.isCollection(association)) {
+            let formattedKey = this.keyForRelationshipIds(key);
+
+            newHash[formattedKey] = model[key].models.map((m) => m.id);
+          } else if (association) {
+            let formattedKey = this.keyForForeignKey(key);
+
+            newHash[formattedKey] = model[`${key}Id`];
+          }
+        }
+      });
+    }
+
+    return newHash;
+  }
 });

--- a/tests/integration/serializers/rest-serializer/serialize-ids-test.js
+++ b/tests/integration/serializers/rest-serializer/serialize-ids-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+import { RestSerializer, Model, hasMany } from 'ember-cli-mirage';
+
+module('Integration | Serializers | Rest Serializer | Serialize ids', function(hooks) {
+  hooks.beforeEach(function() {
+    this.schema = new Schema(new Db(), {
+      wordSmith: Model.extend({
+        blogPosts: hasMany(),
+        specialPosts: hasMany('blog-post', { inverse: 'specialAuthor' })
+      }),
+      blogPost: Model
+    });
+  });
+
+  hooks.afterEach(function() {
+    this.schema.db.emptyData();
+  });
+
+  test(`if serializeIds is 'always' it serailizes the ides of all hasMany associations`, function(assert) {
+    let ApplicationSerializer = RestSerializer;
+
+    let registry = new SerializerRegistry(this.schema, {
+      application: ApplicationSerializer,
+      wordSmith: ApplicationSerializer.extend({
+        serializeIds: 'always'
+      })
+    });
+
+    let wordSmith = this.schema.wordSmiths.create({
+      id: 1,
+      name: 'Link'
+    });
+    wordSmith.createBlogPost();
+    wordSmith.createBlogPost();
+    wordSmith.createSpecialPost();
+
+    let result = registry.serialize(wordSmith);
+
+    assert.deepEqual(result, {
+      wordSmith: {
+        id: '1',
+        name: 'Link',
+        blogPosts: [
+          { id: '1', type: 'blog-post' },
+          { id: '2', type: 'blog-post' }
+        ],
+        specialPosts: [{ id: '3', type: 'blog-post' }]
+      }
+    });
+  });
+});


### PR DESCRIPTION
Part of #1274.

When using **ember-data's** `RESTSerializer`, it expects associated objects rather than ids, i.e.:
```
{
  "user": {
    "id": "1",
    "things": [{
        "id": "1",
        "type": "picture"
      }]
  }
}
```
What will not work with `RESTSerializer` is the following:
```
{
  "user": {
    "id": "1",
    "thingIds": [{
        "id": "1",
        "type": "picture"
      }]
  }
}
```
OR
```
{
  "user": {
    "id": "1",
    "thingIds": ["1"]
  }
}
```
I couldn't really find good docs on what ember data expects when you are sending associations. But I have this [repo](https://github.com/geekygrappler/mirage-example/tree/isssue-1274-rest-serializer), when you visit http://localhost:4200/users/1 it'll throw an error. When using **Mirage's** `RestSerializer` with `serializeIds: 'always'` the response is:
```
{
  "user": {
    "id": "1",
    "things": ["1"]
  }
}
```

And if I make the changes in this PR, then ember data doesn't throw an error and loads the associated models.

I think the main problem here, is that **ember-data's** `RESTSerializer` doesn't seem to respond to serialized Ids for associations in responses i.e. `thingIds: [ids]`, or it wants serialized objects for with ids for associations in repsonses i.e. `things: [objects]`.

So while this fix works, I'm not sure `serializeIds: 'always'` is the correct option for telling **mirage's** `RestSerializer` to include the associated objects in the response.