### PR TITLE
Better logging

### DIFF
--- a/addon/assert.js
+++ b/addon/assert.js
@@ -45,9 +45,6 @@ export function MirageError(message, stack) {
       this[prop] = tmp[prop];
     }
   }
-
-  console.error(this.message);
-  console.error(this);
 }
 
 MirageError.prototype = Object.create(Error.prototype);

--- a/addon/server.js
+++ b/addon/server.js
@@ -1,6 +1,5 @@
 /* eslint no-console: 0 */
 
-import { Promise } from 'rsvp';
 import { singularize, pluralize, camelize } from './utils/inflector';
 import { toCollectionName, toInternalCollectionName } from 'ember-cli-mirage/utils/normalize-name';
 import { getModels } from './ember-data';
@@ -68,10 +67,7 @@ function createPretender(server) {
     this.unhandledRequest = function(verb, path) {
       path = decodeURI(path);
       assert(
-        `Your Ember app tried to ${verb} '${path}',
-         but there was no route defined to handle this request.
-         Define a route that matches this path in your
-         mirage/config.js file. Did you forget to add your namespace?`
+        `Your Ember app tried to ${verb} '${path}', but there was no route defined to handle this request. Define a route that matches this path in your mirage/config.js file. Did you forget to add your namespace?`
       );
     };
   }, { trackRequests: server.shouldTrackRequests() });
@@ -857,12 +853,12 @@ export default class Server {
     return this.pretender[verb](
       fullPath,
       (request) => {
-        return new Promise(resolve => {
-          Promise.resolve(routeHandler.handle(request)).then(mirageResponse => {
+        return routeHandler.handle(request)
+          .then(mirageResponse => {
             let [ code, headers, response ] = mirageResponse;
-            resolve([ code, headers, this._serialize(response) ]);
+
+            return [ code, headers, this._serialize(response) ];
           });
-        });
       },
       timing
     );

--- a/tests/integration/route-handlers/function-handler/basic-test.js
+++ b/tests/integration/route-handlers/function-handler/basic-test.js
@@ -3,7 +3,6 @@ import { Promise } from 'rsvp';
 import { Model, ActiveModelSerializer, Response } from 'ember-cli-mirage';
 import Server from 'ember-cli-mirage/server';
 import promiseAjax from '../../../helpers/promise-ajax';
-import { logger } from 'ember-cli-mirage/assert';
 
 module('Integration | Route handlers | Function handler', function(hooks) {
   hooks.beforeEach(function() {
@@ -33,17 +32,16 @@ module('Integration | Route handlers | Function handler', function(hooks) {
       throw 'I goofed';
     });
 
-    try {
-      await promiseAjax({
-        method: 'GET',
-        url: '/users'
-      });
-    } catch(e) {
-      assert.equal(e.xhr.responseText, 'I goofed');
-      assert.equal(logger.messages.length, 1);
-      assert.ok(logger.messages[0].match(`Mirage: Your GET handler for the url /users threw an error:`));
-      assert.ok(logger.messages[0].match(`I goofed`));
-    }
+    assert.rejects(
+      promiseAjax({ method: 'GET', url: '/users' }),
+      function(ajaxError) {
+        let text = ajaxError.xhr.responseText;
+        let line1 = text.indexOf(`Mirage: Your GET handler for the url /users threw an error`) > 0;
+        let line2 = text.indexOf(`I goofed`) > 0;
+
+        return line1 && line2;
+      }
+    );
   });
 
   test('mirage response string is not serialized to string', async function(assert) {

--- a/tests/integration/route-handlers/function-handler/serialize-test.js
+++ b/tests/integration/route-handlers/function-handler/serialize-test.js
@@ -97,16 +97,18 @@ module('Integration | Route handlers | Function handler | #serialize', function(
     assert.expect(1);
 
     this.server.create('user', { name: 'Sam' });
-
     this.server.get('/users', function(schema) {
       let users = schema.users.all();
 
-      assert.throws(() => {
-        this.serialize(users, 'foo-user');
-      }, /that serializer doesn't exist/);
+      this.serialize(users, 'foo-user');
     });
 
-    await promiseAjax({ method: 'GET', url: '/users' });
+    assert.rejects(
+      promiseAjax({ method: 'GET', url: '/users' }),
+      function(ajaxError) {
+        return ajaxError.xhr.responseText.indexOf(`that serializer doesn't exist`) > 0;
+      }
+    );
   });
 
   test('it noops on plain JS arrays', async function(assert) {


### PR DESCRIPTION
Many promises were being swallowed because I think I originally wrote this code when I didn't understand promises.

I always had the extra `console.log` lines because I couldn't figure out how to get the error messages to consistently show up. Now that all promises in the request-response cycle are always being either resolved or rejected, we can rely on upstream tooling to properly display error messages (both in dev and in testing).

The `console.log` noise was also problematic when testing errors or in some of our recent work getting Mirage to run in express.

If anybody starts using these changes and feel it obfuscates Mirage's error messaging too much please let me know. I'm still not 100% satisfied with the state of error handling in many code paths in modern Ember app development and not sure the best way to reliably and consistently show a simple message to the user.