### PR TITLE
Adds overridable shouldIncludeLinkageData method to JsonApiSerializer

### DIFF
--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -163,7 +163,7 @@ const JSONAPISerializer = Serializer.extend({
         relationshipHash.links = links[key];
       }
 
-      if (this.alwaysIncludeLinkageData || this._relationshipIsIncludedForModel(key, model)) {
+      if (this.alwaysIncludeLinkageData || this.shouldIncludeLinkageData(key, model) || this._relationshipIsIncludedForModel(key, model)) {
         let data = null;
         if (this.isModel(relationship)) {
           data = {
@@ -372,6 +372,10 @@ const JSONAPISerializer = Serializer.extend({
       return ids.split(',');
     }
     return ids;
+  },
+
+  shouldIncludeLinkageData(relationshipKey, model) {
+    return false;
   }
 });
 

--- a/tests/integration/serializers/json-api-serializer/associations/collection-test.js
+++ b/tests/integration/serializers/json-api-serializer/associations/collection-test.js
@@ -90,6 +90,51 @@ module('Integration | Serializers | JSON API Serializer | Associations | Collect
     });
   });
 
+  test(`when shouldIncludeLinkageData returns true for a relationship, it contains linkage data for that relationship on all of the collection, regardless of includes`, function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: JSONAPISerializer.extend({
+        shouldIncludeLinkageData(relationshipKey, model) {
+          if (relationshipKey == 'posts') {
+            return true;
+          }
+        }
+      })
+    });
+    this.schema.wordSmiths.create({ firstName: 'Link', age: 123 });
+    this.schema.wordSmiths.create({ firstName: 'Zelda', age: 456 });
+
+    let collection = this.schema.wordSmiths.all();
+    let result = registry.serialize(collection);
+
+    assert.deepEqual(result, {
+      data: [{
+        type: 'word-smiths',
+        id: '1',
+        attributes: {
+          'first-name': 'Link',
+          age: 123
+        },
+        relationships: {
+          'posts': {
+            data: []
+          }
+        }
+      }, {
+        type: 'word-smiths',
+        id: '2',
+        attributes: {
+          'first-name': 'Zelda',
+          age: 456
+        },
+        relationships: {
+          'posts': {
+            data: []
+          }
+        }
+      }]
+    });
+  });
+
   test(`it includes linkage data for a has-many relationship that's being included`, function(assert) {
     let registry = new SerializerRegistry(this.schema, {
       application: JSONAPISerializer,


### PR DESCRIPTION
- allows for per-relationship inclusion of linkage data
- use this when alwaysIncludeLinkageData is not granular enough

Example:

```js
      export default JSONAPISerializer.extend({
        shouldIncludeLinkageData(relationshipKey, model) {
          if (relationshipKey === 'author' || relationshipKey === 'ghostWriter') {
            return true;
          }
          return false;
        }
      })
```

@mattmcmanus & @lukemelia