### PR TITLE
Fix exists-sync deprecation by replacing with fs.existsSync

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -3,7 +3,7 @@
 'use strict';
 
 var path = require('path');
-var existsSync = require('exists-sync');
+var fs = require('fs');
 var chalk = require('chalk');
 var EOL = require('os').EOL;
 
@@ -51,7 +51,7 @@ module.exports = {
   },
 
   insertShutdownIntoDestroyApp: function() {
-    if (existsSync('tests/helpers/destroy-app.js')) {
+    if (fs.existsSync('tests/helpers/destroy-app.js')) {
       var shutdownText = '  if (window.server) {\n    window.server.shutdown();\n  }';
       return this.insertIntoFile('tests/helpers/destroy-app.js', shutdownText, {
         after: "run(application, 'destroy');\n"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-get-config": "^0.2.2",
     "ember-inflector": "^2.0.0",
     "ember-lodash": "^4.17.3",
-    "exists-sync": "0.0.3",
     "fake-xml-http-request": "^1.4.0",
     "faker": "^3.0.0",
     "pretender": "^1.6.1",


### PR DESCRIPTION
Fixes this deprecation warning
```
warning ember-cli-mirage > exists-sync@0.0.3: Please replace with usage of fs.existsSync
```