### PR TITLE
return pretender handler

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -485,7 +485,7 @@ export default class Server {
     [['get'], ['post'], ['put'], ['delete', 'del'], ['patch'], ['head'], ['options']].forEach(([verb, alias]) => {
       this[verb] = (path, ...args) => {
         let [ rawHandler, customizedCode, options ] = extractRouteArguments(args);
-        this._registerRouteHandler(verb, path, rawHandler, customizedCode, options);
+        return this._registerRouteHandler(verb, path, rawHandler, customizedCode, options);
       };
 
       if (alias) {
@@ -515,7 +515,7 @@ export default class Server {
     let fullPath = this._getFullPath(path);
     let timing = options.timing !== undefined ? options.timing : (() => this.timing);
 
-    this.pretender[verb](
+    return this.pretender[verb](
       fullPath,
       (request) => {
         return new Promise(resolve => {

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -11,6 +11,16 @@ module('Unit | Server', function() {
     server.shutdown();
   });
 
+  test('it can be instantiated', function(assert) {
+    let server = new Server({ environment: 'test' });
+
+    let handler = server.post('foo');
+
+    assert.strictEqual(handler.numberOfCalls, 0);
+
+    server.shutdown();
+  });
+
   test('it runs the default scenario in non-test environments', function(assert) {
     assert.expect(1);
 


### PR DESCRIPTION
This will enable you to do:

```js
  this.post('token-auth', () => ({ 'jwt': 'xxx' }))._name = 'post:token-auth';
```

```js
export function errorOnAuth() {
  let original = server.pretender.handlers.find(h => h._name === 'post:token-auth');
  server.post('token-auth', { errors: [{ detail: 'There was an error' }] }, 500);
  return function reset() {
    server.post('token-auth', original);
  };
}
```

unless there is already a way to do this?