### PR TITLE
Pass a stack trace for route handler errors, fixes #1386

### DIFF
--- a/addon/assert.js
+++ b/addon/assert.js
@@ -23,8 +23,12 @@ export default function assert(bool, text) {
   @public
   Copied from ember-metal/error
 */
-export function MirageError() {
-  let tmp = Error.apply(this, arguments);
+export function MirageError(message, stack) {
+  let tmp = Error(message);
+
+  if (stack) {
+    tmp.stack = stack;
+  }
 
   for (let idx = 0; idx < errorProps.length; idx++) {
     let prop = errorProps[idx];

--- a/addon/route-handler.js
+++ b/addon/route-handler.js
@@ -79,7 +79,8 @@ export default class RouteHandler {
 
       } else {
         let message = (typeOf(e) === 'string') ? e : e.message;
-        let error = new MirageError(`Your ${request.method} handler for the url ${request.url} threw an error: ${message}`);
+        let messageExtended = `Your ${request.method} handler for the url ${request.url} threw an error: ${message}`;
+        let error = new MirageError(messageExtended, e.stack);
 
         result = new Response(500, {}, error.message);
       }


### PR DESCRIPTION
Initially I tried passing `e.stack` instead of `e.message` [here](https://github.com/samselikoff/ember-cli-mirage/blob/v0.4.9/addon/route-handler.js#L81), relying on a fact that the stack trace starts with the message anyway. But this resulted in the original stack trace being followed by the error hanlder stack trace -- without any indication where one ends and the other begins. :(

So instead I'm overrriding the stack trace of the error handler error.

I would prefer to do it in `handler._getMirageResponseForRequest` [here](https://github.com/samselikoff/ember-cli-mirage/blob/v0.4.9/addon/route-handler.js#L83), after `MirageError` instantiation. Unfortunately, `MirageError` constructor emits `console.error`s before `_getMirageResponseForRequest` has a chance to override `mirageError.stack`. 👎 

So the only option to fix the problem without refactoring the whole thing is to have `MirageError` constructor accept the stack as an argument.

In order to do this, I had to convert `Error(...arguments)` to `Error(message)`. I believe, this is safe to do because:

1. [According to MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error), only the first argument `message` is standardized.
2. All usages of `MirageError` constructor in Mirage codebase only pass error message.
3. Though marked as a public API, `MirageError` is never mentioned in docs.

