### PR TITLE
Remove duplicated dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,22 +8,6 @@ const writeFile = require('broccoli-file-creator');
 module.exports = {
   name: 'ember-cli-mirage',
 
-  options: {
-    nodeAssets: {
-      '@xg-wang/whatwg-fetch': npmAsset({
-        import: ['dist/fetch.umd.js']
-      }),
-      'route-recognizer': npmAsset({
-        srcDir: 'dist',
-        import: ['route-recognizer.js'],
-        vendor: ['route-recognizer.js.map']
-      }),
-      'fake-xml-http-request': npmAsset({
-        import: ['fake_xml_http_request.js']
-      })
-    }
-  },
-
   included() {
     let app;
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "prepare": "./scripts/link.sh"
   },
   "dependencies": {
-    "@xg-wang/whatwg-fetch": "^3.0.0",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.2",
@@ -44,13 +43,10 @@
     "chalk": "^2.4.2",
     "ember-auto-import": "^1.2.19",
     "ember-cli-babel": "^7.5.0",
-    "ember-cli-node-assets": "^0.2.2",
     "ember-get-config": "^0.2.2",
     "ember-inflector": "^2.0.0 || ^3.0.0",
-    "fake-xml-http-request": "^2.0.0",
     "lodash": "^4.17.11",
-    "pretender": "2.1.1",
-    "route-recognizer": "^0.3.4"
+    "pretender": "2.1.1"
   },
   "devDependencies": {
     "@ember/jquery": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12113,11 +12113,6 @@ route-recognizer@^0.3.3:
   resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.3.tgz#1d365e27fa6995e091675f7dc940a8c00353bd29"
   integrity sha1-HTZeJ/ppleCRZ199yUCowANTvSk=
 
-route-recognizer@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
-  integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
-
 rsvp@^3.0.14, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"


### PR DESCRIPTION
These are dependencies of pretender. They stopped being necessary when mirage switched to loading pretender via ember-auto-import. When consumed that way, pretender already does the right thing and includes its own dependencies automatically.

Prior to this PR, all of these were being included twice.