### PR TITLE
fix: shorthand link

### DIFF
--- a/tests/dummy/app/pods/docs/getting-started/quickstart/template.md
+++ b/tests/dummy/app/pods/docs/getting-started/quickstart/template.md
@@ -250,7 +250,7 @@ Mirage ships with two named serializers, JSONAPISerializer and ActiveModelSerial
 ## Shorthands
 
 <aside class='Docs-page__aside'>
-  <p>View more <a href="../shorthands">shorthands</a>.</p>
+  <p>View more <a href="../../advanced/shorthands">shorthands</a>.</p>
 </aside>
 
 Mirage has *shorthands* to reduce the code needed for conventional API routes. For example, the route handler


### PR DESCRIPTION
There is also an issue with:
See the `serializer guide` to learn more.

Not sure where it should point to