### PR TITLE
Fix fastboot test failure under floating deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "qunit-dom": "^0.9.0"
   },
   "resolutions": {
-    "favicons": "5.3.0"
+    "favicons": "5.3.0",
+    "ember-auto-import/**/terser-webpack-plugin": "1.2.1"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"


### PR DESCRIPTION
The 01-basic-app test project had a failing fastboot test under our
Travis floating-deps test case. This means the fastboot tests passed
when all node_modules were installed using our `yarn.lock` file, but
failed when `yarn install --no-lockfile` was used. This means
there was some bump in a transitive dependency that caused an issue
in one of the fastboot tests in 01-basic-app, when newing up a Fastboot
instance.

To track down the problematic dependency, we cut the yarn.lockfile in
half and deleted it, regenerating the remaining entries until we found
the problematic one. It turned out to be terser-webpack-plugin, which
is in our dependency graph because of Ember Auto Import. By pinning
the dependency, all tests now pass when `yarn install --no-lockfile`
is used.