### PR TITLE
Support loading other scenarios in serve mode

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -193,6 +193,15 @@ export default class Server {
     }
 
     let hasFactories = this._hasModulesOfType(config, 'factories');
+
+    let hasConfiguredScenario = !!config.scenario;
+    let configuredScenarioPresent = config.scenarios && config.scenarios.hasOwnProperty(config.scenario);
+
+    if (hasConfiguredScenario) {
+      assert(configuredScenarioPresent,
+        `You configured a scenario '${config.scenario}' but it was not found`);
+    }
+
     let hasDefaultScenario = config.scenarios && config.scenarios.hasOwnProperty('default');
 
     let didOverridePretenderConfig = (config.trackRequests !== undefined) && this.pretender;
@@ -214,6 +223,9 @@ export default class Server {
 
     if (this.isTest() && hasFactories) {
       this.loadFactories(config.factories);
+    } else if (!this.isTest() && hasConfiguredScenario) {
+      this.loadFactories(config.factories);
+      config.scenarios[config.scenario](this);
     } else if (!this.isTest() && hasDefaultScenario) {
       this.loadFactories(config.factories);
       config.scenarios.default(this);

--- a/addon/start-mirage.js
+++ b/addon/start-mirage.js
@@ -32,6 +32,7 @@ export default function startMirage(owner, { env, baseConfig, testConfig } = {})
   let modules = readModules(env.modulePrefix);
   let options = _assign(modules, {environment, baseConfig, testConfig, discoverEmberDataModels});
   options.trackRequests = env['ember-cli-mirage'].trackRequests;
+  options.scenario = env['ember-cli-mirage'].scenario;
 
   return new Server(options);
 }

--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -32,11 +32,6 @@ export default function(prefix) {
     assert(`Subdirectories under ${moduleType} are not supported`,
       moduleParts[moduleParts.length - 3] === 'mirage');
 
-    if (moduleType === 'scenario') {
-      assert('Only scenario/default.js is supported at this time.',
-        moduleKey !== 'default');
-    }
-
     /*
       Ensure fixture keys are pluralized
     */

--- a/tests/unit/server-test.js
+++ b/tests/unit/server-test.js
@@ -35,6 +35,41 @@ module('Unit | Server', function() {
 
     server.shutdown();
   });
+
+  test('it runs a different scenario if configured in non-test environments', function(assert) {
+    assert.expect(1);
+
+    let server = new Server({
+      environment: 'development',
+      scenario: 'plans',
+      scenarios: {
+        default() {
+          assert.ok(false);
+        },
+        plans() {
+          assert.ok(true);
+        }
+      }
+    });
+
+    server.shutdown();
+  });
+
+  test('it throws an exception if the configured scenario is not present in non-test environments', function(assert) {
+    assert.expect(1);
+
+    assert.throws(function() {
+      let server = new Server({
+        environment: 'development',
+        scenario: 'plans',
+        scenarios: {
+          default() {}
+        }
+      });
+
+      server.shutdown();
+    }, /You configured a scenario 'plans' but it was not found/);
+  });
 });
 
 module('Unit | Server #loadConfig', function() {


### PR DESCRIPTION
Took a shot at implementing my feature request [here](https://ember-cli-mirage.canny.io/feature-requests/p/support-for-loading-other-scenarios-in-ember-serve) for myself.

Feedback very welcome and I'm in no real rush to get this merged, I can add documentation as well if the approach is validated.