### PR TITLE
Make pretender a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,8 @@
     "ember-get-config": "^0.2.2",
     "ember-inflector": "^2.0.0",
     "ember-lodash": "^4.17.3",
-    "fake-xml-http-request": "^1.4.0",
     "faker": "^3.0.0",
     "jsdom": "^11.12.0",
-    "pretender": "^1.6.1",
     "route-recognizer": "^0.2.3"
   },
   "devDependencies": {
@@ -83,7 +81,11 @@
     "fastboot": "^1.2.0",
     "loader.js": "^4.2.3",
     "mocha": "^3.4.2",
+    "pretender": "^1.6.1",
     "qunit-dom": "^0.5.0"
+  },
+  "peerDependencies": {
+    "pretender": "^1.6.1"
   },
   "engines": {
     "node": "6.* || >= 7.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,7 +3756,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fake-xml-http-request@^1.4.0, fake-xml-http-request@^1.6.0:
+fake-xml-http-request@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-1.6.0.tgz#bd0ac79ae3e2660098282048a12c730a6f64d550"
   integrity sha512-99XPwwSg89BfzPuv4XCpZxn3EbauMCgAQCxq9MzrvS6DFD73OON6AnUTicL4A0HZtYMBwCZBWVnRqGjZDgQkTg==


### PR DESCRIPTION
Let's let the consumer of this addon decide which version of Pretender
is best for them.

Important Notes
=============

- [x] Assumes #1388 has been merged.
* I haven't gone to the lengths of supporting Pretender v2 yet. A preliminary spike suggests that's a bit more work than just bumping the version number. (Note: the problem seems to be that Pretender has a dependency on a few polyfill libs, and these either aren't being picked up or loaded correctly)

Questions
========

- [ ] Mirage provides a shim for ES6 Pretender imports. Should that still be the case? If not we'll have to bump to much more modern Pretender.