### PR TITLE
Fix bug setting ID of inverse polymorphic belongsTo relationship

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -758,12 +758,16 @@ class Model {
       let inverse = model.inverseFor(association);
       let inverseFk = inverse.getForeignKey();
 
+      let ownerId = this.id;
       if (inverse instanceof BelongsTo) {
-        this.schema.db[toInternalCollectionName(model.modelName)]
-          .update(model.id, { [inverseFk]: this.id });
-
+        let newId;
+        if (inverse.isPolymorphic) {
+          newId = { type: this.modelName, id: ownerId };
+        } else {
+          newId = ownerId;
+        }
+        this.schema.db[toInternalCollectionName(model.modelName)].update(model.id, { [inverseFk]: newId });
       } else {
-        let ownerId = this.id;
         let inverseCollection = this.schema.db[toInternalCollectionName(model.modelName)];
         let currentIdsForInverse = inverseCollection.find(model.id)[inverse.getForeignKey()] || [];
         let newIdsForInverse = _assign([], currentIdsForInverse);

--- a/tests/integration/orm/belongs-to/regressions/pr-1312-test.js
+++ b/tests/integration/orm/belongs-to/regressions/pr-1312-test.js
@@ -1,0 +1,23 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+import { module, test } from 'qunit';
+
+module('Integration | ORM | Belongs To | Regressions | pr-1312', function() {
+  test(`creating and using a record with a polymorphic hasMany and explicit inverse does not fail when accessing the association`, function(assert) {
+    let schema = new Schema(new Db(), {
+      comment: Model.extend({
+        commentable: belongsTo({ polymorphic: true, inverse: 'comments' })
+      }),
+
+      post: Model.extend({
+        comments: hasMany('comment', { inverse: 'commentable' })
+      })
+    });
+
+    let post = schema.posts.create();
+    post.createComment();
+
+    assert.equal(post.comments.models.length, 1);
+  });
+});


### PR DESCRIPTION
Error manifested as:

```
TypeError: Cannot read property 'replace' of undefined
    at Cache.func (http://0.0.0.0:62594/assets/vendor.js:64068:16)
    at Cache.get (http://0.0.0.0:62594/assets/vendor.js:47407:37)
    at decamelize (http://0.0.0.0:62594/assets/vendor.js:64111:29)
    at Cache.func (http://0.0.0.0:62594/assets/vendor.js:64016:12)
    at Cache.get (http://0.0.0.0:62594/assets/vendor.js:47407:37)
    at dasherize (http://0.0.0.0:62594/assets/vendor.js:64115:35)
    at toCollectionName (http://0.0.0.0:62594/assets/vendor.js:193841:46)
    at toInternalCollectionName (http://0.0.0.0:62594/assets/vendor.js:193846:16)
    at Child._validateForeignKeyExistsInDatabase (http://0.0.0.0:62594/assets/vendor.js:190721:78)
    at Child.<anonymous> (http://0.0.0.0:62594/assets/vendor.js:190675:16)
```