### PR TITLE
Rollback using `@embroider/macros`

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,9 +1,7 @@
 import setupMirage from './setup-mirage';
 export { setupMirage };
 
-import { dependencySatisfies } from '@embroider/macros';
-
-if (dependencySatisfies('ember-qunit', '*')) {
+if (typeof window.QUnit !== 'undefined') {
   window.QUnit.config.urlConfig.push({
     id: 'mirageLogging',
     label: 'Mirage logging',

--- a/addon/deprecate-reexports.js
+++ b/addon/deprecate-reexports.js
@@ -1,5 +1,5 @@
 import { deprecate } from '@ember/debug';
-import { importSync, isTesting, dependencySatisfies } from '@embroider/macros';
+import require from 'require';
 import * as mirage from 'miragejs';
 import * as ecMirageExports from './index';
 
@@ -15,8 +15,8 @@ export function initDeprecatedReExports() {
       // eslint-disable-next-line no-import-assign
       Object.defineProperty(ecMirageExports, name, {
         get() {
-          if (isTesting() && dependencySatisfies('ember-qunit', '*')) {
-            const { waitUntil, getContext } = importSync('@ember/test-helpers');
+          if (require.has('ember-qunit')) {
+            const { waitUntil, getContext } = require('@ember/test-helpers');
 
             window.QUnit.begin(function () {
               // Make sure deprecation message does not get "swallowed"

--- a/addon/get-rfc232-test-context.js
+++ b/addon/get-rfc232-test-context.js
@@ -1,4 +1,4 @@
-import { importSync, dependencySatisfies, isTesting } from '@embroider/macros';
+import require from 'require';
 
 /**
   Helper to get our rfc232/rfc268 test context object, or null if we're not in
@@ -10,8 +10,8 @@ export default function getRfc232TestContext() {
   // Support older versions of `ember-qunit` that don't have
   // `@ember/test-helpers` (and therefore cannot possibly be running an
   // rfc232/rfc268 test).
-  if (dependencySatisfies('@ember/test-helpers', '*') && isTesting()) {
-    let { getContext } = importSync('@ember/test-helpers');
+  if (require.has('@ember/test-helpers')) {
+    let { getContext } = require('@ember/test-helpers');
     return getContext();
   }
 }

--- a/addon/utils/ember-data.js
+++ b/addon/utils/ember-data.js
@@ -1,9 +1,18 @@
-import { dependencySatisfies } from '@embroider/macros';
+/* global requirejs */
+
+function _hasEmberData() {
+  let matchRegex1 = /^ember-data/i;
+  let matchRegex2 = /^@ember-data/i;
+
+  return !!Object.keys(requirejs.entries).find(
+    (e) => !!e.match(matchRegex2) || !!e.match(matchRegex1)
+  );
+}
 
 /**
   @hide
 */
-export const hasEmberData = dependencySatisfies('ember-data', '*');
+export const hasEmberData = _hasEmberData();
 
 /**
   @hide

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "prepare": "./scripts/link.sh"
   },
   "dependencies": {
-    "@embroider/macros": "^0.41.0",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
@@ -52,26 +51,11 @@
     "lodash-es": "^4.17.11",
     "miragejs": "^0.1.43"
   },
-  "peerDependencies": {
-    "@ember/test-helpers": "*",
-    "ember-data": "*",
-    "ember-qunit": "*"
-  },
-  "peerDependenciesMeta": {
-    "@ember/test-helpers": {
-      "optional": true
-    },
-    "ember-data": {
-      "optional": true
-    },
-    "ember-qunit": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
+    "@embroider/macros": "^0.41.0",
     "@embroider/test-setup": "^0.41.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",


### PR DESCRIPTION
We can't bump `@embroider/macros` beyond 0.41.0 as it requires Node.js v12 and v2 of ember-cli-mirage depends on Node.js 10

using older version of `@embroider/macros` causes issues for users of this addon hence this PR replaces back usage of `@embroider/macros` with `require.has()` or `require.entries`.

Closes #2343.