### PR TITLE
Allow for the same inverse association key to exists many times

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -271,7 +271,7 @@ class Model {
     let associations = this.schema.associationsFor(this.modelName);
     let matchingExplicitInverses = Object.keys(associations).filter(key => {
       let candidate = associations[key];
-      let modelMatches = association.modelName === candidate.ownerModelName;
+      let modelMatches = association.ownerModelName === candidate.modelName;
       let inverseKeyMatches = association.key === candidate.opts.inverse;
 
       return modelMatches && inverseKeyMatches;

--- a/tests/integration/orm/schema-verification/mixed-test.js
+++ b/tests/integration/orm/schema-verification/mixed-test.js
@@ -244,4 +244,42 @@ module('Integration | ORM | Schema Verification | Mixed', function() {
 
     assert.deepEqual(post.inverseFor(userPostsAssociation), post.associationFor('authors'));
   });
+
+  test('multiple explicit inverse associations with the same key but different models does not throw an error', function(assert) {
+    let schema = new Schema(new Db({
+      users: [
+        { id: 1, name: 'Frodo' }
+      ],
+      posts: [
+        { id: 1, title: 'Lorem' }
+      ],
+      books: [
+        { id: 1, title: 'Ipsum' }
+      ]
+    }), {
+      user: Model.extend({
+        authoredPosts: hasMany('post', { inverse: 'authors' }),
+        authoredBooks: hasMany('book', { inverse: 'authors' })
+      }),
+      post: Model.extend({
+        authors: hasMany('user', { inverse: 'authoredPosts' })
+      }),
+      book: Model.extend({
+        authors: hasMany('user', { inverse: 'authoredBooks' })
+      })
+    });
+
+    let frodo = schema.users.find(1);
+    let post = schema.posts.find(1);
+    let book = schema.books.find(1);
+
+    let userAuthoredPostsAssociation = frodo.associationFor('authoredPosts');
+    let userAuthoredBooksAssociation = frodo.associationFor('authoredBooks');
+    let postsAuthorsAssociation = post.associationFor('authors');
+    let bookAuthorsAssociation = book.associationFor('authors');
+    assert.deepEqual(post.inverseFor(userAuthoredPostsAssociation), post.associationFor('authors'));
+    assert.deepEqual(book.inverseFor(userAuthoredBooksAssociation), book.associationFor('authors'));
+    assert.deepEqual(frodo.inverseFor(postsAuthorsAssociation), frodo.associationFor('authoredPosts'));
+    assert.deepEqual(frodo.inverseFor(bookAuthorsAssociation), frodo.associationFor('authoredBooks'));
+  });
 });


### PR DESCRIPTION
 While this solution works I don't really know enough about the mirage internals to know if it is the right fix. 

Hopefully a test is worth a thousands words here, I'm finding this issue difficult to explain. This should be supported:
```
user: Model.extend({
  authoredPosts: hasMany('post', { inverse: 'authors' }),
  authoredBooks: hasMany('book', { inverse: 'authors' })
}),
post: Model.extend({
  authors: hasMany('user', { inverse: 'authoredPosts' })
}),
book: Model.extend({
  authors: hasMany('user', { inverse: 'authoredBooks' })
})
```

The `user` model here inverses two other models with the same property.