### PR TITLE
Improved BaseRouteHandler#getModelClassFromPath

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -1,6 +1,8 @@
 import assert from 'ember-cli-mirage/assert';
 import { camelize, singularize, dasherize } from 'ember-cli-mirage/utils/inflector';
 
+const PATH_VAR_REGEXP = /^:/;
+
 export default class BaseRouteHandler {
 
   getModelClassFromPath(fullPath) {
@@ -11,7 +13,7 @@ export default class BaseRouteHandler {
     let lastPath;
     while (path.length > 0) {
       lastPath = path.splice(-1)[0];
-      if (lastPath && lastPath !== ':id') {
+      if (lastPath && !PATH_VAR_REGEXP.test(lastPath)) {
         break;
       }
     }

--- a/tests/unit/route-handlers/shorthands/base-test.js
+++ b/tests/unit/route-handlers/shorthands/base-test.js
@@ -28,12 +28,24 @@ module('Unit | Route handlers | Shorthands | BaseShorthandRouteHandler', functio
     assert.equal(this.handler._getIdForRequest(this.request), 'someID', 'it returns a number');
   });
 
-  test('getModelClassFromPath works', function(assert) {
+  test('getModelClassFromPath works with various named route path variable', function(assert) {
     let urlWithSlash = '/api/fancy-users';
     let urlWithIdAndSlash = '/api/fancy-users/:id';
 
     assert.equal(this.handler.getModelClassFromPath(urlWithSlash), 'fancy-user', 'it returns a singular model name');
     assert.equal(this.handler.getModelClassFromPath(urlWithIdAndSlash, true), 'fancy-user', 'it returns a singular model name');
+
+    urlWithSlash = '/api/exquisite-users';
+    urlWithIdAndSlash = '/api/exquisite-users/:objectId';
+
+    assert.equal(this.handler.getModelClassFromPath(urlWithSlash), 'exquisite-user', 'it returns a singular model name');
+    assert.equal(this.handler.getModelClassFromPath(urlWithIdAndSlash, true), 'exquisite-user', 'it returns a singular model name');
+
+    urlWithSlash = '/api/elegant-users';
+    urlWithIdAndSlash = '/api/elegant-users/:firstName/:lastName';
+
+    assert.equal(this.handler.getModelClassFromPath(urlWithSlash), 'elegant-user', 'it returns a singular model name');
+    assert.equal(this.handler.getModelClassFromPath(urlWithIdAndSlash, true), 'elegant-user', 'it returns a singular model name');
   });
 
   test('it can read the id from the url', function(assert) {


### PR DESCRIPTION
Right now, when you provide a path like `/assets/:objectId` and use `this.normalizedRequestAttrs()` in the route handler, it is doing naïve matching on `:id` to break out of the reverse path iterator when looking for the name to "classify" for the model. 

There is no restriction that I am aware of that says route path variables should be `:id`. This change will allow for named route path variables other than :id when using a path and handler that utilizes `BaseRouteHandler#getModelClassFromPath` in some form.