### PR TITLE
Fix a mistake in Factories docs

### DIFF
--- a/tests/dummy/app/pods/docs/data-layer/factories/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/factories/template.md
@@ -508,7 +508,7 @@ export default Factory.extend({
   afterCreate(post, server) {
     if (!post.user) {
       post.update({
-        user: server('user')
+        user: server.create('user')
       });
     }
   }


### PR DESCRIPTION
I assume you meant to write `server.create('user')` unless there is actually a shorthand version. 