### PR TITLE
feat: `normalizeIds` serializer property defaults to true

### DIFF
--- a/addon/serializers/active-model-serializer.js
+++ b/addon/serializers/active-model-serializer.js
@@ -3,7 +3,7 @@ import { underscore, pluralize, dasherize, singularize, camelize } from '../util
 
 export default Serializer.extend({
   serializeIds: 'always',
-  normalizeIds: false,
+  normalizeIds: true,
 
   keyForModel(type) {
     return underscore(type);

--- a/tests/unit/serializers/active-model-serializer-test.js
+++ b/tests/unit/serializers/active-model-serializer-test.js
@@ -90,6 +90,12 @@ module('Unit | Serializers | ActiveModelSerializer', function(hooks) {
     assert.strictEqual(this.serializer.getCoalescedIds(request), undefined);
   });
 
+  test('normalizeIds defaults to true', function(assert) {
+    let serializer = new ActiveModelSerializer();
+
+    assert.equal(serializer.normalizeIds, true);
+  });
+
   test('normalize works with normalizeIds set to true', function(assert) {
     this.serializer.normalizeIds = true;
     let payload = {


### PR DESCRIPTION
BREAKING CHANGE: This applies to the ActiveModelSerializer and
RestSerializer.

The `normalize` property on serializers helps Mirage's shorthands work
by transforming differently formatted payloads into JSON:API documents.
These documents are then used by Mirage to update the database accordingly.

There was a gap in the default `normalize` method for a long time, in that
it didn't take REST payloads that included foreign keys and looked like

```js
let payload = {
  contact: {
    id: 1,
    name: 'Link',
    address: 1
  }
};
```

and turn that `address` key into a proper JSON:API relationship:

```js
data: {
  type: 'contacts',
  id: 1,
  attributes: {
    name: 'Link'
  },
  relationships: {
    address: {
      data: {
        type: 'address',
        id: 1
      }
    }
  }
}
```

We added this feature a while ago, and it's controlled with the `normalizeIds`
property on the ActiveModelSerializer and RESTSerializer. (We did this
so the feature wouldn't be a breaking change.)

We're now making `true` the default, which should be the behavior
everyone desires (assuming they're using shorthands). This is technically
a breaking change, though it's unlikely to affect most people.