### PR TITLE
fix: associationFor should handle dasherized relationshipName

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -1,6 +1,7 @@
 import BelongsTo from './associations/belongs-to';
 import HasMany from './associations/has-many';
 import { toCollectionName, toInternalCollectionName } from 'ember-cli-mirage/utils/normalize-name';
+import { camelize } from 'ember-cli-mirage/utils/inflector';
 import extend from '../utils/extend';
 import assert from '../assert';
 import Collection from './collection';
@@ -186,7 +187,7 @@ class Model {
    * @public
    */
   associationFor(key) {
-    return this.schema.associationsFor(this.modelName)[key];
+    return this.schema.associationsFor(this.modelName)[camelize(key)];
   }
 
   /**


### PR DESCRIPTION
Relationship names are dasherized in most cases (e.g. `product-owner`) but properties of model are camelCase (e.g. `productOwner`). `associationFor()` returned `undefined` in that cases and therefore
`association.isPolymorphic` throws.

This was introduced by a19814654721bbce9131454ad72b4d931de9339a