### PR TITLE
export setupMirage from test-support directly

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,0 +1,2 @@
+import setupMirage from './setup-mirage';
+export { setupMirage };

--- a/test-projects/01-basic-app/tests/acceptance/faker-test.js
+++ b/test-projects/01-basic-app/tests/acceptance/faker-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | Faker', function(hooks) {
   setupTest(hooks);

--- a/test-projects/01-basic-app/tests/acceptance/start-mirage-test.js
+++ b/test-projects/01-basic-app/tests/acceptance/start-mirage-test.js
@@ -3,7 +3,7 @@ import {module as qunitModule, test} from 'qunit';
 import {setupTest} from 'ember-qunit';
 import {visit, currentRouteName} from '@ember/test-helpers';
 import startMirage from 'ember-cli-mirage/start-mirage';
-import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import ENV from 'basic-app/config/environment';
 
 let module;

--- a/tests/dummy/app/pods/docs/writing-your-server/acceptance-testing/template.md
+++ b/tests/dummy/app/pods/docs/writing-your-server/acceptance-testing/template.md
@@ -8,7 +8,7 @@ If you're using Application Tests (introduced in [Ember 3.0](https://emberjs.com
 
 ```diff
   import { setupApplicationTest } from 'ember-qunit';
-+ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
++ import { setupMirage } from 'ember-cli-mirage/test-support';
 
   module('Acceptance | Homepage test', function(hooks) {
     setupApplicationTest(hooks);


### PR DESCRIPTION
Before:
```js
import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
```

After:
```js
import { setupMirage } from 'ember-cli-mirage/test-support';
```

It's less verbose. I also think it's more inline with rest of the ecosystem. Have a look at [Ember Power Select](https://ember-power-select.com/docs/test-helpers), [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth#testing) and [Ember Lifeline](https://ember-lifeline.github.io/ember-lifeline/docs/testing) for example.