### PR TITLE
drop deprecated forms of create, createList and normalizedRequestAttrs

### DIFF
--- a/addon/route-handlers/function.js
+++ b/addon/route-handlers/function.js
@@ -1,6 +1,6 @@
 import BaseRouteHandler from './base';
 import assert from 'ember-cli-mirage/assert';
-import { dasherize, camelize } from 'ember-cli-mirage/utils/inflector';
+import { dasherize } from 'ember-cli-mirage/utils/inflector';
 
 /**
  * @hide
@@ -51,11 +51,7 @@ export default class FunctionRouteHandler extends BaseRouteHandler {
       attrs = this._getAttrsForFormRequest(request);
     } else {
       if (modelName) {
-        if (dasherize(modelName) !== modelName) {
-          // eslint-disable-next-line no-console
-          console.warn(`Mirage [deprecation]: You called normalizedRequestAttrs('${modelName}'), but normalizedRequestAttrs was intended to be used with the dasherized version of the model type. Please change this to normalizedRequestAttrs('${dasherize(modelName)}'). This behavior will be removed in 1.0.`);
-          modelName = camelize(modelName);
-        }
+        assert(dasherize(modelName) === modelName, `You called normalizedRequestAttrs('${modelName}'), but normalizedRequestAttrs was intended to be used with the dasherized version of the model type. Please change this to normalizedRequestAttrs('${dasherize(modelName)}').`);
       } else {
         modelName = this.getModelClassFromPath(path);
       }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "ember-source": "~3.4.0",
     "ember-source-channel-url": "^1.1.0",
     "ember-try": "^1.0.0",
+    "escape-string-regexp": "^1.0.5",
     "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-ember-suave": "^1.0.0",
     "eslint-plugin-node": "^7.0.1",

--- a/tests/helpers/reg-exp-from-string.js
+++ b/tests/helpers/reg-exp-from-string.js
@@ -1,0 +1,5 @@
+import escape from 'escape-string-regexp';
+
+export default function(str) {
+  return new RegExp(escape(str));
+}

--- a/tests/integration/server/create-and-create-list-test.js
+++ b/tests/integration/server/create-and-create-list-test.js
@@ -2,22 +2,11 @@ import { module, test } from 'qunit';
 import { Model, Factory, hasMany, belongsTo } from 'ember-cli-mirage';
 import Inflector from 'ember-inflector';
 import Server from 'ember-cli-mirage/server';
+// import escape from 'escape-string-regexp';
+import regExpFromString from '../../helpers/reg-exp-from-string';
 
 // eslint-disable-next-line no-console
 let originalWarn = console.warn;
-
-function expectWarning(assert, warning) {
-  if (!warning) {
-    assert.ok(false, 'You must pass in a message when expecting a warning');
-  }
-
-  // eslint-disable-next-line no-console
-  console.warn = message => {
-    let re = new RegExp(warning.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-
-    assert.ok(re.test(message), 'the correct warning message was logged');
-  };
-}
 
 function expectNoWarning(assert) {
   // eslint-disable-next-line no-console
@@ -70,18 +59,16 @@ module('Integration | Server | create and createList', function(hooks) {
 
     assert.throws(() => {
       this.server.create('foo');
-    }, /You called server.create\('foo'\) but no model or factory was found\./);
+    }, regExpFromString(`You called server.create('foo') but no model or factory was found.`));
   });
 
-  test('create warns when passing in a pluralized version of a model', function(assert) {
-    assert.expect(3);
+  // This used to be deprecated behavior, but now it errors. So we test it separately from the nonsense test above.
+  test('create throws when passing in a pluralized version of a model', function(assert) {
+    assert.expect(1);
 
-    expectWarning(assert, `server.create was intended to be used with the singularized version of the model`);
-
-    let contact = this.server.create('contacts');
-
-    assert.ok(contact instanceof this.Contact, 'expected a Contact');
-    assert.equal(contact.name, 'Yehuda', 'the factory is used');
+    assert.throws(() => {
+      this.server.create('contacts');
+    }, regExpFromString(`You called server.create('contacts') but no model or factory was found. Make sure you're passing in the singularized version of the model or factory name`));
   });
 
   test('create returns a Model if one is defined', function(assert) {
@@ -107,18 +94,16 @@ module('Integration | Server | create and createList', function(hooks) {
 
     assert.throws(() => {
       this.server.createList('foo', 1);
-    }, /You called server.createList\('foo'\) but no model or factory was found\./);
+    }, regExpFromString(`You called server.createList('foo') but no model or factory was found.`));
   });
 
-  test('createList warns when passing in a pluralized version of a model', function(assert) {
-    assert.expect(3);
+  // This used to be deprecated behavior, but now it errors. So we test it separately from the nonsense test above.
+  test('createList throws when passing in a pluralized version of a model', function(assert) {
+    assert.expect(1);
 
-    expectWarning(assert, `server.createList was intended to be used with the singularized version of the model`);
-
-    let contacts = this.server.createList('contacts', 1);
-
-    assert.ok(contacts[0] instanceof this.Contact, 'expected a Contact');
-    assert.equal(contacts[0].name, 'Yehuda', 'the factory is used');
+    assert.throws(() => {
+      this.server.createList('contacts', 1);
+    }, regExpFromString(`You called server.createList('contacts') but no model or factory was found. Make sure you're passing in the singularized version of the model or factory name.`));
   });
 
   test('createList returns Models if one is defined', function(assert) {


### PR DESCRIPTION
BREAKING CHANGE: There are several places in Mirage's APIs that were
intended to be used with singularized versions of model names, but just
so happened to work if a non-singularized version was passed in.

This behavior was discovered during a refactor, and the non-singularized
versions were maintained to avoid breaking apps. Now that we're moving to
1.0, we're removing this deprecated/unintentional behavior.

- `server.create` and `server.createList` were coded to take a singularized
model name, e.g. `server.create('user')`. It just so happens that
`server.create('users')` also works. That pluralized version is now removed
from Mirage.

    If you're running the latest 0.x version you should see a deprecation
    message letting you know where to change it. Otherwise, it should be
    a pretty mechanic change from things like `server.create('users')`
    to `serer.create('user')`.

    Note this also applies to `server.createList` – the correct form
    is `server.createList('user', 3)`, and the pluralized form
    `server.createList('users', 3)` is now unsupported.

- `this.normalizedRequestAttrs` in a route handler optionally takes a
  modelName as an argument. This is if your URLs are non-standard and
  Mirage cannot guess the modelName from the URL path.

    In this case, you can call `this.normalizedRequestAttrs('blog-post')`
    to tell Mirage to expect the payload to be for a `blog-post` model.

    This API was intended to be used with dasherized names, because that's
    how compound model names are specified throughout Mirage when they
    are represented as strings.

    It just so happened that `this.normalizedRequestAttrs('blogPost')`
    also worked, by chance, until a refactor. So, that behavior was kept
    but now is being removed.

    The correct usage is `this.normalizedRequestAttrs('blog-post')`.
    Using the camelized version of the model name is no longer supported.

If either of these changes cause a ton of refactoring pain, we can try
to marshal some resources to help write a codemod. Please open an
issue if that's the case!