### PR TITLE
Don't create extra models in the db when passing association overrides to `create`

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -358,7 +358,7 @@ export default class Server {
       let attrs = OriginalFactory.attrs || {};
       this._validateTraits(traits, OriginalFactory, type);
       let mergedExtensions = this._mergeExtensions(attrs, traits, overrides);
-      this._mapAssociationsFromAttributes(type, attrs);
+      this._mapAssociationsFromAttributes(type, attrs, overrides);
       this._mapAssociationsFromAttributes(type, mergedExtensions);
 
       let Factory = OriginalFactory.extend(mergedExtensions);
@@ -665,14 +665,16 @@ export default class Server {
    *
    * @private
    */
-  _mapAssociationsFromAttributes(modelType, attributes) {
+  _mapAssociationsFromAttributes(modelType, attributes, overrides = {}) {
     Object.keys(attributes || {}).filter((attr) => {
       return isAssociation(attributes[attr]);
     }).forEach((attr) => {
       let association = attributes[attr];
       let associationName = this._fetchAssociationNameFromModel(modelType, attr);
       let foreignKey = `${camelize(attr)}Id`;
-      attributes[foreignKey] = this.create(associationName, ...association.traitsAndOverrides).id;
+      if (!overrides[attr]) {
+        attributes[foreignKey] = this.create(associationName, ...association.traitsAndOverrides).id;
+      }
       delete attributes[attr];
     });
   }

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -563,6 +563,37 @@ module('Unit | Server #create', function() {
       { name: 'splendid software', id: '1', isPublished: true, publishedAt: '2016-01-01 12:00:00' }
     );
   });
+
+  test('create does not create (extra) models on associations when they are passed in as overrides', function(assert) {
+    let MotherFactory = Factory.extend({
+      name: 'Should not create'
+    });
+    let ChildFactory = Factory.extend({
+      mother: association()
+    });
+
+    let server = new Server({
+      environment: 'test',
+      factories: {
+        mother: MotherFactory,
+        child: ChildFactory
+      },
+      models: {
+        mother: Model.extend({
+          children: hasMany('child')
+        }),
+        child: Model.extend({
+          mother: belongsTo('mother')
+        })
+      }
+    });
+
+    let mother = server.create('mother', { name: 'Lynda' });
+    server.create('child', { name: 'Don', mother });
+    server.create('child', { name: 'Dan', mother });
+
+    assert.equal(server.db.mothers.length, 1);
+  });
 });
 
 module('Unit | Server #createList', function(hooks) {


### PR DESCRIPTION
This addresses #1298. Hope this change works for you.