### PR TITLE
Throw when `include`ing a value that doesn't match an associationKey

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -2,6 +2,7 @@ import Serializer from '../serializer';
 import { dasherize, pluralize, camelize } from '../utils/inflector';
 import _get from 'lodash/get';
 import _ from 'lodash';
+import assert from 'ember-cli-mirage/assert';
 
 const JSONAPISerializer = Serializer.extend({
 
@@ -266,7 +267,12 @@ const JSONAPISerializer = Serializer.extend({
           graph.data[graphKey].relationships = graph.data[graphKey].relationships || {};
           let relationshipKeys = includesPath.split('.');
           let relationshipKey = relationshipKeys[0];
-          let relationship = model[camelize(relationshipKey)];
+          let normalizedRelationshipKey = camelize(relationshipKey);
+          let hasAssociation = model.associationKeys.includes(normalizedRelationshipKey);
+
+          assert(hasAssociation, `You tried to include "${relationshipKey}" with ${model} but no association named "${normalizedRelationshipKey}" is defined on the model.`);
+
+          let relationship = model[normalizedRelationshipKey];
           let relationshipData;
 
           if (this.isModel(relationship)) {

--- a/tests/integration/serializers/json-api-serializer/associations/includes-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/includes-test.js
@@ -494,4 +494,25 @@ module('Integration | Serializers | JSON API Serializer | Associations | Include
       ]
     });
   });
+
+  test('queryParamIncludes throws if including something that is not an association', function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: JSONAPISerializer
+    });
+
+    this.schema.db.loadData({
+      blogPosts: [
+        { id: 2, title: 'Lorem Ipsum' }
+      ]
+    });
+    let request = {
+      queryParams: {
+        include: 'title'
+      }
+    };
+
+    assert.throws(() => {
+      registry.serialize(this.schema.blogPosts.first(), request);
+    }, /You tried to include "title".*but no association named "title" is defined/);
+  });
 });


### PR DESCRIPTION
This prevents downstream errors when a property of the model is being
passed around that Mirage thinks is an association but is in reality a
primitive (such as a string) property of the model.

Fixes #1327