### PR TITLE
A model with two hasMany relationships to the same type doesn’t properly store both attributes

### DIFF
--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -885,7 +885,10 @@ class Model {
 
         // Non-self-referential
         } else if (!tempAssociate.isSaving) {
+
+          // Save the tempAssociate and update the local reference
           tempAssociate.save();
+          this._syncTempAssociations(tempAssociate);
 
           let fkValue;
           if (association.isPolymorphic) {
@@ -976,6 +979,24 @@ class Model {
   // which can cause cycles with associations.
   _updateInDb(attrs) {
     this.attrs = this._schema.db[toInternalCollectionName(this.modelName)].update(this.attrs.id, attrs);
+  }
+
+  /*
+  Super gnarly: after we save this tempAssociate, we we need to through
+  all other tempAssociates for a reference to this same model, and
+  update it. Otherwise those other references are stale, which could
+  cause a bug when they are subsequently saved.
+
+  This only works for belongsTo right now, should add hasMany logic to it.
+
+  See issue #1613: https://github.com/samselikoff/ember-cli-mirage/pull/1613
+  */
+  _syncTempAssociations(tempAssociate) {
+    Object.keys(this._tempAssociations).forEach(key => {
+      if (this._tempAssociations[key].toString() === tempAssociate.toString()) {
+        this._tempAssociations[key] = tempAssociate;
+      }
+    });
   }
 
   /**

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -993,7 +993,7 @@ class Model {
   */
   _syncTempAssociations(tempAssociate) {
     Object.keys(this._tempAssociations).forEach(key => {
-      if (this._tempAssociations[key].toString() === tempAssociate.toString()) {
+      if (this._tempAssociations[key] && this._tempAssociations[key].toString() === tempAssociate.toString()) {
         this._tempAssociations[key] = tempAssociate;
       }
     });

--- a/tests/integration/orm/mixed/regressions/1613-two-bidirectional-many-to-many-with-same-target-model-update-bug-test.js
+++ b/tests/integration/orm/mixed/regressions/1613-two-bidirectional-many-to-many-with-same-target-model-update-bug-test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { Model, hasMany, belongsTo } from 'ember-cli-mirage';
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+
+module('Integration | ORM | Mixed | Regressions | 1613 Two bidirectional one-to-many relationships with same target model update ids bug', function(hooks) {
+  hooks.beforeEach(function() {
+    this.db = new Db();
+
+    this.schema = new Schema(this.db, {
+      user: Model.extend({
+        authoredPosts: hasMany('post', { inverse: 'author' }),
+        editedPosts: hasMany('post', { inverse: 'editor' })
+      }),
+      post: Model.extend({
+        author: belongsTo('user', { inverse: 'authoredPosts' }),
+        editor: belongsTo('user', { inverse: 'editedPosts' })
+      })
+    });
+  });
+
+  test(`it works, and all inverses are correctly updated`, function(assert) {
+    let user = this.schema.users.create();
+    let post = this.schema.posts.create();
+
+    post.update({
+      authorId: user.id,
+      editorId: user.id
+    });
+
+    assert.deepEqual(this.db.posts.find(1), { id: '1', authorId: '1', editorId: '1' });
+    assert.deepEqual(this.db.users.find(1), { id: '1', authoredPostIds: [ '1' ], editedPostIds: [ '1' ] });
+  });
+});

--- a/tests/integration/server/regressions/1613-two-bidirectional-many-to-many-with-same-target-model-update-bug-test.js
+++ b/tests/integration/server/regressions/1613-two-bidirectional-many-to-many-with-same-target-model-update-bug-test.js
@@ -3,27 +3,24 @@ import { Model, hasMany, belongsTo, JSONAPISerializer } from 'ember-cli-mirage';
 import Server from 'ember-cli-mirage/server';
 import promiseAjax from 'dummy/tests/helpers/promise-ajax';
 
-module('Integration | Server | Regressions | same-model different-attribute inverses', function(hooks) {
+module('Integration | Server | Regressions | 1613 Two bidirectional many-to-many with same target model update bug', function(hooks) {
   hooks.beforeEach(function() {
     this.server = new Server({
       environment: 'test',
       models: {
         user: Model.extend({
-          authorings: hasMany('post', { inverse: 'author' }),
-          editings: hasMany('post', { inverse: 'editor' })
+          authoredPosts: hasMany('post', { inverse: 'author' }),
+          editedPosts: hasMany('post', { inverse: 'editor' })
         }),
         post: Model.extend({
-          author: belongsTo('user', { inverse: 'authorings' }),
-          editor: belongsTo('user', { inverse: 'editings' })
+          author: belongsTo('user', { inverse: 'authoredPosts' }),
+          editor: belongsTo('user', { inverse: 'editedPosts' })
         })
       },
       serializers: {
         application: JSONAPISerializer.extend(),
-        post: JSONAPISerializer.extend({
-          include: ['author', 'editor', 'jortle']
-        }),
         user: JSONAPISerializer.extend({
-          include: ['authorings', 'editings']
+          alwaysIncludeLinkageData: true
         })
       },
       baseConfig() {
@@ -82,7 +79,7 @@ module('Integration | Server | Regressions | same-model different-attribute inve
         "attributes": {},
         "id": "1",
         "relationships": {
-          "authorings": {
+          "authored-posts": {
             "data": [
               {
                 "id": "1",
@@ -90,7 +87,7 @@ module('Integration | Server | Regressions | same-model different-attribute inve
               }
             ]
           },
-          "editings": {
+          "edited-posts": {
             "data": [
               {
                 "id": "1",

--- a/tests/integration/server/regressions/same-model-different-attribute-inverses-bug-test.js
+++ b/tests/integration/server/regressions/same-model-different-attribute-inverses-bug-test.js
@@ -1,0 +1,106 @@
+import { module, test } from 'qunit';
+import { Model, hasMany, belongsTo, JSONAPISerializer } from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+import promiseAjax from 'dummy/tests/helpers/promise-ajax';
+
+module('Integration | Server | Regressions | same-model different-attribute inverses', function(hooks) {
+  hooks.beforeEach(function() {
+    this.server = new Server({
+      environment: 'test',
+      models: {
+        user: Model.extend({
+          authorings: hasMany('post', { inverse: 'author' }),
+          editings: hasMany('post', { inverse: 'editor' })
+        }),
+        post: Model.extend({
+          author: belongsTo('user', { inverse: 'authorings' }),
+          editor: belongsTo('user', { inverse: 'editings' })
+        })
+      },
+      serializers: {
+        application: JSONAPISerializer.extend(),
+        post: JSONAPISerializer.extend({
+          include: ['author', 'editor', 'jortle']
+        }),
+        user: JSONAPISerializer.extend({
+          include: ['authorings', 'editings']
+        })
+      },
+      baseConfig() {
+        this.resource('posts');
+        this.resource('users');
+      }
+    });
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
+  });
+
+  test('it stores both relationships', async function(assert) {
+    let post = this.server.create('post');
+    let user = this.server.create('user');
+
+    assert.expect(1);
+
+    await promiseAjax({
+      method: 'PATCH',
+      url: `/posts/${post.id}`,
+      contentType: 'application/vnd.api+json',
+      data: JSON.stringify({
+        data: {
+          id: post.id,
+          attributes: {},
+          relationships: {
+            author: {
+              data: {
+                type: 'users',
+                id: user.id
+              }
+            },
+            editor: {
+              data: {
+                type: 'users',
+                id: user.id
+              }
+            }
+          },
+          type: 'posts'
+        }
+      })
+    });
+
+    let response = await promiseAjax({
+      method: 'GET',
+      url: `/users/${user.id}`
+    });
+
+    let json = response.data;
+
+    assert.deepEqual(json.data,
+      {
+        "attributes": {},
+        "id": "1",
+        "relationships": {
+          "authorings": {
+            "data": [
+              {
+                "id": "1",
+                "type": "posts"
+              }
+            ]
+          },
+          "editings": {
+            "data": [
+              {
+                "id": "1",
+                "type": "posts"
+              }
+            ]
+          }
+        },
+        "type": "users"
+      });
+  });
+
+});


### PR DESCRIPTION
Hey, I’m running into an obscure seemingly-bug in [this open-source application](https://github.com/backspace/prison-rideshare-ui) I maintain. This test demonstrates the problem in a more focused way, but here’s the context from the production application in case it’s helpful:

The relevant portion of the data model is that there are (car) `ride`s that can be assigned to `driver`s and `carOwner`s, which are both of type `person`. Here’s the awkward nomenclature:

```
ride:
  driver: belongsTo('person', { inverse: 'drivings' }),
  carOwner: belongsTo('person', { inverse: 'carOwnings' }),

person:
  drivings: hasMany('ride', { inverse: 'driver' }),
  carOwnings: hasMany('ride', { inverse: 'carOwner' }),
```

I ran into this because in the tests, I have a `PATCH` to update a `ride` by assigning a `driver` and `car-owner`, it looks like this abridged JSON:

```
"data": {
    "id": "1",
    "attributes": {
      …
    },
    "relationships": {
        "driver": {
            "data": {
                "type": "people",
                "id": "1"
            }
        },
        "car-owner": {
            "data": {
                "type": "people",
                "id": "1"
            }
        }
    },
    "type": "rides"
}
```

Here’s what comes back from Mirage (again abridged):

```
        "data": {
            "type": "rides",
            "id": "1",
            "attributes": {
                …
            },
            "relationships": {
                "driver": {
                    "data": {
                        "type": "people",
                        "id": "1"
                    }
                },
                "car-owner": {
                    "data": {
                        "type": "people",
                        "id": "1"
                    }
                }
            }
        },
        "included": [
            {
                "type": "people",
                "id": "1",
                "attributes": {
                    …
                },
                "relationships": {
                    "drivings": {
                        "data": [] // <- shouldn’t be empty!
                    },
                    "car-ownings": {
                        "data": [
                            {
                                "type": "rides",
                                "id": "1"
                            }
                        ]
                    }
                }
            }
        ]
```

The key thing to notice is that the `drivings` relationship is incorrectly empty.

I came across this because it seems like Ember Data 3.1 was ignoring the empty `drivings` relationship on the included `person` record, but Ember Data 3.2 interprets it properly, resulting in the relationship being unassigned after the server’s response is processed.

This failing test doesn’t faithfully reproduce the context of the failure I’m experiencing because I couldn’t figure out how to get the `included` attribute to show up in the `PATCH` response. I added a `GET` instead, which reveals the problem too, but less concisely. It’s strange and inexplicable to me that in my application, the `relationships.driver` is correct, but not the `included`.

It’s possible this test isn’t really at the correct level, as it seems like maybe it’s more of an ORM problem than a server one, but I wasn’t sure how to replicate it otherwise.

I know you’re always busy with your various projects; this is something I could look into fixing myself, I thought maybe you’d have better insight into where to start, but I’d be happy to dig in if you don’t have time.

Let me know if you need any more information or if you have a hint about where I could start on fixing this.

As always, thanks for your work on Mirage. I tried out the latest beta today and everything went smoothly! 💞