### PR TITLE
fix(inflector): get rid of ember inflector

### DIFF
--- a/packages/ember-cli-mirage-docs/app/templates/docs/advanced/customizing-the-inflector.md
+++ b/packages/ember-cli-mirage-docs/app/templates/docs/advanced/customizing-the-inflector.md
@@ -5,7 +5,7 @@ When using Ember Data, you'll sometimes find yourself needing to customize the i
 For example, say you had an `Advice` model. By default, Ember's inflector pluralizes this as "advices"
 
 ```js
-import { pluralize } from 'ember-inflector';
+import { pluralize } from '@ember/string';
 
 pluralize("advice"); // advices
 ```
@@ -31,13 +31,11 @@ might use inflection rules to try to look up the "advices" collection or databas
 
 ```js
 // app/initializers/custom-inflector-rules.js
-import Inflector from 'ember-inflector';
+import { uncountable } from '@ember-data/request-utils/string';
 
 export function initialize(/* application */) {
-  const inflector = Inflector.inflector;
-
   // Tell the inflector that the plural of "advice" is "advice"
-  inflector.uncountable('advice');
+  uncountable('advice');
 }
 
 export default {

--- a/packages/ember-cli-mirage/addon/start-mirage.js
+++ b/packages/ember-cli-mirage/addon/start-mirage.js
@@ -1,5 +1,5 @@
 import readModules from './utils/read-modules';
-import { singularize, pluralize } from 'ember-inflector';
+import { singularize, pluralize } from '@ember-data/request-utils/string';
 import { assert } from '@ember/debug';
 
 /**

--- a/packages/ember-cli-mirage/addon/utils/read-modules.js
+++ b/packages/ember-cli-mirage/addon/utils/read-modules.js
@@ -4,7 +4,7 @@
 
 import assert from '../assert';
 import { _utilsInflectorCamelize as camelize } from 'miragejs';
-import { pluralize } from 'ember-inflector';
+import { pluralize } from '@ember-data/request-utils/string';
 import require from 'require';
 
 /**

--- a/packages/ember-cli-mirage/package.json
+++ b/packages/ember-cli-mirage/package.json
@@ -48,7 +48,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.0.0",
     "ember-get-config": "0.2.4 - 0.5.0 || ^1.0.0 || ^2.1.1",
-    "ember-inflector": "^2.0.0 || ^3.0.0 || ^4.0.2 || ^5.0.0"
+    "@ember-data/request-utils": "^5.3.10"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.22.15",


### PR DESCRIPTION
This will allow migration to Ember 5.x and fixes issue https://github.com/miragejs/ember-cli-mirage/issues/2589