### PR TITLE
Updated link to shorthands documentation

### DIFF
--- a/blueprints/ember-cli-mirage/files/__root__/config.js
+++ b/blueprints/ember-cli-mirage/files/__root__/config.js
@@ -21,6 +21,6 @@ export default function() {
     this.put('/posts/:id'); // or this.patch
     this.del('/posts/:id');
 
-    http://www.ember-cli-mirage.com/docs/v0.3.x/shorthands/
+    http://www.ember-cli-mirage.com/docs/v0.4.x/shorthands/
   */
 }


### PR DESCRIPTION
Link to shorthands documentation was still pointing to older version v0.3.x.