### PR TITLE
temp-fix: After embroider, config was undefined, causing tests to break

### DIFF
--- a/packages/ember-cli-mirage/addon/ember-data.js
+++ b/packages/ember-cli-mirage/addon/ember-data.js
@@ -8,7 +8,7 @@ import { Model, belongsTo, hasMany } from 'miragejs';
 import EmberDataSerializer from 'ember-cli-mirage/serializers/ember-data-serializer';
 import { _utilsInflectorCamelize as camelize } from 'miragejs';
 
-const { modulePrefix, podModulePrefix } = config;
+const { modulePrefix, podModulePrefix } = config || {};
 
 // Caches
 let DsModels, Models;


### PR DESCRIPTION
This pull request includes a small change to the `packages/ember-cli-mirage/addon/ember-data.js` file. The change ensures that the `config` variable is properly initialized to an empty object if it is undefined.

* [`packages/ember-cli-mirage/addon/ember-data.js`](diffhunk://#diff-60862b834d368727936435da3a5e93473de41255e698a1f55994529d161534f7L11-R11): Modified the destructuring assignment of `config` to provide a default empty object, preventing potential errors if `config` is undefined.

Main reference:
https://github.com/cardstack/cardstack/pull/3168