### PR TITLE
Save over 500KB with one weird trick

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -10,7 +10,9 @@ import _isEmpty from 'lodash/isEmpty';
 import _includes from 'lodash/includes';
 import _assign from 'lodash/assign';
 import _get from 'lodash/get';
-import _ from 'lodash';
+import _flatten from 'lodash/flatten';
+import _compact from 'lodash/compact';
+import _uniqBy from 'lodash/uniqBy';
 
 /**
   Serializers are responsible for formatting your route handler's response.
@@ -473,19 +475,20 @@ class Serializer {
       return [hash, []];
 
     } else {
-      let addToIncludes = _(serializer.getKeysForIncluded())
-        .map((key) => {
-          if (this.isCollection(resource)) {
-            return resource.models.map((m) => m[key]);
-          } else {
-            return resource[key];
-          }
-        })
-        .flatten()
-        .compact()
-        .uniqBy(m => m.toString())
-        .value();
-
+      let addToIncludes = _uniqBy(
+        _compact(
+          _flatten(
+            serializer.getKeysForIncluded().map(key => {
+              if (this.isCollection(resource)) {
+                return resource.models.map(m => m[key]);
+              } else {
+                return resource[key];
+              }
+            })
+          )
+        ),
+        m => m.toString()
+      );
       return [hash, addToIncludes];
     }
   }

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -1,7 +1,10 @@
 import Serializer from '../serializer';
 import { dasherize, pluralize, camelize } from '../utils/inflector';
 import _get from 'lodash/get';
-import _ from 'lodash';
+import _flatten from 'lodash/flatten';
+import _compact from 'lodash/compact';
+import _uniqBy from 'lodash/uniqBy';
+import _isEmpty from 'lodash/isEmpty';
 import assert from 'ember-cli-mirage/assert';
 
 /**
@@ -95,11 +98,7 @@ const JSONAPISerializer = Serializer.extend({
       includes.push(newIncludes);
     });
 
-    return _(includes)
-      .flatten()
-      .compact()
-      .uniqBy(m => m.toString())
-      .value();
+    return _uniqBy(_compact(_flatten(includes)), m => m.toString());
   },
 
   getIncludesForResourceAndPath(resource, ...names) {
@@ -182,14 +181,14 @@ const JSONAPISerializer = Serializer.extend({
         relationshipHash.data = data;
       }
 
-      if (!_.isEmpty(relationshipHash)) {
+      if (!_isEmpty(relationshipHash)) {
         relationships[relationshipKey] = relationshipHash;
       }
 
       return relationships;
     }, {});
 
-    if (!_.isEmpty(relationships)) {
+    if (!_isEmpty(relationships)) {
       hash.relationships = relationships;
     }
 


### PR DESCRIPTION
This PR cuts more than half a megabyte from any app that uses mirage.

The problem is that:

```js
import _ from 'lodash';
let item = _(value);
```

needs to put methods on `item` for every possible thing lodash supports. Most of which aren't needed.

This isn't one of the cases where a more aggressive module bundler could try to optimize them out. This style really just can't be statically optimized. It's a pity, because the chaining style is easier to read IMO.