### PR TITLE
Check if there is a server before shutting it down

### DIFF
--- a/addon-test-support/setup-mirage.js
+++ b/addon-test-support/setup-mirage.js
@@ -22,8 +22,10 @@ export default function setupMirage(hooks = self) {
 
   hooks.afterEach(function() {
     return settled().then(() => {
-      this.server.shutdown();
-      delete this.server;
+      if (this.server) {
+        this.server.shutdown();
+        delete this.server;
+      }
     });
   });
 }


### PR DESCRIPTION
In one of our test cases, the `afterEach` cases is called, when there is no server defined, which results in an error and in the case of mocha this cause the whole test suite to fail. Although this is most probably a problem there, I think that it is worth having this simple check here as well.