### PR TITLE
Document and cleanup JSONAPISerializer

### DIFF
--- a/addon/assert.js
+++ b/addon/assert.js
@@ -49,6 +49,9 @@ export function MirageError(message, stack) {
 
 MirageError.prototype = Object.create(Error.prototype);
 
+/**
+  @hide
+*/
 export const logger = {
   errors: [],
 


### PR DESCRIPTION
- Make it an ES6 class and share `extends` from base `Serializer` class