### PR TITLE
fix: serialize belongsTo key in camel-case

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -298,7 +298,7 @@ class Serializer {
           newHash[formattedKey] = model[key].models.map((m) => m.id);
         } else if (association) {
           let formattedKey = this.keyForForeignKey(key);
-          newHash[formattedKey] = model[`${key}Id`];
+          newHash[formattedKey] = model[`${camelize(key)}Id`];
         }
       });
     } else if (this.serializeIds === 'included') {
@@ -318,8 +318,8 @@ class Serializer {
             let formattedTypeKey = this.keyForPolymorphicForeignKeyType(key);
             let formattedIdKey = this.keyForPolymorphicForeignKeyId(key);
 
-            newHash[formattedTypeKey] = model[`${key}Id`].type;
-            newHash[formattedIdKey] = model[`${key}Id`].id;
+            newHash[formattedTypeKey] = model[`${camelize(key)}Id`].type;
+            newHash[formattedIdKey] = model[`${camelize(key)}Id`].id;
           }
         } else {
           if (this.isCollection(association)) {
@@ -329,7 +329,7 @@ class Serializer {
           } else if (association) {
             let formattedKey = this.keyForForeignKey(key);
 
-            newHash[formattedKey] = model[`${key}Id`];
+            newHash[formattedKey] = model[`${camelize(key)}Id`];
           }
         }
       });


### PR DESCRIPTION
Mirage seems to use and expect camelCased keys for its relations, such as belongsTo.

Some application provide snake_cased keys, so in the case of a key being composed of multiple words, `snake_case_key`, Mirage will generate an invalid `snake_case_keyId` while it expects in fact `snakeCaseKeyId`.

This seems to fix the issue for the application I'm working on. I've investigated without success on a more appropriate place.

Am i missing or misunderstanding anything?

I am not sure if this solution should be enforces on other part of the code, and what test to write.

I'll hapilly implement any suggestion.

Cheers.