### PR TITLE
Revert initializer name

### DIFF
--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -13,7 +13,7 @@ import startMirageImpl from 'ember-cli-mirage/start-mirage';
 //    tests.
 //
 export default {
-  name: 'ember-cli-mirage-config',
+  name: 'ember-cli-mirage',
   initialize(application) {
     if (baseConfig) {
       application.register('mirage:base-config', baseConfig, { instantiate: false });


### PR DESCRIPTION
I didn't mean to change this, and it breaks apps that have initializers that reference this one in their `before` or `after` fields.