### PR TITLE
Expand npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 /bower_components
 /config/ember-try.js
 /dist
+/scripts
 /tests
 /tmp
 **/.gitkeep
@@ -14,6 +15,7 @@
 bower.json
 ember-cli-build.js
 testem.js
+yarn.lock
 
 # ember-try
 .node_modules.ember-try/

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,6 +1,0 @@
-{
-  "predef": [
-    "console"
-  ],
-  "strict": false
-}


### PR DESCRIPTION
Let's trim some fat.

Below results are from `npm publish --dry-run`:

Before
------

```
npm notice === Tarball Details ===
npm notice name:          ember-cli-mirage
npm notice version:       0.4.9
npm notice package size:  255.3 kB
npm notice unpacked size: 865.4 kB
npm notice shasum:        e359b3345fa75c80a876f4ed20ddfa8a19ad1106
npm notice integrity:     sha512-l7uJ/QaW6Vwun[...]4b7gMwpKArLWw==
npm notice total files:   74<Paste>
```

```
npm notice === Tarball Details ===
npm notice name:          ember-cli-mirage
npm notice version:       0.4.9
npm notice package size:  44.0 kB
npm notice unpacked size: 183.7 kB
npm notice shasum:        d42e6082d728fc2d8cbafa7600c863849eb4857c
npm notice integrity:     sha512-GgGNVMXXg9ZWq[...]Ei50rC/B9Qp2Q==
npm notice total files:   69
```