### PR TITLE
Adds assert for association definition

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -63,6 +63,11 @@ export default class BaseRouteHandler {
         let association = modelClass.associationFor(camelize(relationshipName));
         let valueForRelationship;
 
+        assert(
+          association,
+          `You're passing the relationship '${relationshipName}' to the '${modelName}' model via a ${request.method} to '${request.url}', but you did not define the '${relationshipName}' association on the '${modelName}' model. http://www.ember-cli-mirage.com/docs/v0.4.x/models/#associations`
+        );
+
         if (association.isPolymorphic) {
           valueForRelationship = relationship.data;
 

--- a/tests/integration/route-handlers/assertions-test.js
+++ b/tests/integration/route-handlers/assertions-test.js
@@ -1,0 +1,64 @@
+import { module, test } from 'qunit';
+
+import { Model, JSONAPISerializer } from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+import FunctionRouteHandler from 'ember-cli-mirage/route-handlers/function';
+
+module('Integration | Route handlers | Assertions', function(hooks) {
+  hooks.beforeEach(function() {
+    this.server = new Server({
+      environment: 'development',
+      models: {
+        user: Model.extend({
+        }),
+        comment: Model.extend({
+        })
+      },
+      serializers: {
+        application: JSONAPISerializer
+      }
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+
+    this.server.post('/users');
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  test('a helpful assert is thrown if a relationship passed in a request is not a defined association on the posted model', async function(assert) {
+    assert.expect(1);
+
+    let request = {
+      requestHeaders: {},
+      method: 'POST',
+      url: '/users',
+      requestBody: JSON.stringify({
+        data: {
+          type: 'user',
+          attributes: {
+            name: 'Jacob Dylan'
+          },
+          relationships: {
+            'comments': {
+              data: {
+                type: 'comment',
+                name: 'Bob Dylan'
+              }
+            }
+          }
+        }
+      })
+    };
+
+    this.functionHandler = new FunctionRouteHandler(this.server.schema, this.server.serializerOrRegistry);
+    this.functionHandler.path = '/users';
+    this.functionHandler.request = request;
+
+    assert.throws(function() {
+      this.functionHandler.normalizedRequestAttrs();
+    }, /You're passing the relationship 'comments' to the 'user' model via a POST to '\/users', but you did not define the 'comments' association on the 'user' model./);
+  });
+});


### PR DESCRIPTION
Hey! This repo is awesome. I have honestly never seen a test 'sweet' as expansive as this one.

I came across an issue in my code where I had not explicitly defined an association that I was posting via the relationships attr. (json:api) 

This resulted in a javascript exception on [this line](https://github.com/samselikoff/ember-cli-mirage/blob/master/addon/route-handlers/base.js#L66): around not being able to access the property `isPolymorphic of undefined`. 

This PR adds a simple assert in that code to help people fix this problem if they hit it. 

* Adds assert that ensures associations are defined when being included in json:api post requests

I tried to match the language style from other asserts. 