### PR TITLE
fix: remove outdated warning about missing destroy-app helper

### DIFF
--- a/blueprints/ember-cli-mirage/index.js
+++ b/blueprints/ember-cli-mirage/index.js
@@ -56,17 +56,6 @@ module.exports = {
       return this.insertIntoFile('tests/helpers/destroy-app.js', shutdownText, {
         after: "run(application, 'destroy');\n"
       });
-    } else {
-      this.ui.writeLine(
-        EOL +
-        chalk.yellow(
-          '******************************************************' + EOL +
-          'destroy-app.js helper is not present. Please read this' + EOL +
-          'https://gist.github.com/blimmer/35d3efbb64563029505a' + EOL +
-          'to see how to fix the problem.' + EOL +
-          '******************************************************' + EOL
-        )
-      );
     }
   },
 


### PR DESCRIPTION
This warning was introduced for applications generated with ember-cli <= 1.13.8. It's safe to assume that none of the applications which weren't updated yet will install ember-cli-mirage now if they haven't so far.

On the other hand this warning is misleading for all new generated projects with ember-cli >= 3.0.0.

Fixes #1300