### PR TITLE
Omit default Content-Type header for 204 responses

### DIFF
--- a/addon/response.js
+++ b/addon/response.js
@@ -44,7 +44,7 @@ export default class Response {
     }
 
     // Default "untyped" responses to application/json
-    if (!this.headers.hasOwnProperty('Content-Type')) {
+    if (code !== 204 && !this.headers.hasOwnProperty('Content-Type')) {
       this.headers['Content-Type'] = 'application/json';
     }
   }

--- a/tests/integration/server/custom-responses-test.js
+++ b/tests/integration/server/custom-responses-test.js
@@ -61,7 +61,7 @@ module('Integration | Server | Custom responses', function(hooks) {
     assert.deepEqual(data, undefined);
     assert.equal(xhr.responseText, '');
     assert.equal(xhr.status, 204);
-    assert.equal(xhr.getAllResponseHeaders().trim(), "Content-Type: application/json");
+    assert.equal(xhr.getAllResponseHeaders().trim(), '');
   });
 
 });

--- a/tests/unit/response-test.js
+++ b/tests/unit/response-test.js
@@ -16,4 +16,18 @@ module('Unit | Response', function() {
     assert.ok(response);
     assert.ok(response.toRackResponse());
   });
+
+  test('it adds Content-Type by default', function(assert) {
+    let response = new Response(200, {}, {});
+
+    assert.ok(response);
+    assert.equal(response.headers['Content-Type'], 'application/json');
+  });
+
+  test('it does not add Content-Type for a 204 response', function(assert) {
+    let response = new Response(204);
+
+    assert.ok(response);
+    assert.notOk(response.headers['Content-Type']);
+  });
 });


### PR DESCRIPTION
As a 204 response has no response body, a Content-Type is basically meaningless. It doesn't seem to be a violation of any spec to have one AFAICT, but as it is optional and does not make sense here, it seems better to not add it automatically.