### PR TITLE
Fix where the  docs reference wrong method

### DIFF
--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -272,7 +272,7 @@ export default class Schema {
 
     ```js
     // Find the first published blog post, or create a new one.
-    let post = blogPosts.findBy({ published: true });
+    let post = blogPosts.findOrCreateBy({ published: true });
     ```
 
     @method findOrCreateBy


### PR DESCRIPTION
It seems that the documentation for the `findOrCreateBy` method on the schema was referencing `findBy` instead. This updates it so it's using the correct method.