### PR TITLE
Use instanceof and overrides to distinguish associations

### DIFF
--- a/addon/orm/associations/association.js
+++ b/addon/orm/associations/association.js
@@ -1,4 +1,4 @@
-import { camelize, dasherize } from 'ember-cli-mirage/utils/inflector';
+import { dasherize } from 'ember-cli-mirage/utils/inflector';
 
 export default class Association {
 

--- a/addon/orm/associations/association.js
+++ b/addon/orm/associations/association.js
@@ -1,4 +1,4 @@
-import { camelize, singularize, dasherize } from 'ember-cli-mirage/utils/inflector';
+import { camelize, dasherize } from 'ember-cli-mirage/utils/inflector';
 
 export default class Association {
 
@@ -49,15 +49,7 @@ export default class Association {
     return this.opts.polymorphic;
   }
 
-  get isHasMany() {
-    return this.constructor.name === 'HasMany';
-  }
-
-  get isBelongsTo() {
-    return this.constructor.name === 'BelongsTo';
-  }
-
   get identifier() {
-    return this.isHasMany ? `${camelize(singularize(this.key))}Ids` : `${camelize(this.key)}Id`;
+    return `${camelize(this.key)}Id`;
   }
 }

--- a/addon/orm/associations/association.js
+++ b/addon/orm/associations/association.js
@@ -50,6 +50,6 @@ export default class Association {
   }
 
   get identifier() {
-    return `${camelize(this.key)}Id`;
+    throw new Error('Subclasses of Association must implement a getter for identifier');
   }
 }

--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -14,6 +14,10 @@ import assert from 'ember-cli-mirage/assert';
  */
 export default class BelongsTo extends Association {
 
+  get identifier() {
+    return `${camelize(this.key)}Id`;
+  }
+
   /**
    * @method getForeignKeyArray
    * @return {Array} Array of camelized name of the model owning the association

--- a/addon/orm/associations/has-many.js
+++ b/addon/orm/associations/has-many.js
@@ -15,6 +15,10 @@ import assert from 'ember-cli-mirage/assert';
  */
 export default class HasMany extends Association {
 
+  get identifier() {
+    return `${camelize(singularize(this.key))}Ids`;
+  }
+
   /**
    * @method getForeignKeyArray
    * @return {Array} Array of camelized model name of associated objects

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -504,13 +504,13 @@ class Model {
         let association = this.associationFor(key);
         let isNull = value === null;
 
-        if (association.isHasMany) {
+        if (association instanceof HasMany) {
           let isCollection = value instanceof Collection || value instanceof PolymorphicCollection;
           let isArrayOfModels = Array.isArray(value) && value.every(item => item instanceof Model);
 
           assert(isCollection || isArrayOfModels || isNull, `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a HasMany relationship. You must pass in a Collection, PolymorphicCollection, array of Models, or null.`);
 
-        } else if (association.isBelongsTo) {
+        } else if (association instanceof BelongsTo) {
           assert(value instanceof Model || isNull, `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a BelongsTo relationship. You must pass in a Model or null.`);
         }
       });

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -1,5 +1,6 @@
 import assert from 'ember-cli-mirage/assert';
 import { camelize, singularize, dasherize } from 'ember-cli-mirage/utils/inflector';
+import HasMany from '../orm/associations/has-many';
 
 const PATH_VAR_REGEXP = /^:/;
 
@@ -71,7 +72,7 @@ export default class BaseRouteHandler {
         if (association.isPolymorphic) {
           valueForRelationship = relationship.data;
 
-        } else if (association.isHasMany) {
+        } else if (association instanceof HasMany) {
           valueForRelationship = relationship.data && relationship.data.map(rel => rel.id);
 
         } else {

--- a/addon/server.js
+++ b/addon/server.js
@@ -12,6 +12,7 @@ import Schema from './orm/schema';
 import assert from './assert';
 import SerializerRegistry from './serializer-registry';
 import RouteHandler from './route-handler';
+import BelongsTo from './orm/associations/belongs-to';
 
 import _pick from 'lodash/pick';
 import _assign from 'lodash/assign';
@@ -703,11 +704,11 @@ export default class Server {
       let modelClass = this.schema.modelClassFor(modelName);
       let association = modelClass.associationFor(attr);
 
-      assert(association && association.isBelongsTo,
+      assert(association && association instanceof BelongsTo,
         `You're using the \`association\` factory helper on the '${attr}' attribute of your ${modelName} factory, but that attribute is not a \`belongsTo\` association. Read the Factories docs for more information: http://www.ember-cli-mirage.com/docs/v0.3.x/factories/#factories-and-relationships`
       );
 
-      let isSelfReferentialBelongsTo = association && association.isBelongsTo && association.modelName === modelName;
+      let isSelfReferentialBelongsTo = association && association instanceof BelongsTo && association.modelName === modelName;
 
       assert(!isSelfReferentialBelongsTo, `You're using the association() helper on your ${modelName} factory for ${attr}, which is a belongsTo self-referential relationship. You can't do this as it will lead to infinite recursion. You can move the helper inside of a trait and use it selectively.`);
 


### PR DESCRIPTION
Similarly to #1092 and #1168, https://github.com/samselikoff/ember-cli-mirage/blob/99c927009a539f7e1fbfb8f6e857372e2319856b/addon/orm/associations/association.js#L52-L54 and https://github.com/samselikoff/ember-cli-mirage/blob/99c927009a539f7e1fbfb8f6e857372e2319856b/addon/orm/associations/association.js#L56-L58 fail in production builds due to minification.

This PR replaces usages of `isHasMany` and `isBelongsTo` with `instanceof` and uses overrides within the associations classes themselves (for `identifier`).