### PR TITLE
Camelize the relationship name before getting the association

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -60,7 +60,7 @@ export default class BaseRouteHandler {
       Object.keys(json.data.relationships).forEach((relationshipName) => {
         let relationship = json.data.relationships[relationshipName];
         let modelClass = this.schema.modelClassFor(modelName);
-        let association = modelClass.associationFor(relationshipName);
+        let association = modelClass.associationFor(camelize(relationshipName));
         let valueForRelationship;
 
         if (association.isPolymorphic) {


### PR DESCRIPTION
The default behaviour of the JSON:API serializer is to dasherize the relationship names, so having a multiple word relationship name, will result in a block like `... "post-author": { data: null }...`.

Without this patch the `_getAttrsForRequest` fails, because it cannot find the correct association (_Cannot read isPolymorphic of undefined_)