### PR TITLE
Improve automatic response type setting

### DIFF
--- a/addon/route-handler.js
+++ b/addon/route-handler.js
@@ -1,4 +1,4 @@
-import { isBlank, typeOf } from '@ember/utils';
+import { typeOf } from '@ember/utils';
 import { Promise } from 'rsvp';
 
 import { MirageError } from 'ember-cli-mirage/assert';
@@ -10,12 +10,6 @@ import PostShorthandHandler from './route-handlers/shorthands/post';
 import PutShorthandHandler from './route-handlers/shorthands/put';
 import DeleteShorthandHandler from './route-handlers/shorthands/delete';
 import HeadShorthandHandler from './route-handlers/shorthands/head';
-
-function isNotBlankResponse(response) {
-  return response
-    && !(typeOf(response) === 'object' && Object.keys(response).length === 0)
-    && (Array.isArray(response) || !isBlank(response));
-}
 
 const DEFAULT_CODES = { get: 200, put: 204, post: 201, 'delete': 204 };
 
@@ -111,7 +105,8 @@ export default class RouteHandler {
       code = this.customizedCode;
     } else {
       code = DEFAULT_CODES[this.verb];
-      if (code === 204 && isNotBlankResponse(response)) {
+      // Returning any data for a 204 is invalid
+      if (code === 204 && response !== undefined && response !== '') {
         code = 200;
       }
     }

--- a/tests/integration/server/falsy-responses-test.js
+++ b/tests/integration/server/falsy-responses-test.js
@@ -62,4 +62,20 @@ module('Integration | Server | Falsy responses', function(hooks) {
     assert.equal(xhr.status, 200);
     assert.equal(xhr.getAllResponseHeaders().trim(), "Content-Type: application/json");
   });
+
+  test('empty object PUT response returns an empty object', async function(assert) {
+    this.server.put('/example', function() {
+      return {};
+    });
+
+    let { data, xhr } = await promiseAjax({
+      method: 'PUT',
+      url: '/example'
+    });
+
+    assert.deepEqual(data, {});
+    assert.equal(xhr.responseText, "{}");
+    assert.equal(xhr.status, 200);
+    assert.equal(xhr.getAllResponseHeaders().trim(), "Content-Type: application/json");
+  });
 });


### PR DESCRIPTION
Simplifies checking for blank response to merely change to 200 when
the response type would have been a 204 and the response is not
undefined or an empty string. This also matches the heuristic in the
204-non-empty-payload warning.