### PR TITLE
Allow native async functions as route handlers

### DIFF
--- a/addon/route-handler.js
+++ b/addon/route-handler.js
@@ -16,11 +16,11 @@ const DEFAULT_CODES = { get: 200, put: 204, post: 201, 'delete': 204 };
 function createHandler({ verb, schema, serializerOrRegistry, path, rawHandler, options }) {
   let handler;
   let args = [schema, serializerOrRegistry, rawHandler, path, options];
-  let type = typeOf(rawHandler);
+  let type = typeof rawHandler;
 
   if (type === 'function') {
     handler = new FunctionHandler(...args);
-  } else if (type === 'object') {
+  } else if (type === 'object' && rawHandler) {
     handler = new ObjectHandler(...args);
   } else if (verb === 'get') {
     handler = new GetShorthandHandler(...args);


### PR DESCRIPTION
I had a handler that looked something like this, and was baffled for a while this afternoon as to why the callback was never triggering even though I saw Mirage logging that it had handled the request:

```js
this.post('/some-path', async () => {
  // some promise-y stuff
});
```

It turns out, on platforms where `async` functions are supported natively, `Ember.typeOf` incorrectly [identifies them as objects](https://github.com/emberjs/ember.js/issues/15151). Ultimately it was decided [not to extend `Ember.typeOf` to handle this](https://github.com/emberjs/ember.js/pull/15165) in favor of native `typeof` instead.