### PR TITLE
Relationship path normalization

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -270,9 +270,9 @@ const JSONAPISerializer = Serializer.extend({
           let graphRelationshipKey = dasherize(relationshipKey);
           let normalizedRelationshipKey = camelize(relationshipKey);
           let hasAssociation = model.associationKeys.includes(normalizedRelationshipKey);
-        
+
           assert(hasAssociation, `You tried to include "${relationshipKey}" with ${model} but no association named "${normalizedRelationshipKey}" is defined on the model.`);
-          
+
           let relationship = model[normalizedRelationshipKey];
           let relationshipData;
 

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -266,6 +266,7 @@ const JSONAPISerializer = Serializer.extend({
           graph.data[graphKey].relationships = graph.data[graphKey].relationships || {};
           let relationshipKeys = includesPath.split('.');
           let relationshipKey = relationshipKeys[0];
+          let graphRelationshipKey = dasherize(relationshipKey);
           let relationship = model[camelize(relationshipKey)];
           let relationshipData;
 
@@ -277,7 +278,7 @@ const JSONAPISerializer = Serializer.extend({
             relationshipData = null;
           }
 
-          graph.data[graphKey].relationships[relationshipKey] = relationshipData;
+          graph.data[graphKey].relationships[graphRelationshipKey] = relationshipData;
 
           if (relationship) {
             this._addResourceToRequestedIncludesGraph(graph, relationship, relationshipKeys.slice(1));

--- a/tests/integration/server/regressions/1322-relationship-path-normalization-test.js
+++ b/tests/integration/server/regressions/1322-relationship-path-normalization-test.js
@@ -1,0 +1,73 @@
+import { module, test } from 'qunit';
+import { Model, hasMany, belongsTo, JSONAPISerializer } from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+import promiseAjax from 'dummy/tests/helpers/promise-ajax';
+
+module('Integration | Server | Regressions | 1322 Relationship Path Normalization Test', function(hooks) {
+  hooks.beforeEach(function() {
+    this.server = new Server({
+      environment: 'test',
+      models: {
+        happyUser: Model.extend({
+          happyLicenses: hasMany()
+        }),
+        happyLicense: Model.extend({
+          happyUser: belongsTo()
+        })
+      },
+      serializers: {
+        application: JSONAPISerializer.extend({
+          keyForRelationship(relationshipName) {
+            if (relationshipName === 'happyUser') {
+              return 'happy_user';
+            } else {
+              return JSONAPISerializer.prototype.keyForRelationship.apply(this, arguments);
+            }
+          }
+        })
+      },
+      baseConfig() {
+        this.resource('happy-licenses');
+      }
+    });
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  test('it works', async function(assert) {
+    let user1 = this.server.create('happy-user');
+    this.server.create('happy-license', { happyUser: user1 });
+
+    assert.expect(2);
+
+    let response = await promiseAjax({
+      method: 'GET',
+      url: '/happy-licenses/1?include=happy_user'
+    });
+    let json = response.data;
+
+    assert.deepEqual(json.data, {
+      attributes: {},
+      id: "1",
+      relationships: {
+        "happy_user": {
+          data: {
+            id: user1.id,
+            type: "happy-users"
+          }
+        }
+      },
+      type: "happy-licenses"
+    });
+    assert.deepEqual(json.included, [
+      {
+        id: user1.id,
+        type: 'happy-users',
+        attributes: {}
+      }
+    ]);
+  });
+
+});


### PR DESCRIPTION
I believe this fixes #1322. This PR adds a commit for the failing test and a separate commit to fix it.

I added the test to the `integration/server/regressions` directory because that seemed the best place for it, but I'm not sure if it really is a regression per se. I'd be happy to move it somewhere more appropriate.