### PR TITLE
Docs: Use consistent name of the fixtures file

### DIFF
--- a/tests/dummy/app/pods/docs/testing/acceptance-tests/template.md
+++ b/tests/dummy/app/pods/docs/testing/acceptance-tests/template.md
@@ -145,7 +145,7 @@ Create the module
 ```js
 // scenarios/shared.js
 export default function(server) {
-  server.loadFixtures('country');
+  server.loadFixtures('countries');
 
   server.createList('event', 10);
 });


### PR DESCRIPTION
Hi!

The Fixtures section suggests naming the fixtures file as `countries.js`.

Then, the Acceptance Testing section suggests loading it as `server.loadFixtures('country')`.

Since both Ember Data and Mirage are notorious for using different pluralization in different places, this particular mismatch didn't raise suspicion.

The problem is, though, it should be `server.loadFixtures('countries')` to load `countries.js`.

And the worst thing is that using a non-existing fixture file name fails silently.

This set me back for a while and took quite some time to figure out.

Hope this tiny change in documentation will help other users.

PS Tell me if you want me to create an issue requiring for `loadFixtures('non-existing')` to throw a meaningful error. I strongly believe it should be.